### PR TITLE
ci: group dependabot directories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,12 +3,7 @@ version: 2
 updates:
   - package-ecosystem: "gomod"
     directories:
-      - "/processor/lsmintervalprocessor/"
-      - "/processor/elasticinframetricsprocessor/"
-      - "/processor/elastictraceprocessor/"
-      - "/processor/ratelimitprocessor/"
-      - "/connector/signaltometricsconnector"
-      - "/internal/tools/"
+      - "**/*"
     schedule:
       interval: "daily"
     labels:


### PR DESCRIPTION
try to reduce the spam of update PRs when a new otel version is released

Closes: https://github.com/elastic/opentelemetry-collector-components/issues/171