### PR TITLE
Bump golang version to 1.22

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21.10"
+          go-version: "1.22.7"
           cache: false
       - name: Cache Go
         id: go-cache
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21.10"
+          go-version: "1.22.7"
           cache: false
       - name: Cache Go
         id: go-cache
@@ -105,7 +105,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21.10"
+          go-version: "1.22.7"
           cache: false
       - name: Cache Go
         id: go-cache
@@ -128,7 +128,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21.10"
+          go-version: "1.22.7"
           cache: false
       - name: Cache Go
         id: go-cache
@@ -167,7 +167,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ["1.22.3", "1.21.10"] # 1.20 is interpreted as 1.2 without quotes
+        go-version: ["1.22.7", "1.23.1"] # 1.20 is interpreted as 1.2 without quotes
         runner: [ubuntu-latest]
         group:
           - all
@@ -200,7 +200,7 @@ jobs:
           path: ~/.cache/go-build
           key: go-test-build-${{ runner.os }}-${{ matrix.go-version }}-${{ matrix.runner }}-${{ hashFiles('**/go.sum') }}
       - name: Run Unit Tests
-        if: startsWith( matrix.go-version, '1.21' ) != true
+        if: startsWith( matrix.go-version, '1.22' ) != true
         run: make gotest GROUP=${{ matrix.group }}
   unittest:
     if: ${{ github.actor != 'dependabot[bot]' && always() }}

--- a/connector/spanmetricsconnectorv2/go.mod
+++ b/connector/spanmetricsconnectorv2/go.mod
@@ -1,6 +1,6 @@
 module github.com/elastic/opentelemetry-collector-components/connector/spanmetricsconnectorv2
 
-go 1.21.0
+go 1.22.0
 
 require (
 	github.com/lightstep/go-expohisto v1.0.0

--- a/distributions/elastic-components/manifest.yaml
+++ b/distributions/elastic-components/manifest.yaml
@@ -4,7 +4,7 @@ dist:
   description: Testing distribution to ensure Elastic's components can be used with the OCB
   version: 0.0.1
   output_path: ./_build
-  otelcol_version: 0.109.0
+  otelcol_version: 0.108.1
 
 extensions:
 

--- a/distributions/elastic-components/manifest.yaml
+++ b/distributions/elastic-components/manifest.yaml
@@ -4,7 +4,7 @@ dist:
   description: Testing distribution to ensure Elastic's components can be used with the OCB
   version: 0.0.1
   output_path: ./_build
-  otelcol_version: 0.105.0
+  otelcol_version: 0.109.0
 
 extensions:
 
@@ -14,7 +14,7 @@ connectors:
 converters:
 
 receivers:
-  - gomod: go.opentelemetry.io/collector/receiver/nopreceiver v0.105.0
+  - gomod: go.opentelemetry.io/collector/receiver/nopreceiver v0.109.0
 
 processors:
   - gomod: github.com/elastic/opentelemetry-collector-components/processor/elasticinframetricsprocessor v0.0.0
@@ -22,7 +22,7 @@ processors:
   - gomod: github.com/elastic/opentelemetry-collector-components/processor/lsmintervalprocessor v0.0.0
 
 exporters:
-  - gomod: go.opentelemetry.io/collector/exporter/nopexporter v0.105.0
+  - gomod: go.opentelemetry.io/collector/exporter/nopexporter v0.109.0
 
 replaces:
   - github.com/elastic/opentelemetry-collector-components/processor/elasticinframetricsprocessor => ../processor/elasticinframetricsprocessor

--- a/processor/elasticinframetricsprocessor/go.mod
+++ b/processor/elasticinframetricsprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/elastic/opentelemetry-collector-components/processor/elasticinframetricsprocessor
 
-go 1.21.1
+go 1.22.0
 
 require (
 	github.com/elastic/opentelemetry-lib v0.9.0

--- a/processor/elastictraceprocessor/go.mod
+++ b/processor/elastictraceprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/elastic/opentelemetry-collector-components/processor/elastictraceprocessor
 
-go 1.21.1
+go 1.22.0
 
 require (
 	github.com/elastic/opentelemetry-lib v0.9.0

--- a/processor/lsmintervalprocessor/go.mod
+++ b/processor/lsmintervalprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/elastic/opentelemetry-collector-components/processor/lsmintervalprocessor
 
-go 1.21.0
+go 1.22.0
 
 require (
 	github.com/cockroachdb/pebble v1.1.2


### PR DESCRIPTION
OTel has bumped up the minimum go version to 1.22. The PR bumps up the golang version for all components to 1.22.0 and checks from 1.21.10 to 1.22.7.

This should also fix vulnerability reports like https://pkg.go.dev/vuln/GO-2024-2687 which are reported in version up PRs like https://github.com/elastic/opentelemetry-collector-components/pull/116 -- it happens because with `GOTOOLCHAIN=auto` it downloads the toolchain based on to go version in go module IF the latest local version is less than the go version.

I am doing go version update of modules here instead of dependabot because dependabot seems to like introducing the `gotoolchain` directive everywhere.