### PR TITLE
[connector/spanmetricsv2] Aggregate spans as 2 counters

### DIFF
--- a/connector/spanmetricsconnectorv2/config/config.go
+++ b/connector/spanmetricsconnectorv2/config/config.go
@@ -37,6 +37,9 @@ const (
 	// error of less than 5%.
 	// Ref: https://opentelemetry.io/docs/specs/otel/metrics/sdk/#base2-exponential-bucket-histogram-aggregation
 	defaultExponentialHistogramMaxSize = 160
+
+	defaultCountersSumSuffix   = ".sum"
+	defaultCountersCountSuffix = ".count"
 )
 
 var defaultHistogramBuckets = []float64{
@@ -57,6 +60,82 @@ type Config struct {
 	Spans []MetricInfo `mapstructure:"spans"`
 }
 
+var _ confmap.Unmarshaler = (*Config)(nil)
+
+func (c *Config) Validate() error {
+	duplicate := make(map[string]MetricInfo)
+	for _, info := range c.Spans {
+		if old, ok := duplicate[info.Name]; ok && info.isEqual(old) {
+			return fmt.Errorf("spans: duplicate configuration found %s", info.Name)
+		}
+		if info.Name == "" {
+			return errors.New("spans: metric name missing")
+		}
+		if info.Unit == "" {
+			return errors.New("spans: metric unit missing")
+		}
+		if err := info.validateAttributes(); err != nil {
+			return fmt.Errorf("spans attributes validation failed: metric %q: %w", info.Name, err)
+		}
+		if info.noAggregatorDefined() {
+			return errors.New("metric definition missing, either histogram, summary, or counters required")
+		}
+		if err := info.validateHistogram(); err != nil {
+			return fmt.Errorf("spans histogram validation failed: metric %q, %w", info.Name, err)
+		}
+		duplicate[info.Name] = info
+	}
+	return nil
+}
+
+// Unmarshal with custom logic to set default values.
+// This is necessary to ensure that default metrics are
+// not configured if the user has specified any custom metrics.
+func (c *Config) Unmarshal(componentParser *confmap.Conf) error {
+	if componentParser == nil {
+		// Nothing to do if there is no config given.
+		return nil
+	}
+	if err := componentParser.Unmarshal(c, confmap.WithIgnoreUnused()); err != nil {
+		return err
+	}
+	if !componentParser.IsSet("spans") {
+		c.Spans = defaultSpansConfig()
+		return nil
+	}
+	for k, info := range c.Spans {
+		if info.Unit == "" {
+			info.Unit = MetricUnitMs
+		}
+		if info.noAggregatorDefined() {
+			info.Histogram.Exponential = &ExponentialHistogram{
+				MaxSize: defaultExponentialHistogramMaxSize,
+			}
+		}
+		if info.Histogram.Explicit != nil {
+			// Add default buckets if explicit histogram is defined
+			if len(info.Histogram.Explicit.Buckets) == 0 {
+				info.Histogram.Explicit.Buckets = defaultHistogramBuckets[:]
+			}
+		}
+		if info.Histogram.Exponential != nil {
+			if info.Histogram.Exponential.MaxSize == 0 {
+				info.Histogram.Exponential.MaxSize = defaultExponentialHistogramMaxSize
+			}
+		}
+		if info.Counters != nil {
+			if info.Counters.SumSuffix == "" {
+				info.Counters.SumSuffix = defaultCountersSumSuffix
+			}
+			if info.Counters.CountSuffix == "" {
+				info.Counters.CountSuffix = defaultCountersCountSuffix
+			}
+		}
+		c.Spans[k] = info
+	}
+	return nil
+}
+
 // MetricInfo for a data type
 type MetricInfo struct {
 	Name        string      `mapstructure:"name"`
@@ -65,6 +144,16 @@ type MetricInfo struct {
 	Unit        MetricUnit  `mapstructure:"unit"`
 	Histogram   Histogram   `mapstructure:"histogram"`
 	Summary     *Summary    `mapstructure:"summary"`
+	Counters    *Counters   `mapstructure:"counters"`
+}
+
+// noAggregatorDefined returns true if none of the required
+// aggregators are defined for a MetricInfo.
+func (mi *MetricInfo) noAggregatorDefined() bool {
+	return mi.Histogram.Exponential == nil &&
+		mi.Histogram.Explicit == nil &&
+		mi.Summary == nil &&
+		mi.Counters == nil
 }
 
 // isEqual checks if two metric have a same identity. Identity of a
@@ -113,30 +202,12 @@ type ExponentialHistogram struct {
 
 type Summary struct{}
 
-func (c *Config) Validate() error {
-	duplicate := make(map[string]MetricInfo)
-	for _, info := range c.Spans {
-		if old, ok := duplicate[info.Name]; ok && info.isEqual(old) {
-			return fmt.Errorf("spans: duplicate configuration found %s", info.Name)
-		}
-		if info.Name == "" {
-			return errors.New("spans: metric name missing")
-		}
-		if info.Unit == "" {
-			return errors.New("spans: metric unit missing")
-		}
-		if info.Histogram.Exponential == nil && info.Histogram.Explicit == nil && info.Summary == nil {
-			return errors.New("metric definition missing, either histogram or summary required")
-		}
-		if err := info.validateHistogram(); err != nil {
-			return fmt.Errorf("spans histogram validation failed: metric %q, %w", info.Name, err)
-		}
-		if err := info.validateAttributes(); err != nil {
-			return fmt.Errorf("spans attributes validation failed: metric %q: %w", info.Name, err)
-		}
-		duplicate[info.Name] = info
-	}
-	return nil
+// Counters aggregate spans as 2 cummulative sum metric with delta temporality.
+// The configs allow adding suffixes to the metric names, the suffix defaults to
+// `.sum` for sum metric and `.count` for count metric.
+type Counters struct {
+	SumSuffix   string `mapstructure:"sum_suffix"`
+	CountSuffix string `mapstructure:"count_suffix"`
 }
 
 func (i *MetricInfo) validateHistogram() error {
@@ -169,48 +240,6 @@ func (i *MetricInfo) validateAttributes() error {
 			return fmt.Errorf("invalid default value specified for attribute %s", attr.Key)
 		}
 		duplicate[attr.Key] = struct{}{}
-	}
-	return nil
-}
-
-var _ confmap.Unmarshaler = (*Config)(nil)
-
-// Unmarshal with custom logic to set default values.
-// This is necessary to ensure that default metrics are
-// not configured if the user has specified any custom metrics.
-func (c *Config) Unmarshal(componentParser *confmap.Conf) error {
-	if componentParser == nil {
-		// Nothing to do if there is no config given.
-		return nil
-	}
-	if err := componentParser.Unmarshal(c, confmap.WithIgnoreUnused()); err != nil {
-		return err
-	}
-	if !componentParser.IsSet("spans") {
-		c.Spans = defaultSpansConfig()
-		return nil
-	}
-	for k, info := range c.Spans {
-		if info.Unit == "" {
-			info.Unit = MetricUnitMs
-		}
-		if info.Histogram.Exponential == nil && info.Histogram.Explicit == nil && info.Summary == nil {
-			info.Histogram.Exponential = &ExponentialHistogram{
-				MaxSize: defaultExponentialHistogramMaxSize,
-			}
-		}
-		if info.Histogram.Explicit != nil {
-			// Add default buckets if explicit histogram is defined
-			if len(info.Histogram.Explicit.Buckets) == 0 {
-				info.Histogram.Explicit.Buckets = defaultHistogramBuckets[:]
-			}
-		}
-		if info.Histogram.Exponential != nil {
-			if info.Histogram.Exponential.MaxSize == 0 {
-				info.Histogram.Exponential.MaxSize = defaultExponentialHistogramMaxSize
-			}
-		}
-		c.Spans[k] = info
 	}
 	return nil
 }

--- a/connector/spanmetricsconnectorv2/config/config_test.go
+++ b/connector/spanmetricsconnectorv2/config/config_test.go
@@ -211,6 +211,43 @@ func TestConfig(t *testing.T) {
 				},
 			},
 		},
+		{
+			path: "with_counters",
+			expected: &Config{
+				Spans: []MetricInfo{
+					{
+						Name:        "http.trace.span.counter",
+						Description: "Counters for HTTP spans with default metric suffixes",
+						Unit:        MetricUnitMs,
+						Attributes:  []Attribute{{Key: "http.response.status_code"}},
+						Counters: &Counters{
+							SumSuffix:   ".sum",
+							CountSuffix: ".count",
+						},
+					},
+					{
+						Name:        "db.trace.span.counter",
+						Description: "Counters for DB spans with default metric suffixes",
+						Unit:        MetricUnitMs,
+						Attributes:  []Attribute{{Key: "db.system"}},
+						Counters: &Counters{
+							SumSuffix:   ".sum",
+							CountSuffix: ".count",
+						},
+					},
+					{
+						Name:        "msg.trace.span.counter",
+						Description: "Counters for messaging spans with custom metric suffixes",
+						Unit:        MetricUnitUs,
+						Attributes:  []Attribute{{Key: "messaging.system"}},
+						Counters: &Counters{
+							SumSuffix:   ".sum.us",
+							CountSuffix: ".count",
+						},
+					},
+				},
+			},
+		},
 	} {
 		t.Run(tc.path, func(t *testing.T) {
 			dir := filepath.Join("../testdata", tc.path)

--- a/connector/spanmetricsconnectorv2/connector_test.go
+++ b/connector/spanmetricsconnectorv2/connector_test.go
@@ -134,7 +134,8 @@ func BenchmarkConnector(b *testing.B) {
 					Explicit:    &config.ExplicitHistogram{},
 					Exponential: &config.ExponentialHistogram{},
 				},
-				Summary: &config.Summary{},
+				Summary:  &config.Summary{},
+				Counters: &config.Counters{},
 			},
 			{
 				Name:        "db.trace.span.duration",
@@ -148,7 +149,8 @@ func BenchmarkConnector(b *testing.B) {
 					Explicit:    &config.ExplicitHistogram{},
 					Exponential: &config.ExponentialHistogram{},
 				},
-				Summary: &config.Summary{},
+				Summary:  &config.Summary{},
+				Counters: &config.Counters{},
 			},
 			{
 				Name:        "msg.trace.span.duration",
@@ -162,7 +164,8 @@ func BenchmarkConnector(b *testing.B) {
 					Explicit:    &config.ExplicitHistogram{},
 					Exponential: &config.ExponentialHistogram{},
 				},
-				Summary: &config.Summary{},
+				Summary:  &config.Summary{},
+				Counters: &config.Counters{},
 			},
 			{
 				Name:        "404.span.duration",
@@ -176,7 +179,8 @@ func BenchmarkConnector(b *testing.B) {
 					Explicit:    &config.ExplicitHistogram{},
 					Exponential: &config.ExponentialHistogram{},
 				},
-				Summary: &config.Summary{},
+				Summary:  &config.Summary{},
+				Counters: &config.Counters{},
 			},
 			{
 				Name:        "404.span.duration.default",
@@ -191,7 +195,8 @@ func BenchmarkConnector(b *testing.B) {
 					Explicit:    &config.ExplicitHistogram{},
 					Exponential: &config.ExponentialHistogram{},
 				},
-				Summary: &config.Summary{},
+				Summary:  &config.Summary{},
+				Counters: &config.Counters{},
 			},
 		},
 	}

