### PR TITLE
[processor/ratelimit] Add `throttle_behavior` for optional delayed processing

### DIFF
--- a/processor/ratelimitprocessor/config.go
+++ b/processor/ratelimitprocessor/config.go
@@ -95,8 +95,8 @@ const (
 	// ThrottleBehaviorError is the behavior to return an error immediately on throttle
 	ThrottleBehaviorError ThrottleBehavior = "error"
 
-	// ThrottleBehaviorBlock is the behavior to block until throttling is done
-	ThrottleBehaviorBlock ThrottleBehavior = "block"
+	// ThrottleBehaviorDelay is the behavior to block until throttling is done
+	ThrottleBehaviorDelay ThrottleBehavior = "delay"
 )
 
 // GubernatorConfig holds Gubernator-specific configuration for the ratelimit processor.
@@ -148,14 +148,14 @@ func (s Strategy) Validate() error {
 // Validate checks if throttle behavior matches the possible options
 func (s ThrottleBehavior) Validate() error {
 	switch s {
-	case ThrottleBehaviorError, ThrottleBehaviorBlock:
+	case ThrottleBehaviorError, ThrottleBehaviorDelay:
 		return nil
 	}
 	return fmt.Errorf(
 		"invalid throttle behavior %q, expected one of %q",
 		s, []string{
 			string(ThrottleBehaviorError),
-			string(ThrottleBehaviorBlock),
+			string(ThrottleBehaviorDelay),
 		},
 	)
 }

--- a/processor/ratelimitprocessor/config.go
+++ b/processor/ratelimitprocessor/config.go
@@ -92,10 +92,10 @@ const (
 type ThrottleBehavior string
 
 const (
-	// ThrottleBehaviorError is the behavior to return an error immediately on throttle
+	// ThrottleBehaviorError is the behavior to return an error immediately on throttle and does not send the event.
 	ThrottleBehaviorError ThrottleBehavior = "error"
 
-	// ThrottleBehaviorDelay is the behavior to block until throttling is done
+	// ThrottleBehaviorDelay is the behavior to delay the sending until it is no longer throttled.
 	ThrottleBehaviorDelay ThrottleBehavior = "delay"
 )
 

--- a/processor/ratelimitprocessor/config.go
+++ b/processor/ratelimitprocessor/config.go
@@ -59,10 +59,10 @@ type Config struct {
 	// Burst holds the maximum capacity of rate limit buckets.
 	Burst int `mapstructure:"burst"`
 
-	// OnThrottle holds the behavior when rate limit is exceeded.
+	// ThrottleBehavior holds the behavior when rate limit is exceeded.
 	//
 	// Defaults to "error"
-	OnThrottle OnThrottleBehavior `mapstructure:"on_throttle"`
+	ThrottleBehavior ThrottleBehavior `mapstructure:"throttle_behavior"`
 }
 
 // Strategy identifies the rate-limiting strategy: requests, records, or bytes.
@@ -88,15 +88,15 @@ const (
 	StrategyRateLimitBytes Strategy = "bytes"
 )
 
-// OnThrottleBehavior identifies the behavior when rate limit is exceeded.
-type OnThrottleBehavior string
+// ThrottleBehavior identifies the behavior when rate limit is exceeded.
+type ThrottleBehavior string
 
 const (
-	// OnThrottleError is the behavior to return an error immediately on throttle
-	OnThrottleError OnThrottleBehavior = "error"
+	// ThrottleBehaviorError is the behavior to return an error immediately on throttle
+	ThrottleBehaviorError ThrottleBehavior = "error"
 
-	// OnThrottleBlock is the behavior to block until throttling is done
-	OnThrottleBlock OnThrottleBehavior = "block"
+	// ThrottleBehaviorBlock is the behavior to block until throttling is done
+	ThrottleBehaviorBlock ThrottleBehavior = "block"
 )
 
 // GubernatorConfig holds Gubernator-specific configuration for the ratelimit processor.
@@ -113,8 +113,8 @@ type GubernatorBehavior string
 
 func createDefaultConfig() component.Config {
 	return &Config{
-		Strategy:   StrategyRateLimitRequests,
-		OnThrottle: OnThrottleError,
+		Strategy:         StrategyRateLimitRequests,
+		ThrottleBehavior: ThrottleBehaviorError,
 	}
 }
 
@@ -141,6 +141,21 @@ func (s Strategy) Validate() error {
 			string(StrategyRateLimitRequests),
 			string(StrategyRateLimitRecords),
 			string(StrategyRateLimitBytes),
+		},
+	)
+}
+
+// Validate checks if throttle behavior matches the possible options
+func (s ThrottleBehavior) Validate() error {
+	switch s {
+	case ThrottleBehaviorError, ThrottleBehaviorBlock:
+		return nil
+	}
+	return fmt.Errorf(
+		"invalid throttle behavior %q, expected one of %q",
+		s, []string{
+			string(ThrottleBehaviorError),
+			string(ThrottleBehaviorBlock),
 		},
 	)
 }

