### PR TITLE
Update to use factory#Create{Traces,Metrics}

### DIFF
--- a/distributions/elastic-components/manifest.yaml
+++ b/distributions/elastic-components/manifest.yaml
@@ -4,7 +4,7 @@ dist:
   description: Testing distribution to ensure Elastic's components can be used with the OCB
   version: 0.0.1
   output_path: ./_build
-  otelcol_version: 0.110.0
+  otelcol_version: 0.111.0
 
 extensions:
 

--- a/processor/elastictraceprocessor/processor_test.go
+++ b/processor/elastictraceprocessor/processor_test.go
@@ -55,7 +55,7 @@ func TestProcessor(t *testing.T) {
 			settings.TelemetrySettings.Logger = zaptest.NewLogger(t, zaptest.Level(zapcore.DebugLevel))
 			next := &consumertest.TracesSink{}
 
-			tp, err := factory.CreateTracesProcessor(ctx, settings, createDefaultConfig(), next)
+			tp, err := factory.CreateTraces(ctx, settings, createDefaultConfig(), next)
 
 			require.NoError(t, err)
 			require.IsType(t, &Processor{}, tp)

--- a/processor/lsmintervalprocessor/generated_component_test.go
+++ b/processor/lsmintervalprocessor/generated_component_test.go
@@ -56,7 +56,7 @@ func TestComponentLifecycle(t *testing.T) {
 		{
 			name: "metrics",
 			createFn: func(ctx context.Context, set processor.Settings, cfg component.Config) (component.Component, error) {
-				return factory.CreateMetricsProcessor(ctx, set, cfg, consumertest.NewNop())
+				return factory.CreateMetrics(ctx, set, cfg, consumertest.NewNop())
 			},
 		},
 	}

--- a/processor/lsmintervalprocessor/processor_test.go
+++ b/processor/lsmintervalprocessor/processor_test.go
@@ -81,7 +81,7 @@ func TestAggregation(t *testing.T) {
 			factory := NewFactory()
 			settings := processortest.NewNopSettings()
 			settings.TelemetrySettings.Logger = zaptest.NewLogger(t, zaptest.Level(zapcore.DebugLevel))
-			mgp, err := factory.CreateMetricsProcessor(
+			mgp, err := factory.CreateMetrics(
 				context.Background(),
 				settings,
 				config,


### PR DESCRIPTION
`factory#Create{Traces,Metrics}Processor` is now deprecated, update to use the non-deprecated methods.