### PR TITLE
[connector/signaltometrics]Add otelcol instance info as res attribute

### DIFF
--- a/connector/signaltometricsconnector/config/config.go
+++ b/connector/signaltometricsconnector/config/config.go
@@ -140,6 +140,12 @@ type MetricInfo struct {
 	// Unit, if not-empty, will set the unit associated with the metric.
 	// See: https://github.com/open-telemetry/opentelemetry-collector/blob/b06236cc794982916cc956f20828b3e18eb33264/pdata/pmetric/generated_metric.go#L72-L81
 	Unit string `mapstructure:"unit"`
+	// CollectorInfoAsResourceAttributes (experimental) appends the
+	// collector instance information, retrieved from the telemetry
+	// settings, as resource attributes to the produced metric if set
+	// to true. This is important to ensure single-writer if resource
+	// attributes are whitelisted using `include_resource_attributes`.
+	CollectorInfoAsResourceAttributes bool `mapstructure:"collector_info_as_resource_attributes"`
 	// IncludeResourceAttributes is a list of resource attributes that
 	// needs to be included in the generated metric. If no resource
 	// attribute is included in the list then all attributes are included.

--- a/connector/signaltometricsconnector/config/config.go
+++ b/connector/signaltometricsconnector/config/config.go
@@ -144,7 +144,7 @@ type MetricInfo struct {
 	// collector instance information, retrieved from the telemetry
 	// settings, as resource attributes to the produced metric if set
 	// to true. This is important to ensure single-writer if resource
-	// attributes are whitelisted using `include_resource_attributes`.
+	// attributes are included using `include_resource_attributes`.
 	CollectorInfoAsResourceAttributes bool `mapstructure:"collector_info_as_resource_attributes"`
 	// IncludeResourceAttributes is a list of resource attributes that
 	// needs to be included in the generated metric. If no resource

--- a/connector/signaltometricsconnector/config/config.go
+++ b/connector/signaltometricsconnector/config/config.go
@@ -140,17 +140,14 @@ type MetricInfo struct {
 	// Unit, if not-empty, will set the unit associated with the metric.
 	// See: https://github.com/open-telemetry/opentelemetry-collector/blob/b06236cc794982916cc956f20828b3e18eb33264/pdata/pmetric/generated_metric.go#L72-L81
 	Unit string `mapstructure:"unit"`
-	// CollectorInfoAsResourceAttributes (experimental) appends the
-	// collector instance information, retrieved from the telemetry
-	// settings, as resource attributes to the produced metric if set
-	// to true. This is important to ensure single-writer if resource
-	// attributes are included using `include_resource_attributes`.
-	CollectorInfoAsResourceAttributes bool `mapstructure:"collector_info_as_resource_attributes"`
 	// IncludeResourceAttributes is a list of resource attributes that
 	// needs to be included in the generated metric. If no resource
 	// attribute is included in the list then all attributes are included.
-	// Note that configuring this setting might cause the produced metric
-	// to lose its identity or cause identity conflict.
+	// Metric data streams MUST obey single-writer. The component produces
+	// metrics from non-metric signals as well as alters resource attributes
+	// from the source signals. To keep the single-writer valid, the
+	// component adds collector information as resource attribute with the
+	// component name as the prefix of the resource attributes.
 	IncludeResourceAttributes []Attribute `mapstructure:"include_resource_attributes"`
 	Attributes                []Attribute `mapstructure:"attributes"`
 	// Conditions are a set of OTTL condtions which are ORd. Data is

--- a/connector/signaltometricsconnector/connector_test.go
+++ b/connector/signaltometricsconnector/connector_test.go
@@ -35,7 +35,9 @@ import (
 	"go.opentelemetry.io/collector/connector/connectortest"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
+	semconv "go.opentelemetry.io/collector/semconv/v1.26.0"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest"
 )
@@ -317,6 +319,7 @@ func setupConnector(
 	t.Helper()
 	factory := NewFactory()
 	settings := connectortest.NewNopSettings()
+	telemetryResource(t).CopyTo(settings.TelemetrySettings.Resource)
 	settings.TelemetrySettings.Logger = zaptest.NewLogger(t, zaptest.Level(zapcore.DebugLevel))
 
 	cfg := createDefaultConfig()
@@ -328,6 +331,16 @@ func setupConnector(
 	require.NoError(t, component.ValidateConfig(cfg))
 
 	return factory, settings, cfg
+}
+
+func telemetryResource(t *testing.T) pcommon.Resource {
+	t.Helper()
+
+	r := pcommon.NewResource()
+	r.Attributes().PutStr(semconv.AttributeServiceInstanceID, "627cc493-f310-47de-96bd-71410b7dec09")
+	r.Attributes().PutStr(semconv.AttributeServiceName, "signaltometrics")
+	r.Attributes().PutStr(semconv.AttributeServiceNamespace, "test")
+	return r
 }
 
 func assertAggregatedMetrics(t *testing.T, expected, actual pmetric.Metrics) bool {

--- a/connector/signaltometricsconnector/connector_test.go
+++ b/connector/signaltometricsconnector/connector_test.go
@@ -135,7 +135,9 @@ func TestConnectorWithLogs(t *testing.T) {
 
 			require.NoError(t, connector.ConsumeLogs(ctx, inputLogs))
 			require.Len(t, next.AllMetrics(), 1)
-			assertAggregatedMetrics(t, expectedMetrics, next.AllMetrics()[0])
+			if !assertAggregatedMetrics(t, expectedMetrics, next.AllMetrics()[0]) {
+				golden.WriteMetrics(t, filepath.Join(tcTestDataDir, "output.yaml"), next.AllMetrics()[0])
+			}
 		})
 	}
 }

--- a/connector/signaltometricsconnector/connector_test.go
+++ b/connector/signaltometricsconnector/connector_test.go
@@ -135,9 +135,7 @@ func TestConnectorWithLogs(t *testing.T) {
 
 			require.NoError(t, connector.ConsumeLogs(ctx, inputLogs))
 			require.Len(t, next.AllMetrics(), 1)
-			if !assertAggregatedMetrics(t, expectedMetrics, next.AllMetrics()[0]) {
-				golden.WriteMetrics(t, filepath.Join(tcTestDataDir, "output.yaml"), next.AllMetrics()[0])
-			}
+			assertAggregatedMetrics(t, expectedMetrics, next.AllMetrics()[0])
 		})
 	}
 }

