### PR TITLE
Fix generate check

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -158,7 +158,7 @@ jobs:
           git diff --exit-code || (echo 'go.mod/go.sum deps changes detected, please run "make gotidy" and commit the changes in this PR.' && exit 1)
       - name: CodeGen
         run: |
-          make -j2 generate
+          make -j2 gogenerate && make -j2 licence-update
           if [[ -n $(git status -s) ]]; then
             echo 'Generated code is out of date, please run "make generate" and commit the changes in this PR.'
             exit 1


### PR DESCRIPTION
<strike>I am a bit confused how this has been passing so far.</strike> As per my understanding, the codegen check should have been failing as the `make generate` cannot work from root but it has been passing so far: https://github.com/elastic/opentelemetry-collector-components/actions/runs/10321562649/job/28574769867?pr=85#step:10:1

The reason why this has been passing so far is because go1.21.10 version does not fail `go generate ./...` even though the root is not a go module:

```shell
lahsivjar@Vishals-MacBook-Pro: ~/Projects/elastic/opentelemetry-collector-components test-why
$ go version
go version go1.21.10 darwin/arm64

lahsivjar@Vishals-MacBook-Pro: ~/Projects/elastic/opentelemetry-collector-components test-why
$ go generate ./...

lahsivjar@Vishals-MacBook-Pro: ~/Projects/elastic/opentelemetry-collector-components test-why
$ echo $?
0

lahsivjar@Vishals-MacBook-Pro: ~/Projects/elastic/opentelemetry-collector-components test-why
$ go version
go version go1.22.7 darwin/arm64

lahsivjar@Vishals-MacBook-Pro: ~/Projects/elastic/opentelemetry-collector-components test-why
$ go generate ./...
pattern ./...: directory prefix . does not contain main module or its selected dependencies
FAIL

lahsivjar@Vishals-MacBook-Pro: ~/Projects/elastic/opentelemetry-collector-components test-why
$ echo $?
1
```