### PR TITLE
[connector/spanmetricsv2] Add support for summary metric

### DIFF
--- a/connector/spanmetricsconnectorv2/config/config_test.go
+++ b/connector/spanmetricsconnectorv2/config/config_test.go
@@ -159,6 +159,34 @@ func TestConfig(t *testing.T) {
 				},
 			},
 		},
+		{
+			path: "with_summary",
+			expected: &Config{
+				Spans: []MetricInfo{
+					{
+						Name:        "http.trace.span.summary",
+						Description: "Summary for HTTP spans",
+						Unit:        MetricUnitMs,
+						Attributes:  []Attribute{{Key: "http.response.status_code"}},
+						Summary:     &Summary{},
+					},
+					{
+						Name:        "db.trace.span.summary",
+						Description: "Summary for DB spans",
+						Unit:        MetricUnitMs,
+						Attributes:  []Attribute{{Key: "db.system"}},
+						Summary:     &Summary{},
+					},
+					{
+						Name:        "msg.trace.span.summary",
+						Description: "Summary for messaging spans",
+						Unit:        MetricUnitMs,
+						Attributes:  []Attribute{{Key: "messaging.system"}},
+						Summary:     &Summary{},
+					},
+				},
+			},
+		},
 	} {
 		t.Run(tc.path, func(t *testing.T) {
 			dir := filepath.Join("../testdata", tc.path)

--- a/connector/spanmetricsconnectorv2/connector.go
+++ b/connector/spanmetricsconnectorv2/connector.go
@@ -48,7 +48,7 @@ func (sm *spanMetrics) ConsumeTraces(ctx context.Context, td ptrace.Traces) erro
 	var multiError error
 	processedMetrics := pmetric.NewMetrics()
 	processedMetrics.ResourceMetrics().EnsureCapacity(td.ResourceSpans().Len())
-	// TODO (lahsivjar): add support for exponential histogram and summary
+	// TODO (lahsivjar): add support for exponential histogram
 	aggregator := aggregator.NewAggregator()
 	for i := 0; i < td.ResourceSpans().Len(); i++ {
 		aggregator.Reset()

--- a/connector/spanmetricsconnectorv2/connector_test.go
+++ b/connector/spanmetricsconnectorv2/connector_test.go
@@ -48,6 +48,7 @@ func TestConnector(t *testing.T) {
 		"with_custom_histogram_buckets",
 		"with_identical_metric_name_different_attrs",
 		"with_identical_metric_name_desc_different_attrs",
+		"with_summary",
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -67,6 +68,7 @@ func TestConnector(t *testing.T) {
 			sub, err := cm.Sub(component.NewIDWithName(metadata.Type, "").String())
 			require.NoError(t, err)
 			require.NoError(t, sub.Unmarshal(&cfg))
+			require.NoError(t, component.ValidateConfig(cfg))
 
 			connector, err := factory.CreateTracesToMetrics(ctx, settings, cfg, next)
 			require.NoError(t, err)

--- a/connector/spanmetricsconnectorv2/factory.go
+++ b/connector/spanmetricsconnectorv2/factory.go
@@ -69,6 +69,7 @@ func createTracesToMetrics(
 			Unit:              info.Unit,
 			Attributes:        attrs,
 			ExplicitHistogram: info.Histogram.Explicit,
+			Summary:           info.Summary,
 		}
 		metricDefs = append(metricDefs, md)
 	}

--- a/connector/spanmetricsconnectorv2/factory.go
+++ b/connector/spanmetricsconnectorv2/factory.go
@@ -62,11 +62,13 @@ func createTracesToMetrics(
 			return nil, fmt.Errorf("failed to parse attribute config: %w", err)
 		}
 		md := model.MetricDef{
-			Name:        info.Name,
-			Description: info.Description,
-			Unit:        info.Unit,
-			Attributes:  attrs,
-			Histogram:   info.Histogram,
+			Key: model.MetricKey{
+				Name:        info.Name,
+				Description: info.Description,
+			},
+			Unit:              info.Unit,
+			Attributes:        attrs,
+			ExplicitHistogram: info.Histogram.Explicit,
 		}
 		metricDefs = append(metricDefs, md)
 	}

--- a/connector/spanmetricsconnectorv2/internal/aggregator/aggregator.go
+++ b/connector/spanmetricsconnectorv2/internal/aggregator/aggregator.go
@@ -1,0 +1,114 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package aggregator // import "github.com/elastic/opentelemetry-collector-components/connector/spanmetricsconnectorv2/internal/aggregator"
+
+import (
+	"errors"
+	"time"
+
+	"github.com/elastic/opentelemetry-collector-components/connector/spanmetricsconnectorv2/config"
+	"github.com/elastic/opentelemetry-collector-components/connector/spanmetricsconnectorv2/internal/model"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+)
+
+// metricUnitToDivider gives a value that could used to divide the
+// nano precision duration to the required unit specified in config.
+var metricUnitToDivider = map[config.MetricUnit]float64{
+	config.MetricUnitNs: float64(time.Nanosecond.Nanoseconds()),
+	config.MetricUnitUs: float64(time.Microsecond.Nanoseconds()),
+	config.MetricUnitMs: float64(time.Millisecond.Nanoseconds()),
+	config.MetricUnitS:  float64(time.Second.Nanoseconds()),
+}
+
+type Aggregator struct {
+	explicitBounds *explicitHistogram
+}
+
+func NewAggregator() *Aggregator {
+	return &Aggregator{}
+}
+
+func (a *Aggregator) Add(
+	md model.MetricDef,
+	srcAttrs pcommon.Map,
+	spanDuration time.Duration,
+) error {
+	filteredAttrs := pcommon.NewMap()
+	for _, definedAttr := range md.Attributes {
+		if srcAttr, ok := srcAttrs.Get(definedAttr.Key); ok {
+			srcAttr.CopyTo(filteredAttrs.PutEmpty(definedAttr.Key))
+			continue
+		}
+		if definedAttr.DefaultValue.Type() != pcommon.ValueTypeEmpty {
+			definedAttr.DefaultValue.CopyTo(filteredAttrs.PutEmpty(definedAttr.Key))
+		}
+	}
+
+	// If all the configured attributes are not present in source
+	// metric then don't count them.
+	if filteredAttrs.Len() != len(md.Attributes) {
+		return nil
+	}
+
+	value := float64(spanDuration.Nanoseconds()) / metricUnitToDivider[md.Unit]
+
+	var errs []error
+	if md.ExplicitHistogram != nil {
+		if a.explicitBounds == nil {
+			a.explicitBounds = newExplicitBounds()
+		}
+		if err := a.explicitBounds.Add(
+			md.Key, value, filteredAttrs, *md.ExplicitHistogram,
+		); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+	return nil
+}
+
+func (a *Aggregator) Move(
+	md model.MetricDef,
+	dest pmetric.MetricSlice,
+) {
+	if md.ExplicitHistogram != nil {
+		if a.explicitBounds == nil {
+			// nothing is added, return
+			return
+		}
+		a.explicitBounds.Move(md.Key, dest)
+	}
+}
+
+func (a *Aggregator) Size() int {
+	var size int
+	if a.explicitBounds != nil {
+		size += a.explicitBounds.Size()
+	}
+	return size
+}
+
+func (a *Aggregator) Reset() {
+	if a.explicitBounds != nil {
+		a.explicitBounds.Reset()
+	}
+}

--- a/connector/spanmetricsconnectorv2/internal/aggregator/explicithistogram.go
+++ b/connector/spanmetricsconnectorv2/internal/aggregator/explicithistogram.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package histogram // import "github.com/elastic/opentelemetry-collector-components/connector/spanmetricsconnectorv2/internal/aggregator/histogram"
+package aggregator // import "github.com/elastic/opentelemetry-collector-components/connector/spanmetricsconnectorv2/internal/aggregator"
 
 import (
 	"sort"
@@ -28,69 +28,42 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 )
 
-// metricUnitToDivider gives a value that could used to divide the
-// nano precision duration to the required unit specified in config.
-var metricUnitToDivider = map[config.MetricUnit]float64{
-	config.MetricUnitNs: float64(time.Nanosecond.Nanoseconds()),
-	config.MetricUnitUs: float64(time.Microsecond.Nanoseconds()),
-	config.MetricUnitMs: float64(time.Millisecond.Nanoseconds()),
-	config.MetricUnitS:  float64(time.Second.Nanoseconds()),
-}
-
-// ExplicitBounds is a representation of explict bound histogram for
+// explicitHistogram is a representation of explict bound histogram for
 // calculating histograms for span durations.
-type ExplicitBounds struct {
+type explicitHistogram struct {
 	// TODO (lahsivjar): Attribute hash collisions are not considered
-	datapoints map[metricKey]map[[16]byte]*explicitHistogramDP
+	datapoints map[model.MetricKey]map[[16]byte]*explicitHistogramDP
 	timestamp  time.Time
 }
 
-// NewExplicitBounds creates a new instance of explicit bounds histogram.
-func NewExplicitBounds() *ExplicitBounds {
-	return &ExplicitBounds{
-		datapoints: make(map[metricKey]map[[16]byte]*explicitHistogramDP),
+// newExplicitBounds creates a new instance of explicit bounds histogram.
+func newExplicitBounds() *explicitHistogram {
+	return &explicitHistogram{
+		datapoints: make(map[model.MetricKey]map[[16]byte]*explicitHistogramDP),
 		timestamp:  time.Now(),
 	}
 }
 
 // Add adds a datapoint for a given metric definition to the histogram.
-func (h *ExplicitBounds) Add(
-	md model.MetricDef,
-	srcAttrs pcommon.Map,
-	spanDuration time.Duration,
+func (h *explicitHistogram) Add(
+	key model.MetricKey,
+	value float64,
+	attributes pcommon.Map,
+	histoCfg config.ExplicitHistogram,
 ) error {
-	filteredAttrs := pcommon.NewMap()
-	for _, definedAttr := range md.Attributes {
-		if srcAttr, ok := srcAttrs.Get(definedAttr.Key); ok {
-			srcAttr.CopyTo(filteredAttrs.PutEmpty(definedAttr.Key))
-			continue
-		}
-		if definedAttr.DefaultValue.Type() != pcommon.ValueTypeEmpty {
-			definedAttr.DefaultValue.CopyTo(filteredAttrs.PutEmpty(definedAttr.Key))
-		}
-	}
-
-	// If all the configured attributes are not present in source
-	// metric then don't count them.
-	if filteredAttrs.Len() != len(md.Attributes) {
-		return nil
-	}
-
-	key := metricKey{Name: md.Name, Desc: md.Description}
 	if _, ok := h.datapoints[key]; !ok {
 		h.datapoints[key] = make(map[[16]byte]*explicitHistogramDP)
 	}
 
 	var attrKey [16]byte
-	if filteredAttrs.Len() > 0 {
-		attrKey = pdatautil.MapHash(filteredAttrs)
+	if attributes.Len() > 0 {
+		attrKey = pdatautil.MapHash(attributes)
 	}
 
 	if _, ok := h.datapoints[key][attrKey]; !ok {
-		h.datapoints[key][attrKey] = newExplicitHistogramDP(filteredAttrs, md.Histogram.Explicit.Buckets)
+		h.datapoints[key][attrKey] = newExplicitHistogramDP(attributes, histoCfg.Buckets)
 	}
 
-	value := float64(spanDuration.Nanoseconds()) / metricUnitToDivider[md.Unit]
 	dp := h.datapoints[key][attrKey]
 	dp.sum += value
 	dp.count++
@@ -100,19 +73,18 @@ func (h *ExplicitBounds) Add(
 
 // Move moves the histogram for a given metric definition to a metric slice.
 // Note that move also deletes the histogram representation after moving.
-func (h *ExplicitBounds) Move(
-	md model.MetricDef,
+func (h *explicitHistogram) Move(
+	key model.MetricKey,
 	dest pmetric.MetricSlice,
 ) {
-	key := metricKey{Name: md.Name, Desc: md.Description}
 	srcDps, ok := h.datapoints[key]
 	if !ok || len(srcDps) == 0 {
 		return
 	}
 
 	destMetric := dest.AppendEmpty()
-	destMetric.SetName(md.Name)
-	destMetric.SetDescription(md.Description)
+	destMetric.SetName(key.Name)
+	destMetric.SetDescription(key.Description)
 	destHist := destMetric.SetEmptyHistogram()
 	destHist.SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
 	destHist.DataPoints().EnsureCapacity(len(srcDps))
@@ -133,19 +105,14 @@ func (h *ExplicitBounds) Move(
 }
 
 // Size returns the number of datapoints in the histogram representation.
-func (h *ExplicitBounds) Size() int {
+func (h *explicitHistogram) Size() int {
 	return len(h.datapoints)
 }
 
 // Reset resets the histogram for another usage. Note that timestamp is
 // not updated as part of the reset.
-func (h *ExplicitBounds) Reset() {
+func (h *explicitHistogram) Reset() {
 	clear(h.datapoints)
-}
-
-type metricKey struct {
-	Name string
-	Desc string
 }
 
 type explicitHistogramDP struct {

--- a/connector/spanmetricsconnectorv2/internal/model/model.go
+++ b/connector/spanmetricsconnectorv2/internal/model/model.go
@@ -28,9 +28,13 @@ type AttributeKeyValue struct {
 }
 
 type MetricDef struct {
+	Key               MetricKey
+	Unit              config.MetricUnit
+	Attributes        []AttributeKeyValue
+	ExplicitHistogram *config.ExplicitHistogram
+}
+
+type MetricKey struct {
 	Name        string
 	Description string
-	Unit        config.MetricUnit
-	Attributes  []AttributeKeyValue
-	Histogram   config.Histogram
 }

--- a/connector/spanmetricsconnectorv2/internal/model/model.go
+++ b/connector/spanmetricsconnectorv2/internal/model/model.go
@@ -32,6 +32,7 @@ type MetricDef struct {
 	Unit              config.MetricUnit
 	Attributes        []AttributeKeyValue
 	ExplicitHistogram *config.ExplicitHistogram
+	Summary           *config.Summary
 }
 
 type MetricKey struct {

--- a/connector/spanmetricsconnectorv2/testdata/with_attributes/config.yaml
+++ b/connector/spanmetricsconnectorv2/testdata/with_attributes/config.yaml
@@ -12,4 +12,3 @@ spanmetricsv2:
       description: Span duration for messaging spans
       attributes:
         - key: messaging.system
-  

--- a/connector/spanmetricsconnectorv2/testdata/with_identical_metric_name_desc_different_attrs/config.yaml
+++ b/connector/spanmetricsconnectorv2/testdata/with_identical_metric_name_desc_different_attrs/config.yaml
@@ -4,7 +4,11 @@ spanmetricsv2:
       description: Identical description
       attributes:
         - key: key.1
+      histogram:
+        explicit: {}
     - name: identical.name
       description: Identical description
       attributes:
         - key: key.2
+      histogram:
+        explicit: {}

--- a/connector/spanmetricsconnectorv2/testdata/with_identical_metric_name_different_attrs/config.yaml
+++ b/connector/spanmetricsconnectorv2/testdata/with_identical_metric_name_different_attrs/config.yaml
@@ -4,7 +4,11 @@ spanmetricsv2:
       description: Identical description
       attributes:
         - key: key.1
+      histogram:
+        explicit: {}
     - name: identical.name
       description: Different description
       attributes:
         - key: key.2
+      histogram:
+        explicit: {}

--- a/connector/spanmetricsconnectorv2/testdata/with_identical_metric_name_identical_attrs/config.yaml
+++ b/connector/spanmetricsconnectorv2/testdata/with_identical_metric_name_identical_attrs/config.yaml
@@ -5,8 +5,12 @@ spanmetricsv2:
       description: Identical metric name
       attributes:
         - key: key.1
+      histogram:
+        explicit: {}
     - name: identical.name
       description: Identical metric name
       attributes:
         - key: key.1
+      histogram:
+        explicit: {}
   

--- a/connector/spanmetricsconnectorv2/testdata/with_missing_attribute/config.yaml
+++ b/connector/spanmetricsconnectorv2/testdata/with_missing_attribute/config.yaml
@@ -4,3 +4,5 @@ spanmetricsv2:
       description: Span duration with missing attribute
       attributes:
         - key: 404.attribute
+      histogram:
+        explicit: {}

--- a/connector/spanmetricsconnectorv2/testdata/with_missing_attribute_default_value/config.yaml
+++ b/connector/spanmetricsconnectorv2/testdata/with_missing_attribute_default_value/config.yaml
@@ -5,3 +5,5 @@ spanmetricsv2:
       attributes:
         - key: 404.attribute
           default_value: undefined
+      histogram:
+        explicit: {}

--- a/connector/spanmetricsconnectorv2/testdata/with_summary/config.yaml
+++ b/connector/spanmetricsconnectorv2/testdata/with_summary/config.yaml
@@ -1,0 +1,17 @@
+spanmetricsv2:
+  spans:
+    - name: http.trace.span.summary
+      description: Summary for HTTP spans
+      attributes:
+        - key: http.response.status_code
+      summary: {}
+    - name: db.trace.span.summary
+      description: Summary for DB spans
+      attributes:
+        - key: db.system
+      summary: {}
+    - name: msg.trace.span.summary
+      description: Summary for messaging spans
+      attributes:
+        - key: messaging.system
+      summary: {}

--- a/connector/spanmetricsconnectorv2/testdata/with_summary/input.yaml
+++ b/connector/spanmetricsconnectorv2/testdata/with_summary/input.yaml
@@ -1,0 +1,1 @@
+../traces.yaml

--- a/connector/spanmetricsconnectorv2/testdata/with_summary/output.yaml
+++ b/connector/spanmetricsconnectorv2/testdata/with_summary/output.yaml
@@ -1,0 +1,46 @@
+resourceMetrics:
+  - resource:
+      attributes:
+        - key: resource.bar
+          value:
+            stringValue: bar
+        - key: resource.foo
+          value:
+            stringValue: foo
+    scopeMetrics:
+      - metrics:
+          - description: Summary for HTTP spans
+            name: http.trace.span.summary
+            summary:
+              dataPoints:
+                - attributes:
+                    - key: http.response.status_code
+                      value:
+                        intValue: "201"
+                  count: "2"
+                  sum: 11900.000936
+                  timeUnixNano: "1000000"
+          - description: Summary for DB spans
+            name: db.trace.span.summary
+            summary:
+              dataPoints:
+                - attributes:
+                    - key: db.system
+                      value:
+                        stringValue: mysql
+                  count: "2"
+                  sum: 1500.000936
+                  timeUnixNano: "1000000"
+          - description: Summary for messaging spans
+            name: msg.trace.span.summary
+            summary:
+              dataPoints:
+                - attributes:
+                    - key: messaging.system
+                      value:
+                        stringValue: kafka
+                  count: "2"
+                  sum: 17002.000935999997
+                  timeUnixNano: "1000000"
+        scope:
+          name: otelcol/spanmetricsconnectorv2


### PR DESCRIPTION
Refactors the code a bit to allow for a single interface for updating all metrics and adds support for summary metric. Currently summary metric doesn't support quantiles.

Related to: https://github.com/elastic/opentelemetry-dev/issues/219