### PR TITLE
[processor/elasticinframetrics] Fix generated tests with latest mdatagen

### DIFF
--- a/processor/elasticinframetricsprocessor/generated_component_test.go
+++ b/processor/elasticinframetricsprocessor/generated_component_test.go
@@ -56,7 +56,7 @@ func TestComponentLifecycle(t *testing.T) {
 		{
 			name: "metrics",
 			createFn: func(ctx context.Context, set processor.Settings, cfg component.Config) (component.Component, error) {
-				return factory.CreateMetricsProcessor(ctx, set, cfg, consumertest.NewNop())
+				return factory.CreateMetrics(ctx, set, cfg, consumertest.NewNop())
 			},
 		},
 	}
@@ -68,21 +68,21 @@ func TestComponentLifecycle(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, sub.Unmarshal(&cfg))
 
-	for _, test := range tests {
-		t.Run(test.name+"-shutdown", func(t *testing.T) {
-			c, err := test.createFn(context.Background(), processortest.NewNopSettings(), cfg)
+	for _, tt := range tests {
+		t.Run(tt.name+"-shutdown", func(t *testing.T) {
+			c, err := tt.createFn(context.Background(), processortest.NewNopSettings(), cfg)
 			require.NoError(t, err)
 			err = c.Shutdown(context.Background())
 			require.NoError(t, err)
 		})
-		t.Run(test.name+"-lifecycle", func(t *testing.T) {
-			c, err := test.createFn(context.Background(), processortest.NewNopSettings(), cfg)
+		t.Run(tt.name+"-lifecycle", func(t *testing.T) {
+			c, err := tt.createFn(context.Background(), processortest.NewNopSettings(), cfg)
 			require.NoError(t, err)
 			host := componenttest.NewNopHost()
 			err = c.Start(context.Background(), host)
 			require.NoError(t, err)
 			require.NotPanics(t, func() {
-				switch test.name {
+				switch tt.name {
 				case "logs":
 					e, ok := c.(processor.Logs)
 					require.True(t, ok)

--- a/processor/elasticinframetricsprocessor/internal/metadata/generated_status.go
+++ b/processor/elasticinframetricsprocessor/internal/metadata/generated_status.go
@@ -24,7 +24,8 @@ import (
 )
 
 var (
-	Type = component.MustNewType("elasticinframetrics")
+	Type      = component.MustNewType("elasticinframetrics")
+	ScopeName = "github.com/elastic/opentelemetry-collector-components/processor/elasticinframetricsprocessor"
 )
 
 const (


### PR DESCRIPTION
Some methods have been deprecated and generated tests need to be regenerated using latest mdatagen.