### PR TITLE
[elasticinframetrics]Fix failing test due to upgrade to v0.105.0

### DIFF
--- a/processor/elasticinframetricsprocessor/generated_component_test.go
+++ b/processor/elasticinframetricsprocessor/generated_component_test.go
@@ -66,7 +66,7 @@ func TestComponentLifecycle(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	sub, err := cm.Sub("tests::config")
 	require.NoError(t, err)
-	require.NoError(t, component.UnmarshalConfig(sub, cfg))
+	require.NoError(t, sub.Unmarshal(&cfg))
 
 	for _, test := range tests {
 		t.Run(test.name+"-shutdown", func(t *testing.T) {


### PR DESCRIPTION
This is a minimal fix for the current failures happening in main. Creating this since https://github.com/elastic/opentelemetry-collector-components/pull/38 had concerns about backward compatibility.