### PR TITLE
[connector/spanmetricsv2] Use slice for spans config

### DIFF
--- a/connector/spanmetricsconnectorv2/config_test.go
+++ b/connector/spanmetricsconnectorv2/config_test.go
@@ -107,7 +107,7 @@ func TestConfig(t *testing.T) {
 				Spans: []MetricInfo{
 					{
 						Name:        "identical.name",
-						Description: "Identical metric name x1",
+						Description: "Identical description",
 						Unit:        MetricUnitMs,
 						Attributes:  []AttributeConfig{{Key: "key.1"}},
 						Histogram: HistogramConfig{
@@ -118,7 +118,36 @@ func TestConfig(t *testing.T) {
 					},
 					{
 						Name:        "identical.name",
-						Description: "Identical metric name x2",
+						Description: "Different description",
+						Unit:        MetricUnitMs,
+						Attributes:  []AttributeConfig{{Key: "key.2"}},
+						Histogram: HistogramConfig{
+							Explicit: &ExplicitHistogramConfig{
+								Buckets: defaultExplicitHistogramBuckets(MetricUnitMs),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			path: "with_identical_metric_name_desc_different_attrs",
+			expected: &Config{
+				Spans: []MetricInfo{
+					{
+						Name:        "identical.name",
+						Description: "Identical description",
+						Unit:        MetricUnitMs,
+						Attributes:  []AttributeConfig{{Key: "key.1"}},
+						Histogram: HistogramConfig{
+							Explicit: &ExplicitHistogramConfig{
+								Buckets: defaultExplicitHistogramBuckets(MetricUnitMs),
+							},
+						},
+					},
+					{
+						Name:        "identical.name",
+						Description: "Identical description",
 						Unit:        MetricUnitMs,
 						Attributes:  []AttributeConfig{{Key: "key.2"}},
 						Histogram: HistogramConfig{

--- a/connector/spanmetricsconnectorv2/config_test.go
+++ b/connector/spanmetricsconnectorv2/config_test.go
@@ -32,6 +32,7 @@ func TestConfig(t *testing.T) {
 	for _, tc := range []struct {
 		path     string // relative to testdata directory
 		expected *Config
+		errorMsg string
 	}{
 		{
 			path: "with_default",
@@ -42,8 +43,9 @@ func TestConfig(t *testing.T) {
 		{
 			path: "with_attributes",
 			expected: &Config{
-				Spans: map[string]MetricInfo{
-					"http.trace.span.duration": {
+				Spans: []MetricInfo{
+					{
+						Name:        "http.trace.span.duration",
 						Description: "Span duration for HTTP spans",
 						Unit:        MetricUnitMs,
 						Attributes:  []AttributeConfig{{Key: "http.response.status_code"}},
@@ -53,7 +55,8 @@ func TestConfig(t *testing.T) {
 							},
 						},
 					},
-					"db.trace.span.duration": {
+					{
+						Name:        "db.trace.span.duration",
 						Description: "Span duration for DB spans",
 						Unit:        MetricUnitMs,
 						Attributes:  []AttributeConfig{{Key: "db.system"}},
@@ -63,7 +66,8 @@ func TestConfig(t *testing.T) {
 							},
 						},
 					},
-					"msg.trace.span.duration": {
+					{
+						Name:        "msg.trace.span.duration",
 						Description: "Span duration for messaging spans",
 						Unit:        MetricUnitMs,
 						Attributes:  []AttributeConfig{{Key: "messaging.system"}},
@@ -79,13 +83,47 @@ func TestConfig(t *testing.T) {
 		{
 			path: "with_custom_histogram_buckets",
 			expected: &Config{
-				Spans: map[string]MetricInfo{
-					"trace.span.duration": {
+				Spans: []MetricInfo{
+					{
+						Name:        "trace.span.duration",
 						Description: "Span duration with custom histogram buckets",
 						Unit:        MetricUnitS,
 						Histogram: HistogramConfig{
 							Explicit: &ExplicitHistogramConfig{
 								Buckets: []float64{0.001, 0.1, 1, 10},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			path:     "with_identical_metric_name_identical_attrs",
+			errorMsg: "duplicate configuration found",
+		},
+		{
+			path: "with_identical_metric_name_different_attrs",
+			expected: &Config{
+				Spans: []MetricInfo{
+					{
+						Name:        "identical.name",
+						Description: "Identical metric name x1",
+						Unit:        MetricUnitMs,
+						Attributes:  []AttributeConfig{{Key: "key.1"}},
+						Histogram: HistogramConfig{
+							Explicit: &ExplicitHistogramConfig{
+								Buckets: defaultExplicitHistogramBuckets(MetricUnitMs),
+							},
+						},
+					},
+					{
+						Name:        "identical.name",
+						Description: "Identical metric name x2",
+						Unit:        MetricUnitMs,
+						Attributes:  []AttributeConfig{{Key: "key.2"}},
+						Histogram: HistogramConfig{
+							Explicit: &ExplicitHistogramConfig{
+								Buckets: defaultExplicitHistogramBuckets(MetricUnitMs),
 							},
 						},
 					},
@@ -103,7 +141,13 @@ func TestConfig(t *testing.T) {
 			require.NoError(t, err)
 			require.NoError(t, sub.Unmarshal(&cfg))
 
-			assert.NoError(t, component.ValidateConfig(cfg))
+			err = component.ValidateConfig(cfg)
+			if tc.errorMsg != "" {
+				assert.ErrorContains(t, err, tc.errorMsg)
+				return
+			}
+
+			assert.NoError(t, err)
 			assert.Equal(t, tc.expected, cfg)
 		})
 	}

--- a/connector/spanmetricsconnectorv2/connector.go
+++ b/connector/spanmetricsconnectorv2/connector.go
@@ -35,7 +35,7 @@ type spanMetrics struct {
 	component.ShutdownFunc
 
 	next            consumer.Metrics
-	spansMetricDefs map[string]metricDef
+	spansMetricDefs []metricDef
 }
 
 func (sm *spanMetrics) Capabilities() consumer.Capabilities {
@@ -66,7 +66,7 @@ func (sm *spanMetrics) ConsumeTraces(ctx context.Context, td ptrace.Traces) erro
 			}
 		}
 
-		if len(spansHist.counts) == 0 {
+		if len(spansHist.data) == 0 {
 			continue // don't add an empty resource
 		}
 

--- a/connector/spanmetricsconnectorv2/connector_test.go
+++ b/connector/spanmetricsconnectorv2/connector_test.go
@@ -74,15 +74,13 @@ func TestConnector(t *testing.T) {
 			require.NoError(t, err)
 
 			require.NoError(t, connector.ConsumeTraces(ctx, inputTraces))
-			if !assert.NoError(t, pmetrictest.CompareMetrics(
+			assert.NoError(t, pmetrictest.CompareMetrics(
 				expectedMetrics,
 				next.AllMetrics()[0],
 				pmetrictest.IgnoreMetricDataPointsOrder(),
 				pmetrictest.IgnoreMetricsOrder(),
 				pmetrictest.IgnoreTimestamp(),
-			)) {
-				golden.WriteMetrics(t, filepath.Join(dir, "output.yaml"), next.AllMetrics()[0])
-			}
+			))
 		})
 	}
 }

--- a/connector/spanmetricsconnectorv2/connector_test.go
+++ b/connector/spanmetricsconnectorv2/connector_test.go
@@ -37,11 +37,12 @@ import (
 
 func TestConnector(t *testing.T) {
 	testCases := []string{
-		"with_default",
-		"with_attributes",
-		"with_missing_attribute",
-		"with_missing_attribute_default_value",
-		"with_custom_histogram_buckets",
+		// "with_default",
+		// "with_attributes",
+		// "with_missing_attribute",
+		// "with_missing_attribute_default_value",
+		// "with_custom_histogram_buckets",
+		"with_identical_metric_name_different_attrs",
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/connector/spanmetricsconnectorv2/connector_test.go
+++ b/connector/spanmetricsconnectorv2/connector_test.go
@@ -37,12 +37,13 @@ import (
 
 func TestConnector(t *testing.T) {
 	testCases := []string{
-		// "with_default",
-		// "with_attributes",
-		// "with_missing_attribute",
-		// "with_missing_attribute_default_value",
-		// "with_custom_histogram_buckets",
+		"with_default",
+		"with_attributes",
+		"with_missing_attribute",
+		"with_missing_attribute_default_value",
+		"with_custom_histogram_buckets",
 		"with_identical_metric_name_different_attrs",
+		"with_identical_metric_name_desc_different_attrs",
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -73,12 +74,15 @@ func TestConnector(t *testing.T) {
 			require.NoError(t, err)
 
 			require.NoError(t, connector.ConsumeTraces(ctx, inputTraces))
-			assert.NoError(t, pmetrictest.CompareMetrics(
+			if !assert.NoError(t, pmetrictest.CompareMetrics(
 				expectedMetrics,
 				next.AllMetrics()[0],
+				pmetrictest.IgnoreMetricDataPointsOrder(),
 				pmetrictest.IgnoreMetricsOrder(),
 				pmetrictest.IgnoreTimestamp(),
-			))
+			)) {
+				golden.WriteMetrics(t, filepath.Join(dir, "output.yaml"), next.AllMetrics()[0])
+			}
 		})
 	}
 }

--- a/connector/spanmetricsconnectorv2/factory.go
+++ b/connector/spanmetricsconnectorv2/factory.go
@@ -53,19 +53,20 @@ func createTracesToMetrics(
 ) (connector.Traces, error) {
 	c := cfg.(*Config)
 
-	spanMetricDefs := make(map[string]metricDef, len(c.Spans))
-	for name, info := range c.Spans {
+	spanMetricDefs := make([]metricDef, 0, len(c.Spans))
+	for _, info := range c.Spans {
 		attrs, err := parseAttributeConfigs(info.Attributes)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse attribute config: %w", err)
 		}
 		md := metricDef{
+			Name:        info.Name,
 			Description: info.Description,
 			Unit:        info.Unit,
 			Attributes:  attrs,
 			Histogram:   info.Histogram,
 		}
-		spanMetricDefs[name] = md
+		spanMetricDefs = append(spanMetricDefs, md)
 	}
 
 	return &spanMetrics{

--- a/connector/spanmetricsconnectorv2/metadata.yaml
+++ b/connector/spanmetricsconnectorv2/metadata.yaml
@@ -10,5 +10,5 @@ status:
 tests:
   config:
     spans:
-      test.metric:
+      - name: test.metric
         description: "test metric"

--- a/connector/spanmetricsconnectorv2/model.go
+++ b/connector/spanmetricsconnectorv2/model.go
@@ -25,6 +25,7 @@ type keyValue struct {
 }
 
 type metricDef struct {
+	Name        string
 	Description string
 	Unit        MetricUnit
 	Attributes  []keyValue

--- a/connector/spanmetricsconnectorv2/testdata/with_attributes/config.yaml
+++ b/connector/spanmetricsconnectorv2/testdata/with_attributes/config.yaml
@@ -1,14 +1,14 @@
 spanmetricsv2:
   spans:
-    http.trace.span.duration:
+    - name: http.trace.span.duration
       description: Span duration for HTTP spans
       attributes:
         - key: http.response.status_code
-    db.trace.span.duration:
+    - name: db.trace.span.duration
       description: Span duration for DB spans
       attributes:
         - key: db.system
-    msg.trace.span.duration:
+    - name: msg.trace.span.duration
       description: Span duration for messaging spans
       attributes:
         - key: messaging.system

--- a/connector/spanmetricsconnectorv2/testdata/with_custom_histogram_buckets/config.yaml
+++ b/connector/spanmetricsconnectorv2/testdata/with_custom_histogram_buckets/config.yaml
@@ -1,6 +1,6 @@
 spanmetricsv2:
   spans:
-    trace.span.duration:
+    - name: trace.span.duration
       description: Span duration with custom histogram buckets
       unit: "s"
       histogram:

--- a/connector/spanmetricsconnectorv2/testdata/with_identical_metric_name_desc_different_attrs/config.yaml
+++ b/connector/spanmetricsconnectorv2/testdata/with_identical_metric_name_desc_different_attrs/config.yaml
@@ -5,6 +5,6 @@ spanmetricsv2:
       attributes:
         - key: key.1
     - name: identical.name
-      description: Different description
+      description: Identical description
       attributes:
         - key: key.2

--- a/connector/spanmetricsconnectorv2/testdata/with_identical_metric_name_desc_different_attrs/input.yaml
+++ b/connector/spanmetricsconnectorv2/testdata/with_identical_metric_name_desc_different_attrs/input.yaml
@@ -1,0 +1,39 @@
+resourceSpans:
+  - resource:
+      attributes:
+        - key: resource.foo
+          value:
+            stringValue: foo
+        - key: resource.bar
+          value:
+            stringValue: bar
+    scopeSpans:
+      - scope: {}
+        spans:
+          - attributes:
+              - key: key.1
+                value:
+                  stringValue: key1
+              - key: key.2
+                value:
+                  stringValue: key2
+            endTimeUnixNano: "1581452772500000789"
+            name: both-keys
+            parentSpanId: ""
+            startTimeUnixNano: "1581452772000000321"
+          - attributes:
+              - key: key.1
+                value:
+                  stringValue: key1
+            endTimeUnixNano: "1581452772900000789"
+            name: only-key-1
+            parentSpanId: ""
+            startTimeUnixNano: "1581452772000000321"
+          - attributes:
+              - key: key.2
+                value:
+                  stringValue: key2
+            endTimeUnixNano: "1581452772002000789"
+            name: only-key-2
+            parentSpanId: ""
+            startTimeUnixNano: "1581452772000000321"

--- a/connector/spanmetricsconnectorv2/testdata/with_identical_metric_name_desc_different_attrs/output.yaml
+++ b/connector/spanmetricsconnectorv2/testdata/with_identical_metric_name_desc_different_attrs/output.yaml
@@ -55,11 +55,6 @@ resourceMetrics:
                     - 15000
                   sum: 1400.000936
                   timeUnixNano: "1000000"
-            name: identical.name
-          - description: Different description
-            histogram:
-              aggregationTemporality: 1
-              dataPoints:
                 - attributes:
                     - key: key.2
                       value:

--- a/connector/spanmetricsconnectorv2/testdata/with_identical_metric_name_different_attrs/config.yaml
+++ b/connector/spanmetricsconnectorv2/testdata/with_identical_metric_name_different_attrs/config.yaml
@@ -1,0 +1,14 @@
+spanmetricsv2:
+  spans:
+    - name: identical.name
+      description: Identical description
+      attributes:
+        - key: key.1
+    - name: identical.name
+      description: Different description
+      attributes:
+        - key: key.2
+    - name: identical.name
+      description: Identical description
+      attributes:
+        - key: key.2

--- a/connector/spanmetricsconnectorv2/testdata/with_identical_metric_name_different_attrs/input.yaml
+++ b/connector/spanmetricsconnectorv2/testdata/with_identical_metric_name_different_attrs/input.yaml
@@ -1,0 +1,39 @@
+resourceSpans:
+  - resource:
+      attributes:
+        - key: resource.foo
+          value:
+            stringValue: foo
+        - key: resource.bar
+          value:
+            stringValue: bar
+    scopeSpans:
+      - scope: {}
+        spans:
+          - attributes:
+              - key: key.1
+                value:
+                  stringValue: key1
+              - key: key.2
+                value:
+                  stringValue: key2
+            endTimeUnixNano: "1581452772500000789"
+            name: both-keys
+            parentSpanId: ""
+            startTimeUnixNano: "1581452772000000321"
+          - attributes:
+              - key: key.1
+                value:
+                  stringValue: key1
+            endTimeUnixNano: "1581452772900000789"
+            name: only-key-1
+            parentSpanId: ""
+            startTimeUnixNano: "1581452772000000321"
+          - attributes:
+              - key: key.2
+                value:
+                  stringValue: key2
+            endTimeUnixNano: "1581452772002000789"
+            name: only-key-2
+            parentSpanId: ""
+            startTimeUnixNano: "1581452772000000321"

--- a/connector/spanmetricsconnectorv2/testdata/with_identical_metric_name_different_attrs/output.yaml
+++ b/connector/spanmetricsconnectorv2/testdata/with_identical_metric_name_different_attrs/output.yaml
@@ -1,0 +1,149 @@
+resourceMetrics:
+  - resource:
+      attributes:
+        - key: resource.bar
+          value:
+            stringValue: bar
+        - key: resource.foo
+          value:
+            stringValue: foo
+    scopeMetrics:
+      - metrics:
+          - description: Identical description
+            histogram:
+              aggregationTemporality: 1
+              dataPoints:
+                - attributes:
+                    - key: key.1
+                      value:
+                        stringValue: key1
+                  bucketCounts:
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "1"
+                    - "1"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                  count: "2"
+                  explicitBounds:
+                    - 2
+                    - 4
+                    - 6
+                    - 8
+                    - 10
+                    - 50
+                    - 100
+                    - 200
+                    - 400
+                    - 800
+                    - 1000
+                    - 1400
+                    - 2000
+                    - 5000
+                    - 10000
+                    - 15000
+                  sum: 1400.000936
+                  timeUnixNano: "1000000"
+                - attributes:
+                    - key: key.2
+                      value:
+                        stringValue: key2
+                  bucketCounts:
+                    - "0"
+                    - "1"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "1"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                  count: "2"
+                  explicitBounds:
+                    - 2
+                    - 4
+                    - 6
+                    - 8
+                    - 10
+                    - 50
+                    - 100
+                    - 200
+                    - 400
+                    - 800
+                    - 1000
+                    - 1400
+                    - 2000
+                    - 5000
+                    - 10000
+                    - 15000
+                  sum: 502.000936
+                  timeUnixNano: "1000000"
+            name: identical.name
+          - description: Different description
+            histogram:
+              aggregationTemporality: 1
+              dataPoints:
+                - attributes:
+                    - key: key.2
+                      value:
+                        stringValue: key2
+                  bucketCounts:
+                    - "0"
+                    - "1"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "1"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                  count: "2"
+                  explicitBounds:
+                    - 2
+                    - 4
+                    - 6
+                    - 8
+                    - 10
+                    - 50
+                    - 100
+                    - 200
+                    - 400
+                    - 800
+                    - 1000
+                    - 1400
+                    - 2000
+                    - 5000
+                    - 10000
+                    - 15000
+                  sum: 502.000936
+                  timeUnixNano: "1000000"
+            name: identical.name
+        scope:
+          name: otelcol/spanmetricsconnectorv2

--- a/connector/spanmetricsconnectorv2/testdata/with_identical_metric_name_identical_attrs/config.yaml
+++ b/connector/spanmetricsconnectorv2/testdata/with_identical_metric_name_identical_attrs/config.yaml
@@ -1,0 +1,12 @@
+# Invalid config, should throw an error on validate
+spanmetricsv2:
+  spans:
+    - name: identical.name
+      description: Identical metric name
+      attributes:
+        - key: key.1
+    - name: identical.name
+      description: Identical metric name
+      attributes:
+        - key: key.1
+  

--- a/connector/spanmetricsconnectorv2/testdata/with_missing_attribute/config.yaml
+++ b/connector/spanmetricsconnectorv2/testdata/with_missing_attribute/config.yaml
@@ -1,6 +1,6 @@
 spanmetricsv2:
   spans:
-    404.span.duration:
+    - name: 404.span.duration
       description: Span duration with missing attribute
       attributes:
         - key: 404.attribute

--- a/connector/spanmetricsconnectorv2/testdata/with_missing_attribute_default_value/config.yaml
+++ b/connector/spanmetricsconnectorv2/testdata/with_missing_attribute_default_value/config.yaml
@@ -1,6 +1,6 @@
 spanmetricsv2:
   spans:
-    404.span.duration:
+    - name: 404.span.duration
       description: Span duration with missing attribute but default value
       attributes:
         - key: 404.attribute


### PR DESCRIPTION
Allows creating span metrics with same metric name but different resource attributes.