### PR TITLE
ci: add Go directories to dependabot configuration 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,11 +2,25 @@
 version: 2
 updates:
   - package-ecosystem: "gomod"
-    directory: "/"
+    directory: "/processor/elasticinframetricsprocessor/"
     schedule:
       interval: "daily"
     labels:
       - automation
+    groups:
+      otel-dependencies:
+        patterns: ["go.opentelemetry.io/*"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "gomod"
+    directory: "/internal/tools/"
+    schedule:
+      interval: "daily"
+    labels:
+      - automation
+      - tools
     groups:
       otel-dependencies:
         patterns: ["go.opentelemetry.io/*"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,7 @@
 ---
 version: 2
 updates:
+  #TODO: Replace go directories with wildcard https://github.com/dependabot/dependabot-core/issues/2178
   - package-ecosystem: "gomod"
     directory: "/processor/elasticinframetricsprocessor/"
     schedule:


### PR DESCRIPTION
Specify which directories contain Go modules. For the moment, we need to replicate each dependabot entry configuration as wildcard patterns are not supported: https://github.com/dependabot/dependabot-core/issues/2178

Fixes: https://github.com/elastic/opentelemetry-collector-components/issues/9