--- a/connector/signaltometricsconnector/factory.go
+++ b/connector/signaltometricsconnector/factory.go
@@ -34,6 +34,8 @@ import (
 	"github.com/elastic/opentelemetry-collector-components/connector/signaltometricsconnector/internal/ottlget"
 )
 
+const collectorInstanceResourceAttributePrefix = "observer"
+
 // NewFactory returns a ConnectorFactory.
 func NewFactory() connector.Factory {
 	return connector.NewFactory(
@@ -76,7 +78,11 @@ func createTracesToMetrics(
 	}
 
 	return &signalToMetrics{
-		logger:         set.Logger,
+		logger: set.Logger,
+		collectorInstanceInfo: model.NewCollectorInstanceInfo(
+			collectorInstanceResourceAttributePrefix,
+			set.TelemetrySettings,
+		),
 		next:           nextConsumer,
 		spanMetricDefs: metricDefs,
 	}, nil
@@ -107,7 +113,11 @@ func createMetricsToMetrics(
 	}
 
 	return &signalToMetrics{
-		logger:       set.Logger,
+		logger: set.Logger,
+		collectorInstanceInfo: model.NewCollectorInstanceInfo(
+			collectorInstanceResourceAttributePrefix,
+			set.TelemetrySettings,
+		),
 		next:         nextConsumer,
 		dpMetricDefs: metricDefs,
 	}, nil
@@ -138,7 +148,11 @@ func createLogsToMetrics(
 	}
 
 	return &signalToMetrics{
-		logger:        set.Logger,
+		logger: set.Logger,
+		collectorInstanceInfo: model.NewCollectorInstanceInfo(
+			collectorInstanceResourceAttributePrefix,
+			set.TelemetrySettings,
+		),
 		next:          nextConsumer,
 		logMetricDefs: metricDefs,
 	}, nil

--- a/connector/signaltometricsconnector/factory.go
+++ b/connector/signaltometricsconnector/factory.go
@@ -34,7 +34,7 @@ import (
 	"github.com/elastic/opentelemetry-collector-components/connector/signaltometricsconnector/internal/model"
 )
 
-const collectorInstanceResourceAttributePrefix = "observer"
+var collectorInstanceResourceAttributePrefix = metadata.Type.String()
 
 // NewFactory returns a ConnectorFactory.
 func NewFactory() connector.Factory {

--- a/connector/signaltometricsconnector/factory.go
+++ b/connector/signaltometricsconnector/factory.go
@@ -34,8 +34,6 @@ import (
 	"github.com/elastic/opentelemetry-collector-components/connector/signaltometricsconnector/internal/model"
 )
 
-var collectorInstanceResourceAttributePrefix = metadata.Type.String()
-
 // NewFactory returns a ConnectorFactory.
 func NewFactory() connector.Factory {
 	return connector.NewFactory(
@@ -77,7 +75,6 @@ func createTracesToMetrics(
 	return &signalToMetrics{
 		logger: set.Logger,
 		collectorInstanceInfo: model.NewCollectorInstanceInfo(
-			collectorInstanceResourceAttributePrefix,
 			set.TelemetrySettings,
 		),
 		next:           nextConsumer,
@@ -109,7 +106,6 @@ func createMetricsToMetrics(
 	return &signalToMetrics{
 		logger: set.Logger,
 		collectorInstanceInfo: model.NewCollectorInstanceInfo(
-			collectorInstanceResourceAttributePrefix,
 			set.TelemetrySettings,
 		),
 		next:         nextConsumer,
@@ -141,7 +137,6 @@ func createLogsToMetrics(
 	return &signalToMetrics{
 		logger: set.Logger,
 		collectorInstanceInfo: model.NewCollectorInstanceInfo(
-			collectorInstanceResourceAttributePrefix,
 			set.TelemetrySettings,
 		),
 		next:          nextConsumer,

--- a/connector/signaltometricsconnector/go.mod
+++ b/connector/signaltometricsconnector/go.mod
@@ -17,6 +17,7 @@ require (
 	go.opentelemetry.io/collector/consumer/consumertest v0.111.0
 	go.opentelemetry.io/collector/pdata v1.17.0
 	go.opentelemetry.io/collector/pipeline v0.111.0
+	go.opentelemetry.io/collector/semconv v0.111.0
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
 )
@@ -58,7 +59,6 @@ require (
 	go.opentelemetry.io/collector/consumer/consumerprofiles v0.111.0 // indirect
 	go.opentelemetry.io/collector/internal/globalsignal v0.111.0 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.111.0 // indirect
-	go.opentelemetry.io/collector/semconv v0.111.0 // indirect
 	go.opentelemetry.io/otel v1.30.0 // indirect
 	go.opentelemetry.io/otel/metric v1.30.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.30.0 // indirect

--- a/connector/signaltometricsconnector/internal/model/collectorinstanceinfo.go
+++ b/connector/signaltometricsconnector/internal/model/collectorinstanceinfo.go
@@ -18,18 +18,19 @@
 package model // import "github.com/elastic/opentelemetry-collector-components/connector/signaltometricsconnector/internal/model"
 
 import (
+	"github.com/elastic/opentelemetry-collector-components/connector/signaltometricsconnector/internal/metadata"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	semconv "go.opentelemetry.io/collector/semconv/v1.26.0"
 )
+
+var prefix = metadata.Type.String()
 
 // CollectorInstanceInfo holds the attributes that could uniquely identify
 // the current collector instance. These attributes are initialized from the
 // telemetry settings. The CollectorInstanceInfo can copy these attributes,
 // with a given prefix, to a provided map.
 type CollectorInstanceInfo struct {
-	prefix string
-
 	size              int
 	serviceInstanceID string
 	serviceName       string
@@ -37,10 +38,9 @@ type CollectorInstanceInfo struct {
 }
 
 func NewCollectorInstanceInfo(
-	prefix string,
 	set component.TelemetrySettings,
 ) *CollectorInstanceInfo {
-	info := CollectorInstanceInfo{prefix: prefix}
+	var info CollectorInstanceInfo
 	set.Resource.Attributes().Range(func(k string, v pcommon.Value) bool {
 		switch k {
 		case semconv.AttributeServiceInstanceID:
@@ -73,19 +73,16 @@ func (info CollectorInstanceInfo) Size() int {
 func (info CollectorInstanceInfo) Copy(to pcommon.Map) {
 	to.EnsureCapacity(info.Size())
 	if info.serviceInstanceID != "" {
-		to.PutStr(keyWithPrefix(info.prefix, semconv.AttributeServiceInstanceID), info.serviceInstanceID)
+		to.PutStr(keyWithPrefix(semconv.AttributeServiceInstanceID), info.serviceInstanceID)
 	}
 	if info.serviceName != "" {
-		to.PutStr(keyWithPrefix(info.prefix, semconv.AttributeServiceName), info.serviceName)
+		to.PutStr(keyWithPrefix(semconv.AttributeServiceName), info.serviceName)
 	}
 	if info.serviceNamespace != "" {
-		to.PutStr(keyWithPrefix(info.prefix, semconv.AttributeServiceNamespace), info.serviceNamespace)
+		to.PutStr(keyWithPrefix(semconv.AttributeServiceNamespace), info.serviceNamespace)
 	}
 }
 
-func keyWithPrefix(prefix, key string) string {
-	if prefix == "" {
-		return key
-	}
+func keyWithPrefix(key string) string {
 	return prefix + "." + key
 }

--- a/connector/signaltometricsconnector/internal/model/collectorinstanceinfo.go
+++ b/connector/signaltometricsconnector/internal/model/collectorinstanceinfo.go
@@ -1,0 +1,91 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package model // import "github.com/elastic/opentelemetry-collector-components/connector/signaltometricsconnector/internal/model"
+
+import (
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	semconv "go.opentelemetry.io/collector/semconv/v1.26.0"
+)
+
+// CollectorInstanceInfo holds the attributes that could uniquely identify
+// the current collector instance. These attributes are initialized from the
+// telemetry settings. The CollectorInstanceInfo can copy these attributes,
+// with a given prefix, to a provided map.
+type CollectorInstanceInfo struct {
+	prefix string
+
+	size              int
+	serviceInstanceID string
+	serviceName       string
+	serviceNamespace  string
+}
+
+func NewCollectorInstanceInfo(
+	prefix string,
+	set component.TelemetrySettings,
+) *CollectorInstanceInfo {
+	info := CollectorInstanceInfo{prefix: prefix}
+	set.Resource.Attributes().Range(func(k string, v pcommon.Value) bool {
+		switch k {
+		case semconv.AttributeServiceInstanceID:
+			if str := v.Str(); str != "" {
+				info.serviceInstanceID = str
+				info.size++
+			}
+		case semconv.AttributeServiceName:
+			if str := v.Str(); str != "" {
+				info.serviceName = str
+				info.size++
+			}
+		case semconv.AttributeServiceNamespace:
+			if str := v.Str(); str != "" {
+				info.serviceNamespace = str
+				info.size++
+			}
+		}
+		return true
+	})
+	return &info
+}
+
+// Size returns the max number of attributes that defines a collector's
+// instance information. Can be used to presize the attributes.
+func (info CollectorInstanceInfo) Size() int {
+	return info.size
+}
+
+func (info CollectorInstanceInfo) Copy(to pcommon.Map) {
+	to.EnsureCapacity(info.Size())
+	if info.serviceInstanceID != "" {
+		to.PutStr(keyWithPrefix(info.prefix, semconv.AttributeServiceInstanceID), info.serviceInstanceID)
+	}
+	if info.serviceName != "" {
+		to.PutStr(keyWithPrefix(info.prefix, semconv.AttributeServiceName), info.serviceName)
+	}
+	if info.serviceNamespace != "" {
+		to.PutStr(keyWithPrefix(info.prefix, semconv.AttributeServiceNamespace), info.serviceNamespace)
+	}
+}
+
+func keyWithPrefix(prefix, key string) string {
+	if prefix == "" {
+		return key
+	}
+	return prefix + "." + key
+}

--- a/connector/signaltometricsconnector/internal/model/collectorinstanceinfo_test.go
+++ b/connector/signaltometricsconnector/internal/model/collectorinstanceinfo_test.go
@@ -50,7 +50,7 @@ func TestCollectorInstanceInfo(t *testing.T) {
 			expected: func() pcommon.Map {
 				m := pcommon.NewMap()
 				m.PutStr(
-					"test."+semconv.AttributeServiceInstanceID,
+					"signaltometrics."+semconv.AttributeServiceInstanceID,
 					"627cc493-f310-47de-96bd-71410b7dec09",
 				)
 				return m
@@ -68,15 +68,15 @@ func TestCollectorInstanceInfo(t *testing.T) {
 			expected: func() pcommon.Map {
 				m := pcommon.NewMap()
 				m.PutStr(
-					"test."+semconv.AttributeServiceInstanceID,
+					"signaltometrics."+semconv.AttributeServiceInstanceID,
 					"627cc493-f310-47de-96bd-71410b7dec09",
 				)
 				m.PutStr(
-					"test."+semconv.AttributeServiceName,
+					"signaltometrics."+semconv.AttributeServiceName,
 					"signaltometrics",
 				)
 				m.PutStr(
-					"test."+semconv.AttributeServiceNamespace,
+					"signaltometrics."+semconv.AttributeServiceNamespace,
 					"test",
 				)
 				return m
@@ -84,7 +84,7 @@ func TestCollectorInstanceInfo(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			ci := NewCollectorInstanceInfo("test", tc.input)
+			ci := NewCollectorInstanceInfo(tc.input)
 			require.NotNil(t, ci)
 
 			actual := pcommon.NewMap()

--- a/connector/signaltometricsconnector/internal/model/collectorinstanceinfo_test.go
+++ b/connector/signaltometricsconnector/internal/model/collectorinstanceinfo_test.go
@@ -1,0 +1,108 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package model // import "github.com/elastic/opentelemetry-collector-components/connector/signaltometricsconnector/internal/model"
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	semconv "go.opentelemetry.io/collector/semconv/v1.26.0"
+)
+
+func TestCollectorInstanceInfo(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		input    component.TelemetrySettings
+		expected pcommon.Map
+	}{
+		{
+			name:     "empty",
+			input:    componenttest.NewNopTelemetrySettings(),
+			expected: pcommon.NewMap(),
+		},
+		{
+			name: "with_service_instance_id",
+			input: func() component.TelemetrySettings {
+				ts := componenttest.NewNopTelemetrySettings()
+				ts.Resource.Attributes().PutStr(semconv.AttributeServiceInstanceID, "627cc493-f310-47de-96bd-71410b7dec09")
+				return ts
+			}(),
+			expected: func() pcommon.Map {
+				m := pcommon.NewMap()
+				m.PutStr(
+					"test."+semconv.AttributeServiceInstanceID,
+					"627cc493-f310-47de-96bd-71410b7dec09",
+				)
+				return m
+			}(),
+		},
+		{
+			name: "with_all_values",
+			input: func() component.TelemetrySettings {
+				ts := componenttest.NewNopTelemetrySettings()
+				ts.Resource.Attributes().PutStr(semconv.AttributeServiceInstanceID, "627cc493-f310-47de-96bd-71410b7dec09")
+				ts.Resource.Attributes().PutStr(semconv.AttributeServiceName, "signaltometrics")
+				ts.Resource.Attributes().PutStr(semconv.AttributeServiceNamespace, "test")
+				return ts
+			}(),
+			expected: func() pcommon.Map {
+				m := pcommon.NewMap()
+				m.PutStr(
+					"test."+semconv.AttributeServiceInstanceID,
+					"627cc493-f310-47de-96bd-71410b7dec09",
+				)
+				m.PutStr(
+					"test."+semconv.AttributeServiceName,
+					"signaltometrics",
+				)
+				m.PutStr(
+					"test."+semconv.AttributeServiceNamespace,
+					"test",
+				)
+				return m
+			}(),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ci := NewCollectorInstanceInfo("test", tc.input)
+			require.NotNil(t, ci)
+
+			actual := pcommon.NewMap()
+			ci.Copy(actual)
+			assert.Equal(t, ci.Size(), actual.Len())
+			assertMapEquality(t, tc.expected, actual)
+		})
+	}
+}
+
+func assertMapEquality(t *testing.T, expected, actual pcommon.Map) bool {
+	t.Helper()
+
+	expectedRaw := expected.AsRaw()
+	actualRaw := actual.AsRaw()
+	return assert.True(
+		t, reflect.DeepEqual(expectedRaw, actualRaw),
+		"attributes don't match expected: %v, actual: %v",
+		expectedRaw, actualRaw,
+	)
+}

--- a/connector/signaltometricsconnector/internal/model/model.go
+++ b/connector/signaltometricsconnector/internal/model/model.go
@@ -180,17 +180,17 @@ func (md *MetricDef[K]) FromMetricInfo(
 	return nil
 }
 
-// FilterResourceAttributes filteres resource attributes based on the
-// `IncludeResourceAttributes` white list for the metric definition. Resource
-// attributes are only filtered if the white list is specified, otherwise
-// all the resource attributes are used for creating the metrics from the
-// metric definition.
+// FilterResourceAttributes filters resource attributes based on the
+// `IncludeResourceAttributes` list for the metric definition. Resource
+// attributes are only filtered if the list is specified, otherwise all the
+// resource attributes are used for creating the metrics from the metric
+// definition.
 func (md *MetricDef[K]) FilterResourceAttributes(
 	attrs pcommon.Map,
 	collectorInfo *CollectorInstanceInfo,
 ) pcommon.Map {
 	if len(md.IncludeResourceAttributes) == 0 {
-		// No resource attributes are whitelisted, return all as a copy.
+		// No resource attributes are specified, return all as a copy.
 		// Copy is performed to avoid mutating the data.
 		m := pcommon.NewMap()
 		attrs.CopyTo(m)

--- a/connector/signaltometricsconnector/testdata/logs/exponential_histograms/config.yaml
+++ b/connector/signaltometricsconnector/testdata/logs/exponential_histograms/config.yaml
@@ -7,7 +7,6 @@ signaltometrics:
         value: attributes["log.duration"]
     - name: total.logrecords.resource.foo.exphistogram
       description: Logrecords with resource attribute foo as exponential histogram with log.duration from attributes
-      collector_info_as_resource_attributes: true
       include_resource_attributes:
         - key: resource.foo
       exponential_histogram:

--- a/connector/signaltometricsconnector/testdata/logs/exponential_histograms/config.yaml
+++ b/connector/signaltometricsconnector/testdata/logs/exponential_histograms/config.yaml
@@ -5,6 +5,14 @@ signaltometrics:
       exponential_histogram:
         count: "1"
         value: attributes["log.duration"]
+    - name: total.logrecords.resource.foo.exphistogram
+      description: Logrecords with resource attribute foo as exponential histogram with log.duration from attributes
+      collector_info_as_resource_attributes: true
+      include_resource_attributes:
+        - key: resource.foo
+      exponential_histogram:
+        count: "1"
+        value: attributes["log.duration"]
     - name: log.foo.exphistogram
       description: Count total number of log records as per log.foo attribute as exponential histogram with log.duration from attributes
       attributes:

--- a/connector/signaltometricsconnector/testdata/logs/exponential_histograms/output.yaml
+++ b/connector/signaltometricsconnector/testdata/logs/exponential_histograms/output.yaml
@@ -1,6 +1,15 @@
 resourceMetrics:
   - resource:
       attributes:
+        - key: observer.service.instance.id
+          value:
+            stringValue: 627cc493-f310-47de-96bd-71410b7dec09
+        - key: observer.service.name
+          value:
+            stringValue: signaltometrics
+        - key: observer.service.namespace
+          value:
+            stringValue: test
         - key: resource.bar
           value:
             stringValue: bar

--- a/connector/signaltometricsconnector/testdata/logs/exponential_histograms/output.yaml
+++ b/connector/signaltometricsconnector/testdata/logs/exponential_histograms/output.yaml
@@ -1,13 +1,13 @@
 resourceMetrics:
   - resource:
       attributes:
-        - key: observer.service.instance.id
+        - key: signaltometrics.service.instance.id
           value:
             stringValue: 627cc493-f310-47de-96bd-71410b7dec09
-        - key: observer.service.name
+        - key: signaltometrics.service.name
           value:
             stringValue: signaltometrics
-        - key: observer.service.namespace
+        - key: signaltometrics.service.namespace
           value:
             stringValue: test
         - key: resource.bar
@@ -333,13 +333,13 @@ resourceMetrics:
           name: github.com/elastic/opentelemetry-collector-components/connector/signaltometricsconnector
   - resource:
       attributes:
-        - key: observer.service.instance.id
+        - key: signaltometrics.service.instance.id
           value:
             stringValue: 627cc493-f310-47de-96bd-71410b7dec09
-        - key: observer.service.name
+        - key: signaltometrics.service.name
           value:
             stringValue: signaltometrics
-        - key: observer.service.namespace
+        - key: signaltometrics.service.namespace
           value:
             stringValue: test
         - key: resource.foo

--- a/connector/signaltometricsconnector/testdata/logs/exponential_histograms/output.yaml
+++ b/connector/signaltometricsconnector/testdata/logs/exponential_histograms/output.yaml
@@ -322,3 +322,161 @@ resourceMetrics:
             name: log.bar.exphistogram
         scope:
           name: github.com/elastic/opentelemetry-collector-components/connector/signaltometricsconnector
+  - resource:
+      attributes:
+        - key: observer.service.instance.id
+          value:
+            stringValue: 627cc493-f310-47de-96bd-71410b7dec09
+        - key: observer.service.name
+          value:
+            stringValue: signaltometrics
+        - key: observer.service.namespace
+          value:
+            stringValue: test
+        - key: resource.foo
+          value:
+            stringValue: foo
+    scopeMetrics:
+      - metrics:
+          - description: Logrecords with resource attribute foo as exponential histogram with log.duration from attributes
+            exponentialHistogram:
+              aggregationTemporality: 1
+              dataPoints:
+                - count: "4"
+                  max: 101.5
+                  min: 7
+                  negative: {}
+                  positive:
+                    bucketCounts:
+                      - "1"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "1"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "1"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "0"
+                      - "1"
+                    offset: 89
+                  scale: 5
+                  sum: 128
+                  timeUnixNano: "1000000"
+            name: total.logrecords.resource.foo.exphistogram
+        scope:
+          name: github.com/elastic/opentelemetry-collector-components/connector/signaltometricsconnector

--- a/connector/signaltometricsconnector/testdata/logs/histograms/config.yaml
+++ b/connector/signaltometricsconnector/testdata/logs/histograms/config.yaml
@@ -6,6 +6,15 @@ signaltometrics:
         count: "1"
         value: attributes["log.duration"]
         buckets: [1, 10, 50, 100, 200]
+    - name: total.logrecords.resource.foo.histogram
+      description: Logrecords with resource attribute foo as histogram with log.duration from attributes
+      collector_info_as_resource_attributes: true
+      include_resource_attributes:
+        - key: resource.foo
+      histogram:
+        count: "1"
+        value: attributes["log.duration"]
+        buckets: [1, 10, 50, 100, 200]
     - name: log.foo.histogram
       description: Count total number of log records as per log.foo attribute as histogram with log.duration from attributes
       attributes:

--- a/connector/signaltometricsconnector/testdata/logs/histograms/config.yaml
+++ b/connector/signaltometricsconnector/testdata/logs/histograms/config.yaml
@@ -8,7 +8,6 @@ signaltometrics:
         buckets: [1, 10, 50, 100, 200]
     - name: total.logrecords.resource.foo.histogram
       description: Logrecords with resource attribute foo as histogram with log.duration from attributes
-      collector_info_as_resource_attributes: true
       include_resource_attributes:
         - key: resource.foo
       histogram:

--- a/connector/signaltometricsconnector/testdata/logs/histograms/output.yaml
+++ b/connector/signaltometricsconnector/testdata/logs/histograms/output.yaml
@@ -1,6 +1,15 @@
 resourceMetrics:
   - resource:
       attributes:
+        - key: observer.service.instance.id
+          value:
+            stringValue: 627cc493-f310-47de-96bd-71410b7dec09
+        - key: observer.service.name
+          value:
+            stringValue: signaltometrics
+        - key: observer.service.namespace
+          value:
+            stringValue: test
         - key: resource.bar
           value:
             stringValue: bar

--- a/connector/signaltometricsconnector/testdata/logs/histograms/output.yaml
+++ b/connector/signaltometricsconnector/testdata/logs/histograms/output.yaml
@@ -122,3 +122,42 @@ resourceMetrics:
             name: log.bar.histogram
         scope:
           name: github.com/elastic/opentelemetry-collector-components/connector/signaltometricsconnector
+  - resource:
+      attributes:
+        - key: observer.service.instance.id
+          value:
+            stringValue: 627cc493-f310-47de-96bd-71410b7dec09
+        - key: observer.service.name
+          value:
+            stringValue: signaltometrics
+        - key: observer.service.namespace
+          value:
+            stringValue: test
+        - key: resource.foo
+          value:
+            stringValue: foo
+    scopeMetrics:
+      - metrics:
+          - description: Logrecords with resource attribute foo as histogram with log.duration from attributes
+            histogram:
+              aggregationTemporality: 1
+              dataPoints:
+                - bucketCounts:
+                    - "0"
+                    - "2"
+                    - "1"
+                    - "0"
+                    - "1"
+                    - "0"
+                  count: "4"
+                  explicitBounds:
+                    - 1
+                    - 10
+                    - 50
+                    - 100
+                    - 200
+                  sum: 128
+                  timeUnixNano: "1000000"
+            name: total.logrecords.resource.foo.histogram
+        scope:
+          name: github.com/elastic/opentelemetry-collector-components/connector/signaltometricsconnector

--- a/connector/signaltometricsconnector/testdata/logs/histograms/output.yaml
+++ b/connector/signaltometricsconnector/testdata/logs/histograms/output.yaml
@@ -1,13 +1,13 @@
 resourceMetrics:
   - resource:
       attributes:
-        - key: observer.service.instance.id
+        - key: signaltometrics.service.instance.id
           value:
             stringValue: 627cc493-f310-47de-96bd-71410b7dec09
-        - key: observer.service.name
+        - key: signaltometrics.service.name
           value:
             stringValue: signaltometrics
-        - key: observer.service.namespace
+        - key: signaltometrics.service.namespace
           value:
             stringValue: test
         - key: resource.bar
@@ -133,13 +133,13 @@ resourceMetrics:
           name: github.com/elastic/opentelemetry-collector-components/connector/signaltometricsconnector
   - resource:
       attributes:
-        - key: observer.service.instance.id
+        - key: signaltometrics.service.instance.id
           value:
             stringValue: 627cc493-f310-47de-96bd-71410b7dec09
-        - key: observer.service.name
+        - key: signaltometrics.service.name
           value:
             stringValue: signaltometrics
-        - key: observer.service.namespace
+        - key: signaltometrics.service.namespace
           value:
             stringValue: test
         - key: resource.foo

--- a/connector/signaltometricsconnector/testdata/logs/sum/config.yaml
+++ b/connector/signaltometricsconnector/testdata/logs/sum/config.yaml
@@ -4,6 +4,13 @@ signaltometrics:
       description: Count total number of log records
       sum:
         value: "1"
+    - name: total.logrecords.resource.foo.sum
+      description: Count total number of log records with resource attribute foo
+      collector_info_as_resource_attributes: true
+      include_resource_attributes:
+        - key: resource.foo
+      sum:
+        value: "1"
     - name: log.foo.sum
       description: Count total number of log records as per log.foo attribute
       attributes:

--- a/connector/signaltometricsconnector/testdata/logs/sum/config.yaml
+++ b/connector/signaltometricsconnector/testdata/logs/sum/config.yaml
@@ -6,7 +6,6 @@ signaltometrics:
         value: "1"
     - name: total.logrecords.resource.foo.sum
       description: Count total number of log records with resource attribute foo
-      collector_info_as_resource_attributes: true
       include_resource_attributes:
         - key: resource.foo
       sum:

--- a/connector/signaltometricsconnector/testdata/logs/sum/output.yaml
+++ b/connector/signaltometricsconnector/testdata/logs/sum/output.yaml
@@ -52,3 +52,28 @@ resourceMetrics:
                   timeUnixNano: "1000000"
         scope:
           name: github.com/elastic/opentelemetry-collector-components/connector/signaltometricsconnector
+  - resource:
+      attributes:
+        - key: observer.service.instance.id
+          value:
+            stringValue: 627cc493-f310-47de-96bd-71410b7dec09
+        - key: observer.service.name
+          value:
+            stringValue: signaltometrics
+        - key: observer.service.namespace
+          value:
+            stringValue: test
+        - key: resource.foo
+          value:
+            stringValue: foo
+    scopeMetrics:
+      - metrics:
+          - description: Count total number of log records with resource attribute foo
+            name: total.logrecords.resource.foo.sum
+            sum:
+              aggregationTemporality: 1
+              dataPoints:
+                - asInt: "4"
+                  timeUnixNano: "1000000"
+        scope:
+          name: github.com/elastic/opentelemetry-collector-components/connector/signaltometricsconnector

--- a/connector/signaltometricsconnector/testdata/logs/sum/output.yaml
+++ b/connector/signaltometricsconnector/testdata/logs/sum/output.yaml
@@ -1,6 +1,15 @@
 resourceMetrics:
   - resource:
       attributes:
+        - key: observer.service.instance.id
+          value:
+            stringValue: 627cc493-f310-47de-96bd-71410b7dec09
+        - key: observer.service.name
+          value:
+            stringValue: signaltometrics
+        - key: observer.service.namespace
+          value:
+            stringValue: test
         - key: resource.bar
           value:
             stringValue: bar

--- a/connector/signaltometricsconnector/testdata/logs/sum/output.yaml
+++ b/connector/signaltometricsconnector/testdata/logs/sum/output.yaml
@@ -1,13 +1,13 @@
 resourceMetrics:
   - resource:
       attributes:
-        - key: observer.service.instance.id
+        - key: signaltometrics.service.instance.id
           value:
             stringValue: 627cc493-f310-47de-96bd-71410b7dec09
-        - key: observer.service.name
+        - key: signaltometrics.service.name
           value:
             stringValue: signaltometrics
-        - key: observer.service.namespace
+        - key: signaltometrics.service.namespace
           value:
             stringValue: test
         - key: resource.bar
@@ -63,13 +63,13 @@ resourceMetrics:
           name: github.com/elastic/opentelemetry-collector-components/connector/signaltometricsconnector
   - resource:
       attributes:
-        - key: observer.service.instance.id
+        - key: signaltometrics.service.instance.id
           value:
             stringValue: 627cc493-f310-47de-96bd-71410b7dec09
-        - key: observer.service.name
+        - key: signaltometrics.service.name
           value:
             stringValue: signaltometrics
-        - key: observer.service.namespace
+        - key: signaltometrics.service.namespace
           value:
             stringValue: test
         - key: resource.foo

--- a/connector/signaltometricsconnector/testdata/metrics/exponential_histograms/output.yaml
+++ b/connector/signaltometricsconnector/testdata/metrics/exponential_histograms/output.yaml
@@ -1,6 +1,15 @@
 resourceMetrics:
   - resource:
       attributes:
+        - key: observer.service.instance.id
+          value:
+            stringValue: 627cc493-f310-47de-96bd-71410b7dec09
+        - key: observer.service.name
+          value:
+            stringValue: signaltometrics
+        - key: observer.service.namespace
+          value:
+            stringValue: test
         - key: resource.foo
           value:
             stringValue: foo

--- a/connector/signaltometricsconnector/testdata/metrics/exponential_histograms/output.yaml
+++ b/connector/signaltometricsconnector/testdata/metrics/exponential_histograms/output.yaml
@@ -1,13 +1,13 @@
 resourceMetrics:
   - resource:
       attributes:
-        - key: observer.service.instance.id
+        - key: signaltometrics.service.instance.id
           value:
             stringValue: 627cc493-f310-47de-96bd-71410b7dec09
-        - key: observer.service.name
+        - key: signaltometrics.service.name
           value:
             stringValue: signaltometrics
-        - key: observer.service.namespace
+        - key: signaltometrics.service.namespace
           value:
             stringValue: test
         - key: resource.foo

--- a/connector/signaltometricsconnector/testdata/metrics/histograms/output.yaml
+++ b/connector/signaltometricsconnector/testdata/metrics/histograms/output.yaml
@@ -1,6 +1,15 @@
 resourceMetrics:
   - resource:
       attributes:
+        - key: observer.service.instance.id
+          value:
+            stringValue: 627cc493-f310-47de-96bd-71410b7dec09
+        - key: observer.service.name
+          value:
+            stringValue: signaltometrics
+        - key: observer.service.namespace
+          value:
+            stringValue: test
         - key: resource.foo
           value:
             stringValue: foo

--- a/connector/signaltometricsconnector/testdata/metrics/histograms/output.yaml
+++ b/connector/signaltometricsconnector/testdata/metrics/histograms/output.yaml
@@ -1,13 +1,13 @@
 resourceMetrics:
   - resource:
       attributes:
-        - key: observer.service.instance.id
+        - key: signaltometrics.service.instance.id
           value:
             stringValue: 627cc493-f310-47de-96bd-71410b7dec09
-        - key: observer.service.name
+        - key: signaltometrics.service.name
           value:
             stringValue: signaltometrics
-        - key: observer.service.namespace
+        - key: signaltometrics.service.namespace
           value:
             stringValue: test
         - key: resource.foo

--- a/connector/signaltometricsconnector/testdata/metrics/sum/output.yaml
+++ b/connector/signaltometricsconnector/testdata/metrics/sum/output.yaml
@@ -1,13 +1,13 @@
 resourceMetrics:
   - resource:
       attributes:
-        - key: observer.service.instance.id
+        - key: signaltometrics.service.instance.id
           value:
             stringValue: 627cc493-f310-47de-96bd-71410b7dec09
-        - key: observer.service.name
+        - key: signaltometrics.service.name
           value:
             stringValue: signaltometrics
-        - key: observer.service.namespace
+        - key: signaltometrics.service.namespace
           value:
             stringValue: test
         - key: resource.bar

--- a/connector/signaltometricsconnector/testdata/metrics/sum/output.yaml
+++ b/connector/signaltometricsconnector/testdata/metrics/sum/output.yaml
@@ -1,6 +1,15 @@
 resourceMetrics:
   - resource:
       attributes:
+        - key: observer.service.instance.id
+          value:
+            stringValue: 627cc493-f310-47de-96bd-71410b7dec09
+        - key: observer.service.name
+          value:
+            stringValue: signaltometrics
+        - key: observer.service.namespace
+          value:
+            stringValue: test
         - key: resource.bar
           value:
             stringValue: bar

--- a/connector/signaltometricsconnector/testdata/traces/exponential_histograms/config.yaml
+++ b/connector/signaltometricsconnector/testdata/traces/exponential_histograms/config.yaml
@@ -3,6 +3,7 @@ signaltometrics:
     - name: with_resource_foo_only
       description: Spans with resource attribute white listing for resource.foo as a exponential histogram metric
       unit: ms
+      collector_info_as_resource_attributes: true
       include_resource_attributes:
         - key: resource.foo
       exponential_histogram:

--- a/connector/signaltometricsconnector/testdata/traces/exponential_histograms/config.yaml
+++ b/connector/signaltometricsconnector/testdata/traces/exponential_histograms/config.yaml
@@ -1,9 +1,8 @@
 signaltometrics:
   spans:
     - name: with_resource_foo_only
-      description: Spans with resource attribute white listing for resource.foo as a exponential histogram metric
+      description: Spans with resource attribute including resource.foo as a exponential histogram metric
       unit: ms
-      collector_info_as_resource_attributes: true
       include_resource_attributes:
         - key: resource.foo
       exponential_histogram:

--- a/connector/signaltometricsconnector/testdata/traces/exponential_histograms/output.yaml
+++ b/connector/signaltometricsconnector/testdata/traces/exponential_histograms/output.yaml
@@ -1,13 +1,13 @@
 resourceMetrics:
   - resource:
       attributes:
-        - key: observer.service.instance.id
+        - key: signaltometrics.service.instance.id
           value:
             stringValue: 627cc493-f310-47de-96bd-71410b7dec09
-        - key: observer.service.name
+        - key: signaltometrics.service.name
           value:
             stringValue: signaltometrics
-        - key: observer.service.namespace
+        - key: signaltometrics.service.namespace
           value:
             stringValue: test
         - key: resource.foo
@@ -141,13 +141,13 @@ resourceMetrics:
           name: github.com/elastic/opentelemetry-collector-components/connector/signaltometricsconnector
   - resource:
       attributes:
-        - key: observer.service.instance.id
+        - key: signaltometrics.service.instance.id
           value:
             stringValue: 627cc493-f310-47de-96bd-71410b7dec09
-        - key: observer.service.name
+        - key: signaltometrics.service.name
           value:
             stringValue: signaltometrics
-        - key: observer.service.namespace
+        - key: signaltometrics.service.namespace
           value:
             stringValue: test
         - key: resource.bar

--- a/connector/signaltometricsconnector/testdata/traces/exponential_histograms/output.yaml
+++ b/connector/signaltometricsconnector/testdata/traces/exponential_histograms/output.yaml
@@ -1,6 +1,15 @@
 resourceMetrics:
   - resource:
       attributes:
+        - key: observer.service.instance.id
+          value:
+            stringValue: 627cc493-f310-47de-96bd-71410b7dec09
+        - key: observer.service.name
+          value:
+            stringValue: signaltometrics
+        - key: observer.service.namespace
+          value:
+            stringValue: test
         - key: resource.foo
           value:
             stringValue: foo

--- a/connector/signaltometricsconnector/testdata/traces/exponential_histograms/output.yaml
+++ b/connector/signaltometricsconnector/testdata/traces/exponential_histograms/output.yaml
@@ -15,7 +15,7 @@ resourceMetrics:
             stringValue: foo
     scopeMetrics:
       - metrics:
-          - description: Spans with resource attribute white listing for resource.foo as a exponential histogram metric
+          - description: Spans with resource attribute including resource.foo as a exponential histogram metric
             exponentialHistogram:
               aggregationTemporality: 1
               dataPoints:
@@ -141,6 +141,15 @@ resourceMetrics:
           name: github.com/elastic/opentelemetry-collector-components/connector/signaltometricsconnector
   - resource:
       attributes:
+        - key: observer.service.instance.id
+          value:
+            stringValue: 627cc493-f310-47de-96bd-71410b7dec09
+        - key: observer.service.name
+          value:
+            stringValue: signaltometrics
+        - key: observer.service.namespace
+          value:
+            stringValue: test
         - key: resource.bar
           value:
             stringValue: bar

--- a/connector/signaltometricsconnector/testdata/traces/histograms/config.yaml
+++ b/connector/signaltometricsconnector/testdata/traces/histograms/config.yaml
@@ -3,6 +3,7 @@ signaltometrics:
     - name: with_resource_foo_only
       description: Spans with resource attribute white listing for resource.foo as a histogram metric
       unit: ms
+      collector_info_as_resource_attributes: true
       include_resource_attributes:
         - key: resource.foo
       histogram:

--- a/connector/signaltometricsconnector/testdata/traces/histograms/config.yaml
+++ b/connector/signaltometricsconnector/testdata/traces/histograms/config.yaml
@@ -1,9 +1,8 @@
 signaltometrics:
   spans:
     - name: with_resource_foo_only
-      description: Spans with resource attribute white listing for resource.foo as a histogram metric
+      description: Spans with resource attribute including resource.foo as a histogram metric
       unit: ms
-      collector_info_as_resource_attributes: true
       include_resource_attributes:
         - key: resource.foo
       histogram:

--- a/connector/signaltometricsconnector/testdata/traces/histograms/output.yaml
+++ b/connector/signaltometricsconnector/testdata/traces/histograms/output.yaml
@@ -1,6 +1,15 @@
 resourceMetrics:
   - resource:
       attributes:
+        - key: observer.service.instance.id
+          value:
+            stringValue: 627cc493-f310-47de-96bd-71410b7dec09
+        - key: observer.service.name
+          value:
+            stringValue: signaltometrics
+        - key: observer.service.namespace
+          value:
+            stringValue: test
         - key: resource.foo
           value:
             stringValue: foo

--- a/connector/signaltometricsconnector/testdata/traces/histograms/output.yaml
+++ b/connector/signaltometricsconnector/testdata/traces/histograms/output.yaml
@@ -15,7 +15,7 @@ resourceMetrics:
             stringValue: foo
     scopeMetrics:
       - metrics:
-          - description: Spans with resource attribute white listing for resource.foo as a histogram metric
+          - description: Spans with resource attribute including resource.foo as a histogram metric
             histogram:
               aggregationTemporality: 1
               dataPoints:
@@ -63,6 +63,15 @@ resourceMetrics:
           name: github.com/elastic/opentelemetry-collector-components/connector/signaltometricsconnector
   - resource:
       attributes:
+        - key: observer.service.instance.id
+          value:
+            stringValue: 627cc493-f310-47de-96bd-71410b7dec09
+        - key: observer.service.name
+          value:
+            stringValue: signaltometrics
+        - key: observer.service.namespace
+          value:
+            stringValue: test
         - key: resource.bar
           value:
             stringValue: bar

--- a/connector/signaltometricsconnector/testdata/traces/histograms/output.yaml
+++ b/connector/signaltometricsconnector/testdata/traces/histograms/output.yaml
@@ -1,13 +1,13 @@
 resourceMetrics:
   - resource:
       attributes:
-        - key: observer.service.instance.id
+        - key: signaltometrics.service.instance.id
           value:
             stringValue: 627cc493-f310-47de-96bd-71410b7dec09
-        - key: observer.service.name
+        - key: signaltometrics.service.name
           value:
             stringValue: signaltometrics
-        - key: observer.service.namespace
+        - key: signaltometrics.service.namespace
           value:
             stringValue: test
         - key: resource.foo
@@ -63,13 +63,13 @@ resourceMetrics:
           name: github.com/elastic/opentelemetry-collector-components/connector/signaltometricsconnector
   - resource:
       attributes:
-        - key: observer.service.instance.id
+        - key: signaltometrics.service.instance.id
           value:
             stringValue: 627cc493-f310-47de-96bd-71410b7dec09
-        - key: observer.service.name
+        - key: signaltometrics.service.name
           value:
             stringValue: signaltometrics
-        - key: observer.service.namespace
+        - key: signaltometrics.service.namespace
           value:
             stringValue: test
         - key: resource.bar

--- a/connector/signaltometricsconnector/testdata/traces/sum/config.yaml
+++ b/connector/signaltometricsconnector/testdata/traces/sum/config.yaml
@@ -3,6 +3,7 @@ signaltometrics:
     - name: with_resource_foo_only
       description: Spans with resource attribute white listing for resource.foo as a int sum metric
       unit: s
+      collector_info_as_resource_attributes: true
       include_resource_attributes:
         - key: resource.foo
       sum:

--- a/connector/signaltometricsconnector/testdata/traces/sum/config.yaml
+++ b/connector/signaltometricsconnector/testdata/traces/sum/config.yaml
@@ -1,9 +1,8 @@
 signaltometrics:
   spans:
     - name: with_resource_foo_only
-      description: Spans with resource attribute white listing for resource.foo as a int sum metric
+      description: Spans with resource attribute including resource.foo as a int sum metric
       unit: s
-      collector_info_as_resource_attributes: true
       include_resource_attributes:
         - key: resource.foo
       sum:

--- a/connector/signaltometricsconnector/testdata/traces/sum/output.yaml
+++ b/connector/signaltometricsconnector/testdata/traces/sum/output.yaml
@@ -1,6 +1,15 @@
 resourceMetrics:
   - resource:
       attributes:
+        - key: observer.service.instance.id
+          value:
+            stringValue: 627cc493-f310-47de-96bd-71410b7dec09
+        - key: observer.service.name
+          value:
+            stringValue: signaltometrics
+        - key: observer.service.namespace
+          value:
+            stringValue: test
         - key: resource.foo
           value:
             stringValue: foo

--- a/connector/signaltometricsconnector/testdata/traces/sum/output.yaml
+++ b/connector/signaltometricsconnector/testdata/traces/sum/output.yaml
@@ -15,7 +15,7 @@ resourceMetrics:
             stringValue: foo
     scopeMetrics:
       - metrics:
-          - description: Spans with resource attribute white listing for resource.foo as a int sum metric
+          - description: Spans with resource attribute including resource.foo as a int sum metric
             name: with_resource_foo_only
             sum:
               aggregationTemporality: 1
@@ -27,6 +27,15 @@ resourceMetrics:
           name: github.com/elastic/opentelemetry-collector-components/connector/signaltometricsconnector
   - resource:
       attributes:
+        - key: observer.service.instance.id
+          value:
+            stringValue: 627cc493-f310-47de-96bd-71410b7dec09
+        - key: observer.service.name
+          value:
+            stringValue: signaltometrics
+        - key: observer.service.namespace
+          value:
+            stringValue: test
         - key: resource.bar
           value:
             stringValue: bar

--- a/connector/signaltometricsconnector/testdata/traces/sum/output.yaml
+++ b/connector/signaltometricsconnector/testdata/traces/sum/output.yaml
@@ -1,13 +1,13 @@
 resourceMetrics:
   - resource:
       attributes:
-        - key: observer.service.instance.id
+        - key: signaltometrics.service.instance.id
           value:
             stringValue: 627cc493-f310-47de-96bd-71410b7dec09
-        - key: observer.service.name
+        - key: signaltometrics.service.name
           value:
             stringValue: signaltometrics
-        - key: observer.service.namespace
+        - key: signaltometrics.service.namespace
           value:
             stringValue: test
         - key: resource.foo
@@ -27,13 +27,13 @@ resourceMetrics:
           name: github.com/elastic/opentelemetry-collector-components/connector/signaltometricsconnector
   - resource:
       attributes:
-        - key: observer.service.instance.id
+        - key: signaltometrics.service.instance.id
           value:
             stringValue: 627cc493-f310-47de-96bd-71410b7dec09
-        - key: observer.service.name
+        - key: signaltometrics.service.name
           value:
             stringValue: signaltometrics
-        - key: observer.service.namespace
+        - key: signaltometrics.service.namespace
           value:
             stringValue: test
         - key: resource.bar


### PR DESCRIPTION
With `include_resource_attributes` white listining which
resource attributes to add as resource attributes to the
final metrics, single-writer is affected. Add the collectors
instance information restores single-writer.

Closes: https://github.com/elastic/opentelemetry-collector-components/issues/159