### PR TITLE
[processor/elastictrace]Remove usage of deprecated NewTracesProcessor

### DIFF
--- a/processor/elastictraceprocessor/generated_component_test.go
+++ b/processor/elastictraceprocessor/generated_component_test.go
@@ -56,7 +56,7 @@ func TestComponentLifecycle(t *testing.T) {
 		{
 			name: "traces",
 			createFn: func(ctx context.Context, set processor.Settings, cfg component.Config) (component.Component, error) {
-				return factory.CreateTracesProcessor(ctx, set, cfg, consumertest.NewNop())
+				return factory.CreateTraces(ctx, set, cfg, consumertest.NewNop())
 			},
 		},
 	}


### PR DESCRIPTION
Update generated test with latest version of `mdatagen` to remove usage of deprecated methods.