--- a/processor/ratelimitprocessor/config.go
+++ b/processor/ratelimitprocessor/config.go
@@ -58,6 +58,11 @@ type Config struct {
 
 	// Burst holds the maximum capacity of rate limit buckets.
 	Burst int `mapstructure:"burst"`
+
+	// OnThrottle holds the behavior when rate limit is exceeded.
+	//
+	// Defaults to "error"
+	OnThrottle OnThrottleBehavior `mapstructure:"on_throttle"`
 }
 
 // Strategy identifies the rate-limiting strategy: requests, records, or bytes.
@@ -81,6 +86,17 @@ const (
 	// and records. Bear in mind that this strategy may impact
 	// CPU and memory usage.
 	StrategyRateLimitBytes Strategy = "bytes"
+)
+
+// OnThrottleBehavior identifies the behavior when rate limit is exceeded.
+type OnThrottleBehavior string
+
+const (
+	// OnThrottleError is the behavior to return an error immediately on throttle
+	OnThrottleError OnThrottleBehavior = "error"
+
+	// OnThrottleBlock is the behavior to block until throttling is done
+	OnThrottleBlock OnThrottleBehavior = "block"
 )
 
 // GubernatorConfig holds Gubernator-specific configuration for the ratelimit processor.

--- a/processor/ratelimitprocessor/config.go
+++ b/processor/ratelimitprocessor/config.go
@@ -113,7 +113,8 @@ type GubernatorBehavior string
 
 func createDefaultConfig() component.Config {
 	return &Config{
-		Strategy: StrategyRateLimitRequests,
+		Strategy:   StrategyRateLimitRequests,
+		OnThrottle: OnThrottleError,
 	}
 }
 

--- a/processor/ratelimitprocessor/config_test.go
+++ b/processor/ratelimitprocessor/config_test.go
@@ -41,17 +41,19 @@ func TestLoadConfig(t *testing.T) {
 		{
 			name: "local",
 			expected: &Config{
-				Rate:     100,
-				Burst:    200,
-				Strategy: StrategyRateLimitRequests,
+				Rate:       100,
+				Burst:      200,
+				Strategy:   StrategyRateLimitRequests,
+				OnThrottle: OnThrottleError,
 			},
 		},
 		{
 			name: "strategy",
 			expected: &Config{
-				Rate:     100,
-				Burst:    200,
-				Strategy: StrategyRateLimitBytes,
+				Rate:       100,
+				Burst:      200,
+				Strategy:   StrategyRateLimitBytes,
+				OnThrottle: OnThrottleError,
 			},
 		},
 		{
@@ -61,6 +63,7 @@ func TestLoadConfig(t *testing.T) {
 				Rate:       100,
 				Burst:      200,
 				Strategy:   StrategyRateLimitRequests,
+				OnThrottle: OnThrottleError,
 			},
 		},
 		{
@@ -70,9 +73,10 @@ func TestLoadConfig(t *testing.T) {
 					ClientConfig: *grpcClientConfig,
 					Behavior:     []GubernatorBehavior{"global", "duration_is_gregorian"},
 				},
-				Rate:     100,
-				Burst:    200,
-				Strategy: StrategyRateLimitRequests,
+				Rate:       100,
+				Burst:      200,
+				Strategy:   StrategyRateLimitRequests,
+				OnThrottle: OnThrottleError,
 			},
 		},
 		{
@@ -81,6 +85,7 @@ func TestLoadConfig(t *testing.T) {
 				Rate:         100,
 				Burst:        200,
 				Strategy:     StrategyRateLimitRequests,
+				OnThrottle:   OnThrottleError,
 				MetadataKeys: []string{"project_id"},
 			},
 		},