--- a/connector/spanmetricsconnectorv2/connector_test.go
+++ b/connector/spanmetricsconnectorv2/connector_test.go
@@ -49,6 +49,7 @@ func TestConnector(t *testing.T) {
 		"with_identical_metric_name_different_attrs",
 		"with_identical_metric_name_desc_different_attrs",
 		"with_summary",
+		"with_counters",
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/connector/spanmetricsconnectorv2/factory.go
+++ b/connector/spanmetricsconnectorv2/factory.go
@@ -71,6 +71,7 @@ func createTracesToMetrics(
 			ExplicitHistogram:    info.Histogram.Explicit,
 			ExponentialHistogram: info.Histogram.Exponential,
 			Summary:              info.Summary,
+			Counters:             info.Counters,
 		}
 		metricDefs = append(metricDefs, md)
 	}

--- a/connector/spanmetricsconnectorv2/internal/aggregator/counters.go
+++ b/connector/spanmetricsconnectorv2/internal/aggregator/counters.go
@@ -1,0 +1,61 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package aggregator // import "github.com/elastic/opentelemetry-collector-components/connector/spanmetricsconnectorv2/internal/aggregator"
+
+import (
+	"time"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+)
+
+// countersDP records sum and count of span duration as two counter metrics.
+// Both counters are assumed to be delta temporality cumulative counters
+// accepting double values.
+type countersDP struct {
+	attrs pcommon.Map
+
+	sum   float64
+	count uint64
+}
+
+func newCountersDP(attrs pcommon.Map) *countersDP {
+	return &countersDP{
+		attrs: attrs,
+	}
+}
+
+func (dp *countersDP) Add(value float64, count uint64) {
+	dp.sum += value * float64(count)
+	dp.count += count
+}
+
+func (dp *countersDP) Copy(
+	timestamp time.Time,
+	destSum pmetric.NumberDataPoint,
+	destCount pmetric.NumberDataPoint,
+) {
+	dp.attrs.CopyTo(destSum.Attributes())
+	dp.attrs.CopyTo(destCount.Attributes())
+	destSum.SetDoubleValue(dp.sum)
+	destCount.SetDoubleValue(float64(dp.count))
+	// TODO determine appropriate start time
+	ts := pcommon.NewTimestampFromTime(timestamp)
+	destSum.SetTimestamp(ts)
+	destCount.SetTimestamp(ts)
+}

