### PR TITLE
[processor/lsminterval]Introduce metric overflow limit

### DIFF
--- a/processor/lsmintervalprocessor/config/config.go
+++ b/processor/lsmintervalprocessor/config/config.go
@@ -18,7 +18,6 @@
 package config // import "github.com/elastic/opentelemetry-collector-components/processor/lsmintervalprocessor/config"
 
 import (
-	"errors"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
@@ -96,8 +95,5 @@ type Attribute struct {
 
 func (config *Config) Validate() error {
 	// TODO (lahsivjar): Add validation for interval duration
-	if len(config.MetricLimit.Overflow.Attributes) > 0 {
-		return errors.New("metric limit does not have overflow attributes")
-	}
 	return nil
 }

--- a/processor/lsmintervalprocessor/config/config.go
+++ b/processor/lsmintervalprocessor/config/config.go
@@ -18,6 +18,7 @@
 package config // import "github.com/elastic/opentelemetry-collector-components/processor/lsmintervalprocessor/config"
 
 import (
+	"errors"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
@@ -39,10 +40,11 @@ type Config struct {
 	// TODO (lahsivjar): Make specifying interval easier. We can just
 	// optimize the timer to run on differnt times and remove any
 	// restriction on different interval configuration.
-	Intervals           []IntervalConfig `mapstructure:"intervals"`
-	ResourceLimit       LimitConfig      `mapstructure:"resource_limit"`
-	ScopeLimit          LimitConfig      `mapstructure:"scope_limit"`
-	ScopeDatapointLimit LimitConfig      `mapstructure:"scope_datapoint_limit"`
+	Intervals      []IntervalConfig `mapstructure:"intervals"`
+	ResourceLimit  LimitConfig      `mapstructure:"resource_limit"`
+	ScopeLimit     LimitConfig      `mapstructure:"scope_limit"`
+	MetricLimit    LimitConfig      `mapstructure:"metric_limit"`
+	DatapointLimit LimitConfig      `mapstructure:"datapoint_limit"`
 }
 
 // PassThrough determines whether metrics should be passed through as they
@@ -94,5 +96,8 @@ type Attribute struct {
 
 func (config *Config) Validate() error {
 	// TODO (lahsivjar): Add validation for interval duration
+	if len(config.MetricLimit.Overflow.Attributes) > 0 {
+		return errors.New("metric limit does not have overflow attributes")
+	}
 	return nil
 }

--- a/processor/lsmintervalprocessor/internal/merger/datapoints.go
+++ b/processor/lsmintervalprocessor/internal/merger/datapoints.go
@@ -41,32 +41,30 @@ type dataPoint[Self any] interface {
 
 func mergeDataPoints[DPS dataPointSlice[DP], DP dataPoint[DP]](
 	from DPS,
-	toScope scopeMetrics,
 	toMetricID identity.Metric,
-	toMetric pmetric.Metric,
-	addDP func(scopeMetrics, identity.Metric, pmetric.Metric, DP) (DP, bool),
+	toMetric metric,
+	addDP func(identity.Metric, metric, DP) (DP, bool),
 	temporality pmetric.AggregationTemporality,
 ) {
 	switch temporality {
 	case pmetric.AggregationTemporalityCumulative:
-		mergeCumulative(from, toScope, toMetricID, toMetric, addDP)
+		mergeCumulative(from, toMetricID, toMetric, addDP)
 	case pmetric.AggregationTemporalityDelta:
-		mergeDelta(from, toScope, toMetricID, toMetric, addDP)
+		mergeDelta(from, toMetricID, toMetric, addDP)
 	}
 }
 
-type addDPFunc[DP dataPoint[DP]] func(scopeMetrics, identity.Metric, pmetric.Metric, DP) (DP, bool)
+type addDPFunc[DP dataPoint[DP]] func(identity.Metric, metric, DP) (DP, bool)
 
 func mergeCumulative[DPS dataPointSlice[DP], DP dataPoint[DP]](
 	from DPS,
-	toScope scopeMetrics,
 	toMetricID identity.Metric,
-	toMetric pmetric.Metric,
+	toMetric metric,
 	addDP addDPFunc[DP],
 ) {
 	for i := 0; i < from.Len(); i++ {
 		fromDP := from.At(i)
-		toDP, exists := addDP(toScope, toMetricID, toMetric, fromDP)
+		toDP, exists := addDP(toMetricID, toMetric, fromDP)
 		if exists && fromDP.Timestamp() > toDP.Timestamp() {
 			fromDP.CopyTo(toDP)
 		}
@@ -75,14 +73,13 @@ func mergeCumulative[DPS dataPointSlice[DP], DP dataPoint[DP]](
 
 func mergeDelta[DPS dataPointSlice[DP], DP dataPoint[DP]](
 	from DPS,
-	toScope scopeMetrics,
 	toMetricID identity.Metric,
-	toMetric pmetric.Metric,
+	toMetric metric,
 	addDP addDPFunc[DP],
 ) {
 	for i := 0; i < from.Len(); i++ {
 		fromDP := from.At(i)
-		if toDP, exists := addDP(toScope, toMetricID, toMetric, fromDP); exists {
+		if toDP, exists := addDP(toMetricID, toMetric, fromDP); exists {
 			switch fromDP := any(fromDP).(type) {
 			case pmetric.NumberDataPoint:
 				mergeDeltaSumDP(fromDP, any(toDP).(pmetric.NumberDataPoint))

--- a/processor/lsmintervalprocessor/internal/merger/datapoints.go
+++ b/processor/lsmintervalprocessor/internal/merger/datapoints.go
@@ -42,8 +42,8 @@ type dataPoint[Self any] interface {
 func mergeDataPoints[DPS dataPointSlice[DP], DP dataPoint[DP]](
 	from DPS,
 	toMetricID identity.Metric,
-	toMetric metric,
-	addDP func(identity.Metric, metric, DP) (DP, bool),
+	toMetric pdataMetric,
+	addDP func(identity.Metric, pdataMetric, DP) (DP, bool),
 	temporality pmetric.AggregationTemporality,
 ) {
 	switch temporality {
@@ -54,12 +54,12 @@ func mergeDataPoints[DPS dataPointSlice[DP], DP dataPoint[DP]](
 	}
 }
 
-type addDPFunc[DP dataPoint[DP]] func(identity.Metric, metric, DP) (DP, bool)
+type addDPFunc[DP dataPoint[DP]] func(identity.Metric, pdataMetric, DP) (DP, bool)
 
 func mergeCumulative[DPS dataPointSlice[DP], DP dataPoint[DP]](
 	from DPS,
 	toMetricID identity.Metric,
-	toMetric metric,
+	toMetric pdataMetric,
 	addDP addDPFunc[DP],
 ) {
 	for i := 0; i < from.Len(); i++ {
@@ -74,7 +74,7 @@ func mergeCumulative[DPS dataPointSlice[DP], DP dataPoint[DP]](
 func mergeDelta[DPS dataPointSlice[DP], DP dataPoint[DP]](
 	from DPS,
 	toMetricID identity.Metric,
-	toMetric metric,
+	toMetric pdataMetric,
 	addDP addDPFunc[DP],
 ) {
 	for i := 0; i < from.Len(); i++ {

--- a/processor/lsmintervalprocessor/internal/merger/limits/tracker.go
+++ b/processor/lsmintervalprocessor/internal/merger/limits/tracker.go
@@ -27,7 +27,7 @@ import (
 	"github.com/axiomhq/hyperloglog"
 )
 
-const version = uint8(2)
+const version = uint8(1)
 
 // Tracker tracks the configured limits while merging. It records the
 // observed count as well as the unique overflow counts.

--- a/processor/lsmintervalprocessor/internal/merger/limits/tracker_test.go
+++ b/processor/lsmintervalprocessor/internal/merger/limits/tracker_test.go
@@ -136,7 +136,7 @@ func TestTracker_Merge(t *testing.T) {
 
 func TestTrackers(t *testing.T) {
 	getTestTrackers := func() *Trackers {
-		return NewTrackers(1, 1, 1)
+		return NewTrackers(1, 1, 1, 1)
 	}
 	for _, tc := range []struct {
 		name     string
@@ -156,7 +156,10 @@ func TestTrackers(t *testing.T) {
 				ts := trackers.NewScopeTracker()
 				ts.CheckOverflow(testHash(0x00010fffffffffff).Hash)
 
-				tdps := trackers.NewScopeDPsTracker()
+				tm := trackers.NewMetricTracker()
+				tm.CheckOverflow(testHash(0x00010fffffffffff).Hash)
+
+				tdps := trackers.NewDatapointTracker()
 				tdps.CheckOverflow(testHash(0x00010fffffffffff).Hash)
 				return trackers
 			}(),
@@ -173,7 +176,11 @@ func TestTrackers(t *testing.T) {
 				ts.CheckOverflow(testHash(0x00010fffffffffff).Hash)
 				ts.CheckOverflow(testHash(0x00020fffffffffff).Hash) // will overflow
 
-				tdps := trackers.NewScopeDPsTracker()
+				tm := trackers.NewMetricTracker()
+				tm.CheckOverflow(testHash(0x00010fffffffffff).Hash)
+				tm.CheckOverflow(testHash(0x00020fffffffffff).Hash) // will overflow
+
+				tdps := trackers.NewDatapointTracker()
 				tdps.CheckOverflow(testHash(0x00010fffffffffff).Hash)
 				tdps.CheckOverflow(testHash(0x00020fffffffffff).Hash) // will overflow
 				return trackers
@@ -197,15 +204,24 @@ func TestTrackers(t *testing.T) {
 				ts3.CheckOverflow(testHash(0x00030fffffffffff).Hash) // will overflow
 				trackers.NewScopeTracker()                           // empty tracker
 
-				tdps1 := trackers.NewScopeDPsTracker()
+				tm1 := trackers.NewMetricTracker()
+				tm1.CheckOverflow(testHash(0x00010fffffffffff).Hash)
+				tm1.CheckOverflow(testHash(0x00020fffffffffff).Hash) // will overflow
+				tm1.CheckOverflow(testHash(0x00030fffffffffff).Hash) // will overflow
+				tm2 := trackers.NewMetricTracker()
+				tm2.CheckOverflow(testHash(0x00010fffffffffff).Hash)
+				tm3 := trackers.NewMetricTracker()
+				tm3.CheckOverflow(testHash(0x00030fffffffffff).Hash) // will overflow
+
+				tdps1 := trackers.NewDatapointTracker()
 				tdps1.CheckOverflow(testHash(0x00010fffffffffff).Hash)
 				tdps1.CheckOverflow(testHash(0x00020fffffffffff).Hash) // will overflow
 				tdps1.CheckOverflow(testHash(0x00030fffffffffff).Hash) // will overflow
-				tdps2 := trackers.NewScopeDPsTracker()
+				tdps2 := trackers.NewDatapointTracker()
 				tdps2.CheckOverflow(testHash(0x00040fffffffffff).Hash)
-				tdps3 := trackers.NewScopeDPsTracker()
+				tdps3 := trackers.NewDatapointTracker()
 				tdps3.CheckOverflow(testHash(0x00050fffffffffff).Hash)
-				tdps4 := trackers.NewScopeDPsTracker()
+				tdps4 := trackers.NewDatapointTracker()
 				tdps4.CheckOverflow(testHash(0x00050fffffffffff).Hash)
 				tdps4.CheckOverflow(testHash(0x00060fffffffffff).Hash) // will overflow
 				return trackers
@@ -227,7 +243,8 @@ func TestTrackers(t *testing.T) {
 				}
 			}
 			allEqual(tc.trackers.scope, newTrackers.scope)
-			allEqual(tc.trackers.scopeDPs, newTrackers.scopeDPs)
+			allEqual(tc.trackers.metric, newTrackers.metric)
+			allEqual(tc.trackers.datapoint, newTrackers.datapoint)
 		})
 	}
 }

--- a/processor/lsmintervalprocessor/internal/merger/merger.go
+++ b/processor/lsmintervalprocessor/internal/merger/merger.go
@@ -27,23 +27,33 @@ import (
 var _ pebble.ValueMerger = (*Merger)(nil)
 
 type Merger struct {
-	current          *Value
-	resourceLimitCfg config.LimitConfig
-	scopeLimitCfg    config.LimitConfig
-	scopeDPLimitCfg  config.LimitConfig
+	current           *Value
+	resourceLimitCfg  config.LimitConfig
+	scopeLimitCfg     config.LimitConfig
+	metricLimitCfg    config.LimitConfig
+	datapointLimitCfg config.LimitConfig
 }
 
-func New(v *Value, resLimit, scopeLimit, scopeDPLimit config.LimitConfig) *Merger {
+func New(
+	v *Value,
+	resLimit, scopeLimit, metricLimit, datapointLimit config.LimitConfig,
+) *Merger {
 	return &Merger{
-		current:          v,
-		resourceLimitCfg: resLimit,
-		scopeLimitCfg:    scopeLimit,
-		scopeDPLimitCfg:  scopeDPLimit,
+		current:           v,
+		resourceLimitCfg:  resLimit,
+		scopeLimitCfg:     scopeLimit,
+		metricLimitCfg:    metricLimit,
+		datapointLimitCfg: datapointLimit,
 	}
 }
 
 func (m *Merger) MergeNewer(value []byte) error {
-	op := NewValue(m.resourceLimitCfg, m.scopeLimitCfg, m.scopeDPLimitCfg)
+	op := NewValue(
+		m.resourceLimitCfg,
+		m.scopeLimitCfg,
+		m.metricLimitCfg,
+		m.datapointLimitCfg,
+	)
 	if err := op.Unmarshal(value); err != nil {
 		return err
 	}
@@ -51,7 +61,12 @@ func (m *Merger) MergeNewer(value []byte) error {
 }
 
 func (m *Merger) MergeOlder(value []byte) error {
-	op := NewValue(m.resourceLimitCfg, m.scopeLimitCfg, m.scopeDPLimitCfg)
+	op := NewValue(
+		m.resourceLimitCfg,
+		m.scopeLimitCfg,
+		m.metricLimitCfg,
+		m.datapointLimitCfg,
+	)
 	if err := op.Unmarshal(value); err != nil {
 		return err
 	}

--- a/processor/lsmintervalprocessor/internal/merger/value.go
+++ b/processor/lsmintervalprocessor/internal/merger/value.go
@@ -313,31 +313,6 @@ func (s *Value) Finalize() (pmetric.Metrics, error) {
 		}
 		overflowDP.SetIntValue(int64(m.datapointLimits.EstimateOverflow()))
 	}
-	// Remove any hanging metrics, scope, or resource which failed to have any
-	// entries due to datapoints overflowing. Overflowing datapoints discards
-	// that metric and creates a new overflow metric which might result in the
-	// original metric and its parent to exist without any datapoints.
-	s.source.ResourceMetrics().RemoveIf(func(rm pmetric.ResourceMetrics) bool {
-		rm.ScopeMetrics().RemoveIf(func(sm pmetric.ScopeMetrics) bool {
-			sm.Metrics().RemoveIf(func(m pmetric.Metric) bool {
-				switch m.Type() {
-				case pmetric.MetricTypeGauge:
-					return m.Gauge().DataPoints().Len() == 0
-				case pmetric.MetricTypeSum:
-					return m.Sum().DataPoints().Len() == 0
-				case pmetric.MetricTypeHistogram:
-					return m.Histogram().DataPoints().Len() == 0
-				case pmetric.MetricTypeExponentialHistogram:
-					return m.ExponentialHistogram().DataPoints().Len() == 0
-				case pmetric.MetricTypeSummary:
-					return m.Summary().DataPoints().Len() == 0
-				}
-				return false
-			})
-			return sm.Metrics().Len() == 0
-		})
-		return rm.ScopeMetrics().Len() == 0
-	})
 	return s.source, nil
 }
 

--- a/processor/lsmintervalprocessor/internal/merger/value_test.go
+++ b/processor/lsmintervalprocessor/internal/merger/value_test.go
@@ -41,32 +41,35 @@ var testCases = []string{
 
 func BenchmarkMerge(b *testing.B) {
 	for _, tc := range []struct {
-		name          string
-		resLimit      config.LimitConfig
-		scopeLimit    config.LimitConfig
-		scopeDPsLimit config.LimitConfig
+		name        string
+		resLimit    config.LimitConfig
+		scopeLimit  config.LimitConfig
+		metricLimit config.LimitConfig
+		dpLimit     config.LimitConfig
 	}{
 		{
-			name:          "without_overflow",
-			resLimit:      config.LimitConfig{MaxCardinality: math.MaxInt64},
-			scopeLimit:    config.LimitConfig{MaxCardinality: math.MaxInt64},
-			scopeDPsLimit: config.LimitConfig{MaxCardinality: math.MaxInt64},
+			name:        "without_overflow",
+			resLimit:    config.LimitConfig{MaxCardinality: math.MaxInt64},
+			scopeLimit:  config.LimitConfig{MaxCardinality: math.MaxInt64},
+			metricLimit: config.LimitConfig{MaxCardinality: math.MaxInt64},
+			dpLimit:     config.LimitConfig{MaxCardinality: math.MaxInt64},
 		},
 		{
-			name:          "with_overflow",
-			resLimit:      config.LimitConfig{MaxCardinality: 1},
-			scopeLimit:    config.LimitConfig{MaxCardinality: 1},
-			scopeDPsLimit: config.LimitConfig{MaxCardinality: 1},
+			name:        "with_overflow",
+			resLimit:    config.LimitConfig{MaxCardinality: 1},
+			scopeLimit:  config.LimitConfig{MaxCardinality: 1},
+			metricLimit: config.LimitConfig{MaxCardinality: 1},
+			dpLimit:     config.LimitConfig{MaxCardinality: 1},
 		},
 	} {
-		benchmarkWithTestdata(b, tc.name, tc.resLimit, tc.scopeLimit, tc.scopeDPsLimit)
+		benchmarkWithTestdata(b, tc.name, tc.resLimit, tc.scopeLimit, tc.metricLimit, tc.dpLimit)
 	}
 }
 
 func benchmarkWithTestdata(
 	b *testing.B,
 	name string,
-	resLimit, scopeLimit, scopeDPsLimit config.LimitConfig,
+	resLimit, scopeLimit, metricLimit, dpLimit config.LimitConfig,
 ) {
 	b.Helper()
 
@@ -79,8 +82,8 @@ func benchmarkWithTestdata(
 		b.Run(name+"/"+tc, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				b.StopTimer()
-				to := NewValue(resLimit, scopeLimit, scopeDPsLimit)
-				from := NewValue(resLimit, scopeLimit, scopeDPsLimit)
+				to := NewValue(resLimit, scopeLimit, metricLimit, dpLimit)
+				from := NewValue(resLimit, scopeLimit, metricLimit, dpLimit)
 				// Update from to have the pmetric structure
 				mdCopy := pmetric.NewMetrics()
 				md.CopyTo(mdCopy)

--- a/processor/lsmintervalprocessor/processor.go
+++ b/processor/lsmintervalprocessor/processor.go
@@ -102,7 +102,8 @@ func newProcessor(cfg *config.Config, ivlDefs []intervalDef, log *zap.Logger, ne
 				v := merger.NewValue(
 					cfg.ResourceLimit,
 					cfg.ScopeLimit,
-					cfg.ScopeDatapointLimit,
+					cfg.MetricLimit,
+					cfg.DatapointLimit,
 				)
 				if err := v.Unmarshal(value); err != nil {
 					return nil, fmt.Errorf("failed to unmarshal value from db: %w", err)
@@ -111,7 +112,8 @@ func newProcessor(cfg *config.Config, ivlDefs []intervalDef, log *zap.Logger, ne
 					v,
 					cfg.ResourceLimit,
 					cfg.ScopeLimit,
-					cfg.ScopeDatapointLimit,
+					cfg.MetricLimit,
+					cfg.DatapointLimit,
 				), nil
 			},
 		},
@@ -254,7 +256,8 @@ func (p *Processor) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) erro
 	v := merger.NewValue(
 		p.cfg.ResourceLimit,
 		p.cfg.ScopeLimit,
-		p.cfg.ScopeDatapointLimit,
+		p.cfg.MetricLimit,
+		p.cfg.DatapointLimit,
 	)
 	md.ResourceMetrics().RemoveIf(func(rm pmetric.ResourceMetrics) bool {
 		rm.ScopeMetrics().RemoveIf(func(sm pmetric.ScopeMetrics) bool {
@@ -418,7 +421,8 @@ func (p *Processor) exportForInterval(
 		v := merger.NewValue(
 			p.cfg.ResourceLimit,
 			p.cfg.ScopeLimit,
-			p.cfg.ScopeDatapointLimit,
+			p.cfg.MetricLimit,
+			p.cfg.DatapointLimit,
 		)
 		if err := v.Unmarshal(iter.Value()); err != nil {
 			errs = append(errs, fmt.Errorf("failed to decode binary from database: %w", err))

--- a/processor/lsmintervalprocessor/processor_test.go
+++ b/processor/lsmintervalprocessor/processor_test.go
@@ -113,9 +113,10 @@ func TestAggregationOverflow(t *testing.T) {
 					},
 				},
 			},
-			ResourceLimit:       oneCardinalityLimitConfig,
-			ScopeLimit:          oneCardinalityLimitConfig,
-			ScopeDatapointLimit: oneCardinalityLimitConfig,
+			ResourceLimit:  oneCardinalityLimitConfig,
+			ScopeLimit:     oneCardinalityLimitConfig,
+			MetricLimit:    oneCardinalityLimitConfig,
+			DatapointLimit: oneCardinalityLimitConfig,
 		}
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()

--- a/processor/lsmintervalprocessor/testdata/exphistogram_cumulative_overflow/input.yaml
+++ b/processor/lsmintervalprocessor/testdata/exphistogram_cumulative_overflow/input.yaml
@@ -53,6 +53,25 @@ resourceMetrics:
                     - key: aaa
                       value:
                         stringValue: bbb
+          - name: cumulative.exphistogram.test.1
+            exponentialHistogram:
+              aggregationTemporality: 2
+              dataPoints:
+                - timeUnixNano: 8000000
+                  scale: 4
+                  zeroCount: 2
+                  sum: 1.2
+                  count: 57
+                  positive:
+                    offset: 2
+                    bucketCounts: [1, 2, 9, 5, 22]
+                  negative:
+                    offset: 7
+                    bucketCounts: [5, 2, 7, 2]
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: ccc
           - name: cumulative.exphistogram.test.2
             exponentialHistogram:
               aggregationTemporality: 2

--- a/processor/lsmintervalprocessor/testdata/exphistogram_cumulative_overflow/output.yaml
+++ b/processor/lsmintervalprocessor/testdata/exphistogram_cumulative_overflow/output.yaml
@@ -41,8 +41,18 @@ resourceMetrics:
                   timeUnixNano: "7000000"
                   zeroCount: "2"
             name: cumulative.exphistogram.test.1
-          - description: Overflow count due to datapoints limit
-            name: _other
+          - description: Overflow metric count due to metric limit
+            name: _overflow_metric
+            sum:
+              aggregationTemporality: 1
+              dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: custom_dp_attr
+                      value:
+                        stringValue: dp
+          - description: Overflow datapoint count due to datapoint limit
+            name: _overflow_datapoints
             sum:
               aggregationTemporality: 1
               dataPoints:

--- a/processor/lsmintervalprocessor/testdata/exphistogram_cumulative_overflow/output.yaml
+++ b/processor/lsmintervalprocessor/testdata/exphistogram_cumulative_overflow/output.yaml
@@ -51,6 +51,9 @@ resourceMetrics:
                     - key: custom_dp_attr
                       value:
                         stringValue: dp
+                    - key: test_overflow
+                      value:
+                        boolValue: true
           - description: Overflow datapoint count due to datapoint limit
             name: _overflow_datapoints
             sum:

--- a/processor/lsmintervalprocessor/testdata/exphistogram_delta_overflow/input.yaml
+++ b/processor/lsmintervalprocessor/testdata/exphistogram_delta_overflow/input.yaml
@@ -53,6 +53,25 @@ resourceMetrics:
                     - key: aaa
                       value:
                         stringValue: bbb
+          - name: cumulative.exphistogram.test.1
+            exponentialHistogram:
+              aggregationTemporality: 1
+              dataPoints:
+                - timeUnixNano: 8000000
+                  scale: 4
+                  zeroCount: 2
+                  sum: 1.2
+                  count: 57
+                  positive:
+                    offset: 2
+                    bucketCounts: [1, 2, 9, 5, 22]
+                  negative:
+                    offset: 7
+                    bucketCounts: [5, 2, 7, 2]
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: ccc
           - name: cumulative.exphistogram.test.2
             exponentialHistogram:
               aggregationTemporality: 1

--- a/processor/lsmintervalprocessor/testdata/exphistogram_delta_overflow/output.yaml
+++ b/processor/lsmintervalprocessor/testdata/exphistogram_delta_overflow/output.yaml
@@ -52,6 +52,9 @@ resourceMetrics:
                     - key: custom_dp_attr
                       value:
                         stringValue: dp
+                    - key: test_overflow
+                      value:
+                        boolValue: true
           - description: Overflow datapoint count due to datapoint limit
             name: _overflow_datapoints
             sum:

--- a/processor/lsmintervalprocessor/testdata/exphistogram_delta_overflow/output.yaml
+++ b/processor/lsmintervalprocessor/testdata/exphistogram_delta_overflow/output.yaml
@@ -42,8 +42,18 @@ resourceMetrics:
                   timeUnixNano: "7000000"
                   zeroCount: "7"
             name: cumulative.exphistogram.test.1
-          - description: Overflow count due to datapoints limit
-            name: _other
+          - description: Overflow metric count due to metric limit
+            name: _overflow_metric
+            sum:
+              aggregationTemporality: 1
+              dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: custom_dp_attr
+                      value:
+                        stringValue: dp
+          - description: Overflow datapoint count due to datapoint limit
+            name: _overflow_datapoints
             sum:
               aggregationTemporality: 1
               dataPoints:

--- a/processor/lsmintervalprocessor/testdata/histogram_cumulative_overflow/input.yaml
+++ b/processor/lsmintervalprocessor/testdata/histogram_cumulative_overflow/input.yaml
@@ -41,6 +41,19 @@ resourceMetrics:
                     - key: aaa
                       value:
                         stringValue: bbb
+          - name: cumulative.histogram.test.1
+            histogram:
+              aggregationTemporality: 2
+              dataPoints:
+                - timeUnixNano: 8000000
+                  count: 36
+                  sum: 2010.23
+                  explicitBounds: [0.01, 0.1, 1, 10, 100]
+                  bucketCounts: [4, 2, 3, 6, 3, 18]
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: ccc
           - name: cumulative.histogram.test.2
             histogram:
               aggregationTemporality: 2

--- a/processor/lsmintervalprocessor/testdata/histogram_cumulative_overflow/output.yaml
+++ b/processor/lsmintervalprocessor/testdata/histogram_cumulative_overflow/output.yaml
@@ -47,6 +47,9 @@ resourceMetrics:
                     - key: custom_dp_attr
                       value:
                         stringValue: dp
+                    - key: test_overflow
+                      value:
+                        boolValue: true
           - description: Overflow datapoint count due to datapoint limit
             name: _overflow_datapoints
             sum:

--- a/processor/lsmintervalprocessor/testdata/histogram_cumulative_overflow/output.yaml
+++ b/processor/lsmintervalprocessor/testdata/histogram_cumulative_overflow/output.yaml
@@ -37,8 +37,18 @@ resourceMetrics:
                   sum: 2110
                   timeUnixNano: "7000000"
             name: cumulative.histogram.test.1
-          - description: Overflow count due to datapoints limit
-            name: _other
+          - description: Overflow metric count due to metric limit
+            name: _overflow_metric
+            sum:
+              aggregationTemporality: 1
+              dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: custom_dp_attr
+                      value:
+                        stringValue: dp
+          - description: Overflow datapoint count due to datapoint limit
+            name: _overflow_datapoints
             sum:
               aggregationTemporality: 1
               dataPoints:

--- a/processor/lsmintervalprocessor/testdata/histogram_delta_overflow/input.yaml
+++ b/processor/lsmintervalprocessor/testdata/histogram_delta_overflow/input.yaml
@@ -41,6 +41,19 @@ resourceMetrics:
                     - key: aaa
                       value:
                         stringValue: bbb
+          - name: delta.histogram.test.1
+            histogram:
+              aggregationTemporality: 1
+              dataPoints:
+                - timeUnixNano: 8000000
+                  count: 36
+                  sum: 2010.23
+                  explicitBounds: [0.01, 0.1, 1, 10, 100]
+                  bucketCounts: [4, 2, 3, 6, 3, 18]
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: ccc
           - name: delta.histogram.test.2
             histogram:
               aggregationTemporality: 1

--- a/processor/lsmintervalprocessor/testdata/histogram_delta_overflow/output.yaml
+++ b/processor/lsmintervalprocessor/testdata/histogram_delta_overflow/output.yaml
@@ -37,8 +37,18 @@ resourceMetrics:
                   sum: 4780
                   timeUnixNano: "7000000"
             name: delta.histogram.test.1
-          - description: Overflow count due to datapoints limit
-            name: _other
+          - description: Overflow metric count due to metric limit
+            name: _overflow_metric
+            sum:
+              aggregationTemporality: 1
+              dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: custom_dp_attr
+                      value:
+                        stringValue: dp
+          - description: Overflow datapoint count due to datapoint limit
+            name: _overflow_datapoints
             sum:
               aggregationTemporality: 1
               dataPoints:

--- a/processor/lsmintervalprocessor/testdata/histogram_delta_overflow/output.yaml
+++ b/processor/lsmintervalprocessor/testdata/histogram_delta_overflow/output.yaml
@@ -47,6 +47,9 @@ resourceMetrics:
                     - key: custom_dp_attr
                       value:
                         stringValue: dp
+                    - key: test_overflow
+                      value:
+                        boolValue: true
           - description: Overflow datapoint count due to datapoint limit
             name: _overflow_datapoints
             sum:

--- a/processor/lsmintervalprocessor/testdata/sum_cumulative_overflow/input.yaml
+++ b/processor/lsmintervalprocessor/testdata/sum_cumulative_overflow/input.yaml
@@ -37,6 +37,17 @@ resourceMetrics:
                     - key: aaa
                       value:
                         stringValue: bbb
+          - name: cumulative.monotonic.sum.1
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 8000000
+                  asDouble: 143
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: ccc
           - name: cumulative.monotonic.sum.2
             sum:
               aggregationTemporality: 2

--- a/processor/lsmintervalprocessor/testdata/sum_cumulative_overflow/output.yaml
+++ b/processor/lsmintervalprocessor/testdata/sum_cumulative_overflow/output.yaml
@@ -24,8 +24,18 @@ resourceMetrics:
                         stringValue: dp
                   timeUnixNano: "7000000"
               isMonotonic: true
-          - description: Overflow count due to datapoints limit
-            name: _other
+          - description: Overflow metric count due to metric limit
+            name: _overflow_metric
+            sum:
+              aggregationTemporality: 1
+              dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: custom_dp_attr
+                      value:
+                        stringValue: dp
+          - description: Overflow datapoint count due to datapoint limit
+            name: _overflow_datapoints
             sum:
               aggregationTemporality: 1
               dataPoints:

--- a/processor/lsmintervalprocessor/testdata/sum_cumulative_overflow/output.yaml
+++ b/processor/lsmintervalprocessor/testdata/sum_cumulative_overflow/output.yaml
@@ -34,6 +34,9 @@ resourceMetrics:
                     - key: custom_dp_attr
                       value:
                         stringValue: dp
+                    - key: test_overflow
+                      value:
+                        boolValue: true
           - description: Overflow datapoint count due to datapoint limit
             name: _overflow_datapoints
             sum:

--- a/processor/lsmintervalprocessor/testdata/sum_delta_overflow/input.yaml
+++ b/processor/lsmintervalprocessor/testdata/sum_delta_overflow/input.yaml
@@ -37,6 +37,17 @@ resourceMetrics:
                     - key: aaa
                       value:
                         stringValue: bbb
+          - name: delta.monotonic.sum.1
+            sum:
+              aggregationTemporality: 1
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 8000000
+                  asDouble: 143
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: ccc
           - name: delta.monotonic.sum.2
             sum:
               aggregationTemporality: 1

--- a/processor/lsmintervalprocessor/testdata/sum_delta_overflow/output.yaml
+++ b/processor/lsmintervalprocessor/testdata/sum_delta_overflow/output.yaml
@@ -34,6 +34,9 @@ resourceMetrics:
                     - key: custom_dp_attr
                       value:
                         stringValue: dp
+                    - key: test_overflow
+                      value:
+                        boolValue: true
           - description: Overflow datapoint count due to datapoint limit
             name: _overflow_datapoints
             sum:

--- a/processor/lsmintervalprocessor/testdata/sum_delta_overflow/output.yaml
+++ b/processor/lsmintervalprocessor/testdata/sum_delta_overflow/output.yaml
@@ -24,8 +24,18 @@ resourceMetrics:
                         stringValue: dp
                   timeUnixNano: "8000000"
               isMonotonic: true
-          - description: Overflow count due to datapoints limit
-            name: _other
+          - description: Overflow metric count due to metric limit
+            name: _overflow_metric
+            sum:
+              aggregationTemporality: 1
+              dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: custom_dp_attr
+                      value:
+                        stringValue: dp
+          - description: Overflow datapoint count due to datapoint limit
+            name: _overflow_datapoints
             sum:
               aggregationTemporality: 1
               dataPoints:


### PR DESCRIPTION
Introduces a metric overflow limit and removes the previous scope datapoint limit. Now, the limits follow the same hierarchy as the pmetric datastructure:

1. Resource limit
2. Scope limit
3. Metric limit
4. Datapoint limit

It is also possible to only set some of the limits, for example: if we only set datapoint limit then there will only be limit on the datapoint per metric and rest all will be without limit.

Closes: https://github.com/elastic/opentelemetry-collector-components/issues/141