### PR TITLE
[processor/lsminterval]Use vendored data package for all merges

### DIFF
--- a/processor/lsmintervalprocessor/testdata/histogram_cumulative/input.yaml
+++ b/processor/lsmintervalprocessor/testdata/histogram_cumulative/input.yaml
@@ -20,6 +20,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - timeUnixNano: 5000000
+                  count: 60
+                  sum: 2670
                   explicitBounds: [0.01, 0.1, 1, 10, 100]
                   bucketCounts: [9, 4, 7, 9, 6, 25]
                   attributes:
@@ -29,6 +31,8 @@ resourceMetrics:
                 # This data point is out of order
                 # The aggregator should ignore it since the first data point has a newer timestamp
                 - timeUnixNano: 2000000
+                  count: 41
+                  sum: 2110
                   explicitBounds: [0.01, 0.1, 1, 10, 100]
                   bucketCounts: [5, 2, 3, 7, 4, 20]
                   attributes:
@@ -37,6 +41,8 @@ resourceMetrics:
                         stringValue: bbb
                 # This one is the newest, so it should be the one stored
                 - timeUnixNano: 8000000
+                  count: 91
+                  sum: 3600
                   explicitBounds: [0.01, 0.1, 1, 10, 100]
                   bucketCounts: [11, 9, 12, 17, 8, 34]
                   attributes:

--- a/processor/lsmintervalprocessor/testdata/histogram_cumulative/output.yaml
+++ b/processor/lsmintervalprocessor/testdata/histogram_cumulative/output.yaml
@@ -37,6 +37,8 @@ resourceMetrics:
                     - 10
                     - 100
                   timeUnixNano: "8000000"
+                  sum: 3600
+                  count: 91
             name: cumulative.histogram.test
         schemaUrl: https://test-scope-schema.com/schema
         scope:

--- a/processor/lsmintervalprocessor/testdata/histogram_delta/input.yaml
+++ b/processor/lsmintervalprocessor/testdata/histogram_delta/input.yaml
@@ -20,6 +20,8 @@ resourceMetrics:
               aggregationTemporality: 1
               dataPoints:
                 - timeUnixNano: 5000000
+                  count: 60
+                  sum: 2670
                   explicitBounds: [0.01, 0.1, 1, 10, 100]
                   bucketCounts: [9, 4, 7, 9, 6, 25]
                   attributes:
@@ -27,6 +29,8 @@ resourceMetrics:
                       value:
                         stringValue: bbb
                 - timeUnixNano: 2000000
+                  count: 41
+                  sum: 2110
                   explicitBounds: [0.01, 0.1, 1, 10, 100]
                   bucketCounts: [5, 2, 3, 7, 4, 20]
                   attributes:
@@ -34,6 +38,8 @@ resourceMetrics:
                       value:
                         stringValue: bbb
                 - timeUnixNano: 8000000
+                  count: 91
+                  sum: 3600
                   explicitBounds: [0.01, 0.1, 1, 10, 100]
                   bucketCounts: [11, 9, 12, 17, 8, 34]
                   attributes:

--- a/processor/lsmintervalprocessor/testdata/histogram_delta/output.yaml
+++ b/processor/lsmintervalprocessor/testdata/histogram_delta/output.yaml
@@ -37,6 +37,8 @@ resourceMetrics:
                     - 10
                     - 100
                   timeUnixNano: "8000000"
+                  count: 192
+                  sum: 8380
             name: delta.histogram.test
         schemaUrl: https://test-scope-schema.com/schema
         scope:


### PR DESCRIPTION
In https://github.com/elastic/opentelemetry-collector-components/pull/151 we vendored data package from upstream. In this PR, I have updated all our merges to use the vendored code since we already have it.