--- a/connector/spanmetricsconnectorv2/internal/model/model.go
+++ b/connector/spanmetricsconnectorv2/internal/model/model.go
@@ -34,6 +34,7 @@ type MetricDef struct {
 	ExponentialHistogram *config.ExponentialHistogram
 	ExplicitHistogram    *config.ExplicitHistogram
 	Summary              *config.Summary
+	Counters             *config.Counters
 }
 
 type MetricKey struct {

--- a/connector/spanmetricsconnectorv2/testdata/with_counters/config.yaml
+++ b/connector/spanmetricsconnectorv2/testdata/with_counters/config.yaml
@@ -1,0 +1,20 @@
+spanmetricsv2:
+  spans:
+    - name: http.trace.span.counter
+      description: Counters for HTTP spans with default metric suffixes
+      attributes:
+        - key: http.response.status_code
+      counters: {}
+    - name: db.trace.span.counter
+      description: Counters for DB spans with default metric suffixes
+      attributes:
+        - key: db.system
+      counters: {}
+    - name: msg.trace.span.counter
+      description: Counters for messaging spans with custom metric suffixes
+      attributes:
+        - key: messaging.system
+      counters:
+        sum_suffix: .sum.us
+        count_suffix: .count
+      unit: us

--- a/connector/spanmetricsconnectorv2/testdata/with_counters/input.yaml
+++ b/connector/spanmetricsconnectorv2/testdata/with_counters/input.yaml
@@ -1,0 +1,1 @@
+../traces.yaml

--- a/connector/spanmetricsconnectorv2/testdata/with_counters/output.yaml
+++ b/connector/spanmetricsconnectorv2/testdata/with_counters/output.yaml
@@ -1,0 +1,79 @@
+resourceMetrics:
+  - resource:
+      attributes:
+        - key: resource.bar
+          value:
+            stringValue: bar
+        - key: resource.foo
+          value:
+            stringValue: foo
+    scopeMetrics:
+      - metrics:
+          - description: Counters for HTTP spans with default metric suffixes
+            name: http.trace.span.counter.sum
+            sum:
+              aggregationTemporality: 1
+              dataPoints:
+                - asDouble: 11900.000936
+                  attributes:
+                    - key: http.response.status_code
+                      value:
+                        intValue: "201"
+                  timeUnixNano: "1000000"
+          - description: Counters for HTTP spans with default metric suffixes
+            name: http.trace.span.counter.count
+            sum:
+              aggregationTemporality: 1
+              dataPoints:
+                - asDouble: 2
+                  attributes:
+                    - key: http.response.status_code
+                      value:
+                        intValue: "201"
+                  timeUnixNano: "1000000"
+          - description: Counters for DB spans with default metric suffixes
+            name: db.trace.span.counter.sum
+            sum:
+              aggregationTemporality: 1
+              dataPoints:
+                - asDouble: 2500.001782
+                  attributes:
+                    - key: db.system
+                      value:
+                        stringValue: mysql
+                  timeUnixNano: "1000000"
+          - description: Counters for DB spans with default metric suffixes
+            name: db.trace.span.counter.count
+            sum:
+              aggregationTemporality: 1
+              dataPoints:
+                - asDouble: 4
+                  attributes:
+                    - key: db.system
+                      value:
+                        stringValue: mysql
+                  timeUnixNano: "1000000"
+          - description: Counters for messaging spans with custom metric suffixes
+            name: msg.trace.span.counter.sum.us
+            sum:
+              aggregationTemporality: 1
+              dataPoints:
+                - asDouble: 1.7002000935999997e+07
+                  attributes:
+                    - key: messaging.system
+                      value:
+                        stringValue: kafka
+                  timeUnixNano: "1000000"
+          - description: Counters for messaging spans with custom metric suffixes
+            name: msg.trace.span.counter.count
+            sum:
+              aggregationTemporality: 1
+              dataPoints:
+                - asDouble: 2
+                  attributes:
+                    - key: messaging.system
+                      value:
+                        stringValue: kafka
+                  timeUnixNano: "1000000"
+        scope:
+          name: otelcol/spanmetricsconnectorv2


### PR DESCRIPTION
Allows aggregating the span as 2 separate counters with customizable suffixes. The counters represent sum of span duration and count of spans respectively.

Related to: https://github.com/elastic/opentelemetry-dev/issues/372