--- a/processor/ratelimitprocessor/config_test.go
+++ b/processor/ratelimitprocessor/config_test.go
@@ -41,29 +41,29 @@ func TestLoadConfig(t *testing.T) {
 		{
 			name: "local",
 			expected: &Config{
-				Rate:       100,
-				Burst:      200,
-				Strategy:   StrategyRateLimitRequests,
-				OnThrottle: OnThrottleError,
+				Rate:             100,
+				Burst:            200,
+				Strategy:         StrategyRateLimitRequests,
+				ThrottleBehavior: ThrottleBehaviorError,
 			},
 		},
 		{
 			name: "strategy",
 			expected: &Config{
-				Rate:       100,
-				Burst:      200,
-				Strategy:   StrategyRateLimitBytes,
-				OnThrottle: OnThrottleError,
+				Rate:             100,
+				Burst:            200,
+				Strategy:         StrategyRateLimitBytes,
+				ThrottleBehavior: ThrottleBehaviorError,
 			},
 		},
 		{
 			name: "gubernator",
 			expected: &Config{
-				Gubernator: &GubernatorConfig{ClientConfig: *grpcClientConfig},
-				Rate:       100,
-				Burst:      200,
-				Strategy:   StrategyRateLimitRequests,
-				OnThrottle: OnThrottleError,
+				Gubernator:       &GubernatorConfig{ClientConfig: *grpcClientConfig},
+				Rate:             100,
+				Burst:            200,
+				Strategy:         StrategyRateLimitRequests,
+				ThrottleBehavior: ThrottleBehaviorError,
 			},
 		},
 		{
@@ -73,20 +73,20 @@ func TestLoadConfig(t *testing.T) {
 					ClientConfig: *grpcClientConfig,
 					Behavior:     []GubernatorBehavior{"global", "duration_is_gregorian"},
 				},
-				Rate:       100,
-				Burst:      200,
-				Strategy:   StrategyRateLimitRequests,
-				OnThrottle: OnThrottleError,
+				Rate:             100,
+				Burst:            200,
+				Strategy:         StrategyRateLimitRequests,
+				ThrottleBehavior: ThrottleBehaviorError,
 			},
 		},
 		{
 			name: "metadata_keys",
 			expected: &Config{
-				Rate:         100,
-				Burst:        200,
-				Strategy:     StrategyRateLimitRequests,
-				OnThrottle:   OnThrottleError,
-				MetadataKeys: []string{"project_id"},
+				Rate:             100,
+				Burst:            200,
+				Strategy:         StrategyRateLimitRequests,
+				ThrottleBehavior: ThrottleBehaviorError,
+				MetadataKeys:     []string{"project_id"},
 			},
 		},
 		{
@@ -100,6 +100,10 @@ func TestLoadConfig(t *testing.T) {
 		{
 			name:        "invalid_strategy",
 			expectedErr: `invalid strategy "foo", expected one of ["requests" "records" "bytes"]`,
+		},
+		{
+			name:        "invalid_throttle_behavior",
+			expectedErr: `invalid throttle behavior "foo", expected one of ["error" "block"]`,
 		},
 		{
 			name:        "invalid_gubernator_behavior",

--- a/processor/ratelimitprocessor/config_test.go
+++ b/processor/ratelimitprocessor/config_test.go
@@ -103,7 +103,7 @@ func TestLoadConfig(t *testing.T) {
 		},
 		{
 			name:        "invalid_throttle_behavior",
-			expectedErr: `invalid throttle behavior "foo", expected one of ["error" "block"]`,
+			expectedErr: `invalid throttle behavior "foo", expected one of ["error" "delay"]`,
 		},
 		{
 			name:        "invalid_gubernator_behavior",

--- a/processor/ratelimitprocessor/gubernator.go
+++ b/processor/ratelimitprocessor/gubernator.go
@@ -115,7 +115,7 @@ func (r *gubernatorRateLimiter) RateLimit(ctx context.Context, hits int) error {
 	}
 
 	if isUnderLimit := resp.GetStatus() == gubernator.Status_UNDER_LIMIT; !isUnderLimit {
-		// TODO add configurable behaviour for returning an error vs. delaying processing.
+		// TODO support `throttle_behavior` config for returning an error vs. delaying processing.
 		r.set.Logger.Error(
 			"request is over the limits defined by the rate limiter",
 			zap.Error(errTooManyRequests),

--- a/processor/ratelimitprocessor/gubernator.go
+++ b/processor/ratelimitprocessor/gubernator.go
@@ -114,7 +114,7 @@ func (r *gubernatorRateLimiter) RateLimit(ctx context.Context, hits int) error {
 		return errors.New(resp.GetError())
 	}
 
-	if isUnderLimit := resp.GetStatus() == gubernator.Status_UNDER_LIMIT; !isUnderLimit {
+	if resp.GetStatus() != gubernator.Status_UNDER_LIMIT {
 		// Same logic as local
 		switch r.cfg.ThrottleBehavior {
 		case ThrottleBehaviorError:

--- a/processor/ratelimitprocessor/gubernator_test.go
+++ b/processor/ratelimitprocessor/gubernator_test.go
@@ -92,51 +92,59 @@ func TestGubernatorRateLimiter_StartStop(t *testing.T) {
 }
 
 func TestGubernatorRateLimiter_RateLimit(t *testing.T) {
-	server, rateLimiter := newTestGubernatorRateLimiter(t, &Config{Rate: 1, Burst: 2})
-	err := rateLimiter.Start(context.Background(), componenttest.NewNopHost())
-	require.NoError(t, err)
+	for _, behavior := range []ThrottleBehavior{ThrottleBehaviorError, ThrottleBehaviorDelay} {
+		t.Run(string(behavior), func(t *testing.T) {
+			server, rateLimiter := newTestGubernatorRateLimiter(t, &Config{Rate: 1, Burst: 2, ThrottleBehavior: behavior})
+			err := rateLimiter.Start(context.Background(), componenttest.NewNopHost())
+			require.NoError(t, err)
 
-	var resp gubernator.GetRateLimitsResp
-	var req *gubernator.GetRateLimitsReq
-	var respErr error
-	server.getRateLimits = func(ctx context.Context, reqIn *gubernator.GetRateLimitsReq) (*gubernator.GetRateLimitsResp, error) {
-		req = reqIn
-		return &resp, respErr
+			var resp gubernator.GetRateLimitsResp
+			var req *gubernator.GetRateLimitsReq
+			var respErr error
+			server.getRateLimits = func(ctx context.Context, reqIn *gubernator.GetRateLimitsReq) (*gubernator.GetRateLimitsResp, error) {
+				req = reqIn
+				return &resp, respErr
+			}
+
+			resp.Responses = []*gubernator.RateLimitResp{{Status: gubernator.Status_UNDER_LIMIT}}
+			err = rateLimiter.RateLimit(context.Background(), 1)
+			assert.NoError(t, err)
+			require.NotNil(t, req)
+			require.Len(t, req.Requests, 1)
+			// CreatedAt is based on time.Now(). Check it is not nil, then nil it out for the next assertion.
+			assert.NotNil(t, req.Requests[0].CreatedAt)
+			req.Requests[0].CreatedAt = nil
+			assert.Equal(t, &gubernator.RateLimitReq{
+				Name:      "ratelimit/abc123",
+				UniqueKey: "default",
+				Hits:      1,
+				Limit:     1,
+				Burst:     2,
+				Duration:  1000,
+				Algorithm: gubernator.Algorithm_LEAKY_BUCKET,
+			}, req.Requests[0])
+
+			resp.Responses = []*gubernator.RateLimitResp{{Error: "yeah, nah"}}
+			err = rateLimiter.RateLimit(context.Background(), 1)
+			assert.EqualError(t, err, "yeah, nah")
+
+			resp.Responses = []*gubernator.RateLimitResp{}
+			err = rateLimiter.RateLimit(context.Background(), 1)
+			assert.EqualError(t, err, "expected 1 response from gubernator, got 0")
+
+			resp.Responses = []*gubernator.RateLimitResp{{Status: gubernator.Status_OVER_LIMIT}}
+			err = rateLimiter.RateLimit(context.Background(), 1)
+			assert.EqualError(t, err, "too many requests")
+
+			resp.Responses = []*gubernator.RateLimitResp{{Status: -1}} // handled like OVER_LIMIT
+			err = rateLimiter.RateLimit(context.Background(), 1)
+			assert.EqualError(t, err, "too many requests")
+
+			respErr = errors.New("nope")
+			err = rateLimiter.RateLimit(context.Background(), 1)
+			assert.EqualError(t, err, "error executing gubernator rate limit request: rpc error: code = Unknown desc = nope")
+		})
 	}
-
-	resp.Responses = []*gubernator.RateLimitResp{{Status: gubernator.Status_UNDER_LIMIT}}
-	err = rateLimiter.RateLimit(context.Background(), 1)
-	assert.NoError(t, err)
-	require.NotNil(t, req)
-	assert.Equal(t, []*gubernator.RateLimitReq{{
-		Name:      "ratelimit/abc123",
-		UniqueKey: "default",
-		Hits:      1,
-		Limit:     1,
-		Burst:     2,
-		Duration:  1000,
-		Algorithm: gubernator.Algorithm_LEAKY_BUCKET,
-	}}, req.Requests)
-
-	resp.Responses = []*gubernator.RateLimitResp{{Error: "yeah, nah"}}
-	err = rateLimiter.RateLimit(context.Background(), 1)
-	assert.EqualError(t, err, "yeah, nah")
-
-	resp.Responses = []*gubernator.RateLimitResp{}
-	err = rateLimiter.RateLimit(context.Background(), 1)
-	assert.EqualError(t, err, "expected 1 response from gubernator, got 0")
-
-	resp.Responses = []*gubernator.RateLimitResp{{Status: gubernator.Status_OVER_LIMIT}}
-	err = rateLimiter.RateLimit(context.Background(), 1)
-	assert.EqualError(t, err, "too many requests")
-
-	resp.Responses = []*gubernator.RateLimitResp{{Status: -1}} // handled like OVER_LIMIT
-	err = rateLimiter.RateLimit(context.Background(), 1)
-	assert.EqualError(t, err, "too many requests")
-
-	respErr = errors.New("nope")
-	err = rateLimiter.RateLimit(context.Background(), 1)
-	assert.EqualError(t, err, "error executing gubernator rate limit request: rpc error: code = Unknown desc = nope")
 }
 
 func TestGubernatorRateLimiter_RateLimit_MetadataKeys(t *testing.T) {

--- a/processor/ratelimitprocessor/local.go
+++ b/processor/ratelimitprocessor/local.go
@@ -56,9 +56,17 @@ func (r *localRateLimiter) RateLimit(ctx context.Context, hits int) error {
 	key := getUniqueKey(ctx, r.cfg.MetadataKeys)
 	v, _ := r.limiters.LoadOrStore(key, rate.NewLimiter(rate.Limit(r.cfg.Rate), r.cfg.Burst))
 	limiter := v.(*rate.Limiter)
-	if ok := limiter.AllowN(time.Now(), hits); !ok {
-		// TODO add configurable behaviour for returning an error vs. delaying processing.
-		return errTooManyRequests
+	switch r.cfg.OnThrottle {
+	case OnThrottleError:
+		if ok := limiter.AllowN(time.Now(), hits); !ok {
+			return errTooManyRequests
+		}
+	case OnThrottleBlock:
+		r := limiter.ReserveN(time.Now(), hits)
+		if !r.OK() {
+			return errTooManyRequests
+		}
+		time.Sleep(r.Delay())
 	}
 	return nil
 }

--- a/processor/ratelimitprocessor/local.go
+++ b/processor/ratelimitprocessor/local.go
@@ -56,12 +56,12 @@ func (r *localRateLimiter) RateLimit(ctx context.Context, hits int) error {
 	key := getUniqueKey(ctx, r.cfg.MetadataKeys)
 	v, _ := r.limiters.LoadOrStore(key, rate.NewLimiter(rate.Limit(r.cfg.Rate), r.cfg.Burst))
 	limiter := v.(*rate.Limiter)
-	switch r.cfg.OnThrottle {
-	case OnThrottleError:
+	switch r.cfg.ThrottleBehavior {
+	case ThrottleBehaviorError:
 		if ok := limiter.AllowN(time.Now(), hits); !ok {
 			return errTooManyRequests
 		}
-	case OnThrottleBlock:
+	case ThrottleBehaviorBlock:
 		r := limiter.ReserveN(time.Now(), hits)
 		if !r.OK() {
 			return errTooManyRequests

--- a/processor/ratelimitprocessor/local.go
+++ b/processor/ratelimitprocessor/local.go
@@ -61,7 +61,7 @@ func (r *localRateLimiter) RateLimit(ctx context.Context, hits int) error {
 		if ok := limiter.AllowN(time.Now(), hits); !ok {
 			return errTooManyRequests
 		}
-	case ThrottleBehaviorBlock:
+	case ThrottleBehaviorDelay:
 		r := limiter.ReserveN(time.Now(), hits)
 		if !r.OK() {
 			return errTooManyRequests

--- a/processor/ratelimitprocessor/local_test.go
+++ b/processor/ratelimitprocessor/local_test.go
@@ -56,23 +56,34 @@ func TestLocalRateLimiter_StartStop(t *testing.T) {
 }
 
 func TestLocalRateLimiter_RateLimit(t *testing.T) {
-	burst := 2
-	rateLimiter := newTestLocalRateLimiter(t, &Config{Rate: 1, Burst: burst, ThrottleBehavior: ThrottleBehaviorError})
-	err := rateLimiter.Start(context.Background(), componenttest.NewNopHost())
-	require.NoError(t, err)
+	for _, behavior := range []ThrottleBehavior{ThrottleBehaviorError, ThrottleBehaviorDelay} {
+		t.Run(string(behavior), func(t *testing.T) {
+			burst := 2
+			rateLimiter := newTestLocalRateLimiter(t, &Config{Rate: 1, Burst: burst, ThrottleBehavior: behavior})
+			err := rateLimiter.Start(context.Background(), componenttest.NewNopHost())
+			require.NoError(t, err)
 
-	for i := 0; i < burst; i++ {
-		err = rateLimiter.RateLimit(context.Background(), 1) // should pass
-		assert.NoError(t, err)
+			startTime := time.Now()
+
+			for i := 0; i < burst; i++ {
+				err = rateLimiter.RateLimit(context.Background(), 1) // should pass
+				assert.NoError(t, err)
+			}
+
+			err = rateLimiter.RateLimit(context.Background(), 1) // should fail
+			switch behavior {
+			case ThrottleBehaviorError:
+				assert.EqualError(t, err, "too many requests")
+				// retry every 20ms to ensure that RateLimit will recover from error when bucket refills after 1 second
+				assert.Eventually(t, func() bool {
+					return rateLimiter.RateLimit(context.Background(), 1) == nil
+				}, 2*time.Second, 20*time.Millisecond)
+			case ThrottleBehaviorDelay:
+				assert.NoError(t, err)
+				assert.GreaterOrEqual(t, time.Now(), startTime.Add(time.Second))
+			}
+		})
 	}
-
-	err = rateLimiter.RateLimit(context.Background(), 1) // should fail
-	assert.EqualError(t, err, "too many requests")
-
-	// retry every 20ms to ensure that RateLimit will recover from error when bucket refills after 1 second
-	assert.Eventually(t, func() bool {
-		return rateLimiter.RateLimit(context.Background(), 1) == nil
-	}, 2*time.Second, 20*time.Millisecond)
 }
 
 func TestLocalRateLimiter_RateLimit_MetadataKeys(t *testing.T) {

--- a/processor/ratelimitprocessor/local_test.go
+++ b/processor/ratelimitprocessor/local_test.go
@@ -57,7 +57,7 @@ func TestLocalRateLimiter_StartStop(t *testing.T) {
 
 func TestLocalRateLimiter_RateLimit(t *testing.T) {
 	burst := 2
-	rateLimiter := newTestLocalRateLimiter(t, &Config{Rate: 1, Burst: burst})
+	rateLimiter := newTestLocalRateLimiter(t, &Config{Rate: 1, Burst: burst, OnThrottle: OnThrottleError})
 	err := rateLimiter.Start(context.Background(), componenttest.NewNopHost())
 	require.NoError(t, err)
 
@@ -81,6 +81,7 @@ func TestLocalRateLimiter_RateLimit_MetadataKeys(t *testing.T) {
 		Rate:         1,
 		Burst:        burst,
 		MetadataKeys: []string{"metadata_key"},
+		OnThrottle:   OnThrottleError,
 	})
 	err := rateLimiter.Start(context.Background(), componenttest.NewNopHost())
 	require.NoError(t, err)

--- a/processor/ratelimitprocessor/local_test.go
+++ b/processor/ratelimitprocessor/local_test.go
@@ -57,7 +57,7 @@ func TestLocalRateLimiter_StartStop(t *testing.T) {
 
 func TestLocalRateLimiter_RateLimit(t *testing.T) {
 	burst := 2
-	rateLimiter := newTestLocalRateLimiter(t, &Config{Rate: 1, Burst: burst, OnThrottle: OnThrottleError})
+	rateLimiter := newTestLocalRateLimiter(t, &Config{Rate: 1, Burst: burst, ThrottleBehavior: ThrottleBehaviorError})
 	err := rateLimiter.Start(context.Background(), componenttest.NewNopHost())
 	require.NoError(t, err)
 
@@ -78,10 +78,10 @@ func TestLocalRateLimiter_RateLimit(t *testing.T) {
 func TestLocalRateLimiter_RateLimit_MetadataKeys(t *testing.T) {
 	burst := 2
 	rateLimiter := newTestLocalRateLimiter(t, &Config{
-		Rate:         1,
-		Burst:        burst,
-		MetadataKeys: []string{"metadata_key"},
-		OnThrottle:   OnThrottleError,
+		Rate:             1,
+		Burst:            burst,
+		MetadataKeys:     []string{"metadata_key"},
+		ThrottleBehavior: ThrottleBehaviorError,
 	})
 	err := rateLimiter.Start(context.Background(), componenttest.NewNopHost())
 	require.NoError(t, err)

--- a/processor/ratelimitprocessor/processor_test.go
+++ b/processor/ratelimitprocessor/processor_test.go
@@ -104,7 +104,7 @@ func TestGetCountFunc_Profiles(t *testing.T) {
 }
 
 func TestConsume_Logs(t *testing.T) {
-	rateLimiter := newTestLocalRateLimiter(t, &Config{Rate: 1, Burst: 1})
+	rateLimiter := newTestLocalRateLimiter(t, &Config{Rate: 1, Burst: 1, OnThrottle: OnThrottleError})
 	err := rateLimiter.Start(context.Background(), componenttest.NewNopHost())
 	require.NoError(t, err)
 
@@ -135,7 +135,7 @@ func TestConsume_Logs(t *testing.T) {
 }
 
 func TestConsume_Metrics(t *testing.T) {
-	rateLimiter := newTestLocalRateLimiter(t, &Config{Rate: 1, Burst: 1})
+	rateLimiter := newTestLocalRateLimiter(t, &Config{Rate: 1, Burst: 1, OnThrottle: OnThrottleError})
 	err := rateLimiter.Start(context.Background(), componenttest.NewNopHost())
 	require.NoError(t, err)
 
@@ -166,7 +166,7 @@ func TestConsume_Metrics(t *testing.T) {
 }
 
 func TestConsume_Traces(t *testing.T) {
-	rateLimiter := newTestLocalRateLimiter(t, &Config{Rate: 1, Burst: 1})
+	rateLimiter := newTestLocalRateLimiter(t, &Config{Rate: 1, Burst: 1, OnThrottle: OnThrottleError})
 	err := rateLimiter.Start(context.Background(), componenttest.NewNopHost())
 	require.NoError(t, err)
 
@@ -197,7 +197,7 @@ func TestConsume_Traces(t *testing.T) {
 }
 
 func TestConsume_Profiles(t *testing.T) {
-	rateLimiter := newTestLocalRateLimiter(t, &Config{Rate: 1, Burst: 1})
+	rateLimiter := newTestLocalRateLimiter(t, &Config{Rate: 1, Burst: 1, OnThrottle: OnThrottleError})
 	err := rateLimiter.Start(context.Background(), componenttest.NewNopHost())
 	require.NoError(t, err)
 

--- a/processor/ratelimitprocessor/processor_test.go
+++ b/processor/ratelimitprocessor/processor_test.go
@@ -104,7 +104,7 @@ func TestGetCountFunc_Profiles(t *testing.T) {
 }
 
 func TestConsume_Logs(t *testing.T) {
-	rateLimiter := newTestLocalRateLimiter(t, &Config{Rate: 1, Burst: 1, OnThrottle: OnThrottleError})
+	rateLimiter := newTestLocalRateLimiter(t, &Config{Rate: 1, Burst: 1, ThrottleBehavior: ThrottleBehaviorError})
 	err := rateLimiter.Start(context.Background(), componenttest.NewNopHost())
 	require.NoError(t, err)
 
@@ -135,7 +135,7 @@ func TestConsume_Logs(t *testing.T) {
 }
 
 func TestConsume_Metrics(t *testing.T) {
-	rateLimiter := newTestLocalRateLimiter(t, &Config{Rate: 1, Burst: 1, OnThrottle: OnThrottleError})
+	rateLimiter := newTestLocalRateLimiter(t, &Config{Rate: 1, Burst: 1, ThrottleBehavior: ThrottleBehaviorError})
 	err := rateLimiter.Start(context.Background(), componenttest.NewNopHost())
 	require.NoError(t, err)
 
@@ -166,7 +166,7 @@ func TestConsume_Metrics(t *testing.T) {
 }
 
 func TestConsume_Traces(t *testing.T) {
-	rateLimiter := newTestLocalRateLimiter(t, &Config{Rate: 1, Burst: 1, OnThrottle: OnThrottleError})
+	rateLimiter := newTestLocalRateLimiter(t, &Config{Rate: 1, Burst: 1, ThrottleBehavior: ThrottleBehaviorError})
 	err := rateLimiter.Start(context.Background(), componenttest.NewNopHost())
 	require.NoError(t, err)
 
@@ -197,7 +197,7 @@ func TestConsume_Traces(t *testing.T) {
 }
 
 func TestConsume_Profiles(t *testing.T) {
-	rateLimiter := newTestLocalRateLimiter(t, &Config{Rate: 1, Burst: 1, OnThrottle: OnThrottleError})
+	rateLimiter := newTestLocalRateLimiter(t, &Config{Rate: 1, Burst: 1, ThrottleBehavior: ThrottleBehaviorError})
 	err := rateLimiter.Start(context.Background(), componenttest.NewNopHost())
 	require.NoError(t, err)
 

--- a/processor/ratelimitprocessor/testdata/config.yaml
+++ b/processor/ratelimitprocessor/testdata/config.yaml
@@ -41,6 +41,11 @@ ratelimit/invalid_strategy:
   burst: 1
   strategy: foo
 
+ratelimit/invalid_throttle_behavior:
+  rate: 1
+  burst: 1
+  throttle_behavior: foo
+
 ratelimit/invalid_gubernator_behavior:
   rate: 1
   burst: 1


### PR DESCRIPTION
Configurable behavior on rate limit exceeded via config `throttle_behavior`.
- `error`: original behavior, return error immediately without forwarding event
- `delay`: delayed processing
