### PR TITLE
[dependabot] Merge otel-contrib and otel groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,8 +12,6 @@ updates:
       otel-dependencies:
         patterns:
           - "go.opentelemetry.io/*"
-      otel-contrib-dependencies:
-        patterns:
           - "github.com/open-telemetry/opentelemetry-collector-contrib/*"
     ignore:
       - dependency-name: "*"
@@ -29,8 +27,6 @@ updates:
       otel-dependencies:
         patterns:
           - "go.opentelemetry.io/*"
-      otel-contrib-dependencies:
-        patterns:
           - "github.com/open-telemetry/opentelemetry-collector-contrib/*"
     ignore:
       - dependency-name: "*"
@@ -46,8 +42,6 @@ updates:
       otel-dependencies:
         patterns:
           - "go.opentelemetry.io/*"
-      otel-contrib-dependencies:
-        patterns:
           - "github.com/open-telemetry/opentelemetry-collector-contrib/*"
     ignore:
       - dependency-name: "*"
@@ -63,8 +57,6 @@ updates:
       otel-dependencies:
         patterns:
           - "go.opentelemetry.io/*"
-      otel-contrib-dependencies:
-        patterns:
           - "github.com/open-telemetry/opentelemetry-collector-contrib/*"
     ignore:
       - dependency-name: "*"


### PR DESCRIPTION
It is ususally ending up that both the groups (otel and otel-contrib) have merge PR open together and in most cases the changelogs are also inter-dependent, so merging both the groups as what was also previously suggested by @kruskall .