### PR TITLE
Exclude _build from ALL_MODULES

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ include ./Makefile.Common
 ALL_DOC := $(shell find . \( -name "*.md" -o -name "*.yaml" \) \
                                 -type f | sort)
 
-# ALL_MODULES includes ./* dirs (excludes . dir)
-ALL_MODULES := $(shell find . -type f -name "go.mod" -exec dirname {} \; | sort | grep -E '^./' )
+# ALL_MODULES includes ./* dirs with a go.mod file (excludes . and ./_build dirs)
+ALL_MODULES := $(shell find . -type f -name "go.mod" -not -wholename "./go.mod" -not -wholename "./_build/*" -exec dirname {} \; | sort )
 
 GROUP ?= all
 FOR_GROUP_TARGET=for-$(GROUP)-target


### PR DESCRIPTION
Rewrite filtering of files when discovering modules to use `find` options and exclude `_build` directory.

Including `_build` makes some targets to fail if the directory exists:
```
$ make gotest
make[1]: Entering directory '/home/jaime/gocode/src/github.com/elastic/opentelemetry-collector-components'
Running target 'test' in module '_build'
make -C _build test
make[2]: Entering directory '/home/jaime/gocode/src/github.com/elastic/opentelemetry-collector-components/_build'
make[2]: *** No rule to make target 'test'.  Stop.
make[2]: Leaving directory '/home/jaime/gocode/src/github.com/elastic/opentelemetry-collector-components/_build'
make[1]: *** [Makefile:25: _build] Error 2
make[1]: Leaving directory '/home/jaime/gocode/src/github.com/elastic/opentelemetry-collector-components'
make: *** [Makefile:37: gotest] Error 2
```