### PR TITLE
Adding CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Default owners
+* @elastic/otel-devs
+
+# Per-component owners
+# TODO: define as needed


### PR DESCRIPTION
This PR defines an initial `CODEOWNERS` file with @elastic/otel-devs as the default codeowners.  As we add components to this repository, more specific code owners per component will likely be added in the future.