### PR TITLE
ratelimitprocessor: make delays interruptible

### DIFF
--- a/processor/ratelimitprocessor/local.go
+++ b/processor/ratelimitprocessor/local.go
@@ -66,7 +66,13 @@ func (r *localRateLimiter) RateLimit(ctx context.Context, hits int) error {
 		if !r.OK() {
 			return errTooManyRequests
 		}
-		time.Sleep(r.Delay())
+		timer := time.NewTimer(r.Delay())
+		defer timer.Stop()
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-timer.C:
+		}
 	}
 	return nil
 }

--- a/processor/ratelimitprocessor/local_test.go
+++ b/processor/ratelimitprocessor/local_test.go
@@ -59,7 +59,9 @@ func TestLocalRateLimiter_RateLimit(t *testing.T) {
 	for _, behavior := range []ThrottleBehavior{ThrottleBehaviorError, ThrottleBehaviorDelay} {
 		t.Run(string(behavior), func(t *testing.T) {
 			burst := 2
-			rateLimiter := newTestLocalRateLimiter(t, &Config{Rate: 1, Burst: burst, ThrottleBehavior: behavior})
+			rateLimiter := newTestLocalRateLimiter(t, &Config{
+				Rate: 10, Burst: burst, ThrottleBehavior: behavior,
+			})
 			err := rateLimiter.Start(context.Background(), componenttest.NewNopHost())
 			require.NoError(t, err)
 
@@ -80,7 +82,7 @@ func TestLocalRateLimiter_RateLimit(t *testing.T) {
 				}, 2*time.Second, 20*time.Millisecond)
 			case ThrottleBehaviorDelay:
 				assert.NoError(t, err)
-				assert.GreaterOrEqual(t, time.Now(), startTime.Add(time.Second))
+				assert.GreaterOrEqual(t, time.Now(), startTime.Add(100*time.Millisecond))
 			}
 		})
 	}


### PR DESCRIPTION
Use select+timer rather than time.Sleep so
the delay is interrupted on context cancellation.

Also, speed up the local rate limiter delay
test from 1s to 100ms, to align with gubernator.