### PR TITLE
[connector/spanmetrics] Use fixed default buckets for histograms

### DIFF
--- a/connector/spanmetricsconnectorv2/config.go
+++ b/connector/spanmetricsconnectorv2/config.go
@@ -20,7 +20,6 @@ package spanmetricsconnectorv2 // import "github.com/elastic/opentelemetry-colle
 import (
 	"errors"
 	"fmt"
-	"time"
 
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -31,9 +30,9 @@ const (
 	defaultMetricDescSpans = "Observed span duration."
 )
 
-var (
-	defaultHistogramBucketsMs = [...]float64{2, 4, 6, 8, 10, 50, 100, 200, 400, 800, 1000, 1400, 2000, 5000, 10_000, 15_000}
-)
+var defaultHistogramBuckets = []float64{
+	2, 4, 6, 8, 10, 50, 100, 200, 400, 800, 1000, 1400, 2000, 5000, 10_000, 15_000,
+}
 
 type MetricUnit string
 
@@ -173,7 +172,7 @@ func (c *Config) Unmarshal(componentParser *confmap.Conf) error {
 			info.Histogram.Explicit = &ExplicitHistogramConfig{}
 		}
 		if len(info.Histogram.Explicit.Buckets) == 0 {
-			info.Histogram.Explicit.Buckets = defaultExplicitHistogramBuckets(info.Unit)
+			info.Histogram.Explicit.Buckets = defaultHistogramBuckets[:]
 		}
 		c.Spans[k] = info
 	}
@@ -188,23 +187,9 @@ func defaultSpansConfig() []MetricInfo {
 			Unit:        MetricUnitMs,
 			Histogram: HistogramConfig{
 				Explicit: &ExplicitHistogramConfig{
-					Buckets: defaultExplicitHistogramBuckets(MetricUnitMs),
+					Buckets: defaultHistogramBuckets[:],
 				},
 			},
 		},
 	}
-}
-
-func defaultExplicitHistogramBuckets(unit MetricUnit) []float64 {
-	switch unit {
-	case MetricUnitMs:
-		return defaultHistogramBucketsMs[:]
-	case MetricUnitS:
-		buckets := make([]float64, len(defaultHistogramBucketsMs))
-		for i := 0; i < len(buckets); i++ {
-			buckets[i] /= float64(time.Second.Milliseconds())
-		}
-		return buckets
-	}
-	return nil
 }

--- a/connector/spanmetricsconnectorv2/config_test.go
+++ b/connector/spanmetricsconnectorv2/config_test.go
@@ -51,7 +51,7 @@ func TestConfig(t *testing.T) {
 						Attributes:  []AttributeConfig{{Key: "http.response.status_code"}},
 						Histogram: HistogramConfig{
 							Explicit: &ExplicitHistogramConfig{
-								Buckets: defaultExplicitHistogramBuckets(MetricUnitMs),
+								Buckets: defaultHistogramBuckets[:],
 							},
 						},
 					},
@@ -62,7 +62,7 @@ func TestConfig(t *testing.T) {
 						Attributes:  []AttributeConfig{{Key: "db.system"}},
 						Histogram: HistogramConfig{
 							Explicit: &ExplicitHistogramConfig{
-								Buckets: defaultExplicitHistogramBuckets(MetricUnitMs),
+								Buckets: defaultHistogramBuckets[:],
 							},
 						},
 					},
@@ -73,7 +73,7 @@ func TestConfig(t *testing.T) {
 						Attributes:  []AttributeConfig{{Key: "messaging.system"}},
 						Histogram: HistogramConfig{
 							Explicit: &ExplicitHistogramConfig{
-								Buckets: defaultExplicitHistogramBuckets(MetricUnitMs),
+								Buckets: defaultHistogramBuckets[:],
 							},
 						},
 					},
@@ -112,7 +112,7 @@ func TestConfig(t *testing.T) {
 						Attributes:  []AttributeConfig{{Key: "key.1"}},
 						Histogram: HistogramConfig{
 							Explicit: &ExplicitHistogramConfig{
-								Buckets: defaultExplicitHistogramBuckets(MetricUnitMs),
+								Buckets: defaultHistogramBuckets[:],
 							},
 						},
 					},
@@ -123,7 +123,7 @@ func TestConfig(t *testing.T) {
 						Attributes:  []AttributeConfig{{Key: "key.2"}},
 						Histogram: HistogramConfig{
 							Explicit: &ExplicitHistogramConfig{
-								Buckets: defaultExplicitHistogramBuckets(MetricUnitMs),
+								Buckets: defaultHistogramBuckets[:],
 							},
 						},
 					},
@@ -141,7 +141,7 @@ func TestConfig(t *testing.T) {
 						Attributes:  []AttributeConfig{{Key: "key.1"}},
 						Histogram: HistogramConfig{
 							Explicit: &ExplicitHistogramConfig{
-								Buckets: defaultExplicitHistogramBuckets(MetricUnitMs),
+								Buckets: defaultHistogramBuckets[:],
 							},
 						},
 					},
@@ -152,7 +152,7 @@ func TestConfig(t *testing.T) {
 						Attributes:  []AttributeConfig{{Key: "key.2"}},
 						Histogram: HistogramConfig{
 							Explicit: &ExplicitHistogramConfig{
-								Buckets: defaultExplicitHistogramBuckets(MetricUnitMs),
+								Buckets: defaultHistogramBuckets[:],
 							},
 						},
 					},


### PR DESCRIPTION
The previous code was trying to normalize the buckets incorrectly, I have removed the normalization entirely as it was confusing for the end users that the buckets can change based on the unit configured.