### PR TITLE
Add client metadata to key

### DIFF
--- a/processor/lsmintervalprocessor/config/config.go
+++ b/processor/lsmintervalprocessor/config/config.go
@@ -18,6 +18,8 @@
 package config // import "github.com/elastic/opentelemetry-collector-components/processor/lsmintervalprocessor/config"
 
 import (
+	"fmt"
+	"strings"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
@@ -29,20 +31,36 @@ type Config struct {
 	// Directory is the data directory used by the database to store files.
 	// If the directory is empty in-memory storage is used.
 	Directory string `mapstructure:"directory"`
+
 	// PassThrough is a configuration that determines whether summary
 	// metrics should be passed through as they are or aggregated. This
 	// is because they lead to lossy aggregations.
 	PassThrough PassThrough `mapstructure:"pass_through"`
+
 	// Intervals is a list of interval configuration that the processor
 	// will aggregate over. The interval duration must be in increasing
 	// order and must be a factor of the smallest interval duration.
 	// TODO (lahsivjar): Make specifying interval easier. We can just
 	// optimize the timer to run on differnt times and remove any
 	// restriction on different interval configuration.
-	Intervals           []IntervalConfig `mapstructure:"intervals"`
-	ResourceLimit       LimitConfig      `mapstructure:"resource_limit"`
-	ScopeLimit          LimitConfig      `mapstructure:"scope_limit"`
-	ScopeDatapointLimit LimitConfig      `mapstructure:"scope_datapoint_limit"`
+	Intervals []IntervalConfig `mapstructure:"intervals"`
+
+	// MetadataKeys is a list of client.Metadata keys that will be
+	// used to form distinct instances of the processor.
+	//
+	// If this setting is empty, a single instance will be used.
+	// When this setting is not empty, one instance will be created
+	// per distinct combination of values for the listed metadata
+	// keys. Only the listed metadata keys will be propagated to
+	// the resulting metrics.
+	//
+	// Entries are case-insensitive. Duplicated entries will
+	// trigger a validation error.
+	MetadataKeys []string `mapstructure:"metadata_keys"`
+
+	ResourceLimit       LimitConfig `mapstructure:"resource_limit"`
+	ScopeLimit          LimitConfig `mapstructure:"scope_limit"`
+	ScopeDatapointLimit LimitConfig `mapstructure:"scope_datapoint_limit"`
 }
 
 // PassThrough determines whether metrics should be passed through as they
@@ -92,7 +110,15 @@ type Attribute struct {
 	Value any    `mapstructure:"value"`
 }
 
-func (config *Config) Validate() error {
+func (cfg *Config) Validate() error {
 	// TODO (lahsivjar): Add validation for interval duration
+	uniq := map[string]bool{}
+	for _, k := range cfg.MetadataKeys {
+		l := strings.ToLower(k)
+		if _, has := uniq[l]; has {
+			return fmt.Errorf("duplicate entry in metadata_keys: %q (case-insensitive)", l)
+		}
+		uniq[l] = true
+	}
 	return nil
 }

--- a/processor/lsmintervalprocessor/config/config.go
+++ b/processor/lsmintervalprocessor/config/config.go
@@ -46,13 +46,10 @@ type Config struct {
 	Intervals []IntervalConfig `mapstructure:"intervals"`
 
 	// MetadataKeys is a list of client.Metadata keys that will be
-	// used to form distinct instances of the processor.
+	// propagated through the metrics aggregated by the processor.
 	//
-	// If this setting is empty, a single instance will be used.
-	// When this setting is not empty, one instance will be created
-	// per distinct combination of values for the listed metadata
-	// keys. Only the listed metadata keys will be propagated to
-	// the resulting metrics.
+	// Only the listed metadata keys will be propagated to the
+	// resulting metrics.
 	//
 	// Entries are case-insensitive. Duplicated entries will
 	// trigger a validation error.

--- a/processor/lsmintervalprocessor/go.mod
+++ b/processor/lsmintervalprocessor/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.116.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.116.0
 	github.com/stretchr/testify v1.10.0
+	go.opentelemetry.io/collector/client v1.22.0
 	go.opentelemetry.io/collector/component v0.116.0
 	go.opentelemetry.io/collector/component/componenttest v0.116.0
 	go.opentelemetry.io/collector/confmap v1.22.0
@@ -19,6 +20,7 @@ require (
 	go.opentelemetry.io/collector/pdata v1.22.0
 	go.opentelemetry.io/collector/processor v0.116.0
 	go.opentelemetry.io/collector/processor/processortest v0.116.0
+	go.opentelemetry.io/otel v1.32.0
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
 )
@@ -81,7 +83,6 @@ require (
 	go.opentelemetry.io/collector/pipeline v0.116.0 // indirect
 	go.opentelemetry.io/collector/processor/xprocessor v0.116.0 // indirect
 	go.opentelemetry.io/collector/semconv v0.116.0 // indirect
-	go.opentelemetry.io/otel v1.32.0 // indirect
 	go.opentelemetry.io/otel/metric v1.32.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.32.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.32.0 // indirect

--- a/processor/lsmintervalprocessor/go.sum
+++ b/processor/lsmintervalprocessor/go.sum
@@ -140,6 +140,8 @@ github.com/ua-parser/uap-go v0.0.0-20240611065828-3a4781585db6/go.mod h1:BUbeWZi
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+go.opentelemetry.io/collector/client v1.22.0 h1:AAUzHuqYQqxoNqacw1WXgGF/MxtBTwNZuhBvJIorgA0=
+go.opentelemetry.io/collector/client v1.22.0/go.mod h1:wcCSdTwbDVNTycoqs7BiDNVj3e1Ta7EnWH2sAofKnEk=
 go.opentelemetry.io/collector/component v0.116.0 h1:SQE1YeVfYCN7bw1n4hknUwJE5U/1qJL552sDhAdSlaA=
 go.opentelemetry.io/collector/component v0.116.0/go.mod h1:MYgXFZWDTq0uPgF1mkLSFibtpNqksRVAOrmihckOQEs=
 go.opentelemetry.io/collector/component/componentstatus v0.116.0 h1:wpgY0H2K9IPBzaNAvavKziK86VZ7TuNFQbS9OC4Z6Cs=

--- a/processor/lsmintervalprocessor/processor.go
+++ b/processor/lsmintervalprocessor/processor.go
@@ -21,12 +21,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"sync"
 	"time"
 
 	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottldatapoint"
+	"go.opentelemetry.io/collector/client"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -74,7 +76,8 @@ const (
 )
 
 type Processor struct {
-	cfg *config.Config
+	cfg                *config.Config
+	sortedMetadataKeys []string
 
 	db      *pebble.DB
 	dataDir string
@@ -128,18 +131,22 @@ func newProcessor(cfg *config.Config, ivlDefs []intervalDef, log *zap.Logger, ne
 		dataDir = "/data" // will be created in the in-mem file-system
 	}
 
+	sortedMetadataKeys := append([]string{}, cfg.MetadataKeys...)
+	sort.Strings(sortedMetadataKeys)
+
 	ctx, cancel := context.WithCancel(context.Background())
 	return &Processor{
-		cfg:            cfg,
-		dataDir:        dataDir,
-		dbOpts:         dbOpts,
-		wOpts:          writeOpts,
-		intervals:      ivlDefs,
-		next:           next,
-		processingTime: time.Now().UTC().Truncate(ivlDefs[0].Duration),
-		ctx:            ctx,
-		cancel:         cancel,
-		logger:         log,
+		cfg:                cfg,
+		sortedMetadataKeys: sortedMetadataKeys,
+		dataDir:            dataDir,
+		dbOpts:             dbOpts,
+		wOpts:              writeOpts,
+		intervals:          ivlDefs,
+		next:               next,
+		processingTime:     time.Now().UTC().Truncate(ivlDefs[0].Duration),
+		ctx:                ctx,
+		cancel:             cancel,
+		logger:             log,
 	}, nil
 }
 
@@ -292,7 +299,18 @@ func (p *Processor) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) erro
 		return errors.Join(append(errs, fmt.Errorf("failed to marshal value to proto binary: %w", err))...)
 	}
 
-	if err := p.mergeToBatch(vb); err != nil {
+	clientInfo := client.FromContext(ctx)
+	clientMetadata := make([]merger.KeyValues, 0, len(p.sortedMetadataKeys))
+	for _, k := range p.sortedMetadataKeys {
+		if values := clientInfo.Metadata.Get(k); len(values) != 0 {
+			clientMetadata = append(clientMetadata, merger.KeyValues{
+				Key:    k,
+				Values: values,
+			})
+		}
+	}
+
+	if err := p.mergeToBatch(vb, clientMetadata); err != nil {
 		return fmt.Errorf("failed to merge the value to batch: %w", err)
 	}
 
@@ -307,26 +325,25 @@ func (p *Processor) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) erro
 	return nil
 }
 
-func (p *Processor) mergeToBatch(vb []byte) (err error) {
+func (p *Processor) mergeToBatch(vb []byte, clientMetadata []merger.KeyValues) (err error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-
-	keys := make([][]byte, len(p.intervals))
-	for i, ivl := range p.intervals {
-		// TODO (lahsivjar): If key ends up being independent of any other dimensions
-		// then we can simply cache the marshaled key while updating them on each harvest
-		key := merger.NewKey(ivl.Duration, p.processingTime)
-		keys[i], err = key.Marshal()
-		if err != nil {
-			return fmt.Errorf("failed to marshal key to binary for ivl %s: %w", ivl.Duration, err)
-		}
-	}
 
 	if p.batch == nil {
 		p.batch = newBatch(p.db)
 	}
 
-	for _, k := range keys {
+	var k []byte
+	for _, ivl := range p.intervals {
+		key := merger.Key{
+			Interval:       ivl.Duration,
+			ProcessingTime: p.processingTime,
+			Metadata:       clientMetadata,
+		}
+		k, err := key.AppendBinary(k[:0])
+		if err != nil {
+			return fmt.Errorf("failed to marshal key to binary for ivl %s: %w", ivl.Duration, err)
+		}
 		if err := p.batch.Merge(k, vb, nil); err != nil {
 			return fmt.Errorf("failed to merge to db: %w", err)
 		}
@@ -396,17 +413,20 @@ func (p *Processor) exportForInterval(
 	end time.Time,
 	ivl intervalDef,
 ) (int, error) {
-	from := merger.NewKey(ivl.Duration, zeroTime)
-	lb, err := from.Marshal()
+	var boundsBuffer []byte
+	from := merger.Key{Interval: ivl.Duration, ProcessingTime: zeroTime}
+	boundsBuffer, err := from.AppendBinary(nil)
 	if err != nil {
 		return 0, fmt.Errorf("failed to encode range: %w", err)
 	}
+	lb := boundsBuffer[:]
 
-	to := merger.NewKey(ivl.Duration, end)
-	ub, err := to.Marshal()
+	to := merger.Key{Interval: ivl.Duration, ProcessingTime: end}
+	boundsBuffer, err = to.AppendBinary(boundsBuffer)
 	if err != nil {
 		return 0, fmt.Errorf("failed to encode range: %w", err)
 	}
+	ub := boundsBuffer[len(lb):]
 
 	iter, err := snap.NewIter(&pebble.IterOptions{
 		LowerBound: lb,
@@ -426,8 +446,13 @@ func (p *Processor) exportForInterval(
 			p.cfg.ScopeLimit,
 			p.cfg.ScopeDatapointLimit,
 		)
+		var key merger.Key
+		if err := key.Unmarshal(iter.Key()); err != nil {
+			errs = append(errs, fmt.Errorf("failed to decode key from database: %w", err))
+			continue
+		}
 		if err := v.Unmarshal(iter.Value()); err != nil {
-			errs = append(errs, fmt.Errorf("failed to decode binary from database: %w", err))
+			errs = append(errs, fmt.Errorf("failed to decode value from database: %w", err))
 			continue
 		}
 		finalMetrics, err := v.Finalize()
@@ -483,6 +508,15 @@ func (p *Processor) exportForInterval(
 					}
 				}
 			}
+		}
+		if n := len(key.Metadata); n != 0 {
+			metadataMap := make(map[string][]string, n)
+			for _, kvs := range key.Metadata {
+				metadataMap[kvs.Key] = kvs.Values
+			}
+			info := client.FromContext(ctx)
+			info.Metadata = client.NewMetadata(metadataMap)
+			ctx = client.NewContext(ctx, info)
 		}
 		if err := p.next.ConsumeMetrics(ctx, finalMetrics); err != nil {
 			errs = append(errs, fmt.Errorf("failed to consume the decoded value: %w", err))

--- a/processor/lsmintervalprocessor/processor_test.go
+++ b/processor/lsmintervalprocessor/processor_test.go
@@ -27,10 +27,14 @@ import (
 	"github.com/elastic/opentelemetry-collector-components/processor/lsmintervalprocessor/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/client"
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/processor"
 	"go.opentelemetry.io/collector/processor/processortest"
+	"go.opentelemetry.io/otel/attribute"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest"
@@ -130,26 +134,13 @@ func testRunHelper(t *testing.T, name string, config *config.Config) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	next := &consumertest.MetricsSink{}
-
-	factory := NewFactory()
-	settings := processortest.NewNopSettings()
-	settings.TelemetrySettings.Logger = zaptest.NewLogger(t, zaptest.Level(zapcore.DebugLevel))
-	mgp, err := factory.CreateMetrics(
-		context.Background(),
-		settings,
-		config,
-		next,
-	)
-	require.NoError(t, err)
-	require.IsType(t, &Processor{}, mgp)
-	t.Cleanup(func() { require.NoError(t, mgp.Shutdown(context.Background())) })
-
 	dir := filepath.Join("testdata", name)
 	md, err := golden.ReadMetrics(filepath.Join(dir, "input.yaml"))
 	require.NoError(t, err)
 
 	// Start the processor and feed the metrics
+	next := &consumertest.MetricsSink{}
+	mgp := newTestProcessor(t, config, next)
 	err = mgp.Start(context.Background(), componenttest.NewNopHost())
 	require.NoError(t, err)
 	err = mgp.ConsumeMetrics(ctx, md)
@@ -169,6 +160,134 @@ func testRunHelper(t *testing.T, name string, config *config.Config) {
 	expectedExportData, err := golden.ReadMetrics(filepath.Join(dir, "output.yaml"))
 	require.NoError(t, err)
 	assert.NoError(t, pmetrictest.CompareMetrics(expectedExportData, allMetrics[1]))
+}
+
+func newTestProcessor(t testing.TB, cfg *config.Config, next consumer.Metrics) processor.Metrics {
+	factory := NewFactory()
+	settings := processortest.NewNopSettings()
+	settings.TelemetrySettings.Logger = zaptest.NewLogger(t, zaptest.Level(zapcore.DebugLevel))
+	mgp, err := factory.CreateMetrics(context.Background(), settings, cfg, next)
+	require.NoError(t, err)
+	require.IsType(t, &Processor{}, mgp)
+	t.Cleanup(func() { require.NoError(t, mgp.Shutdown(context.Background())) })
+	return mgp
+}
+
+func TestClientMetadata(t *testing.T) {
+	cfg := &config.Config{
+		MetadataKeys: []string{"k1", "k2"},
+		Intervals: []config.IntervalConfig{{
+			Duration: time.Minute,
+		}},
+	}
+
+	// N is the number of times to send each delta data point,
+	// and the expected aggregated value.
+	const N = 10
+
+	received := make(map[attribute.Set]int64)
+	next, _ := consumer.NewMetrics(consumer.ConsumeMetricsFunc(
+		func(ctx context.Context, metrics pmetric.Metrics) error {
+			if metrics.MetricCount() == 0 {
+				// This is the original input, with
+				// pending aggregated metrics removed.
+				return nil
+			}
+			info := client.FromContext(ctx)
+
+			// k3 should never be in the metadata even if it's in
+			// the original input, as it's not a configured key
+			// in the processor.
+			require.Nil(t, info.Metadata.Get("k3"))
+
+			var kvs []attribute.KeyValue
+			for _, k := range cfg.MetadataKeys {
+				vs := info.Metadata.Get(k)
+				if vs == nil {
+					continue
+				}
+				kvs = append(kvs, attribute.StringSlice(k, vs))
+			}
+			attrs := attribute.NewSet(kvs...)
+
+			require.Equal(t, 1, metrics.MetricCount())
+			metric := metrics.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0)
+			dp := metric.Sum().DataPoints().At(0)
+			received[attrs] = dp.IntValue()
+			return nil
+		},
+	))
+	p := newTestProcessor(t, cfg, next)
+	err := p.Start(context.Background(), componenttest.NewNopHost())
+	require.NoError(t, err)
+
+	metadataCombinations := []map[string][]string{
+		{}, // no metadata
+		{
+			"k3": []string{"ignored"},
+		},
+		{
+			"k1": []string{"v1"},
+		},
+		{
+			"k1": []string{"v2"},
+		},
+		{
+			"k2": []string{"v1"},
+		},
+		{
+			"k2": []string{"v1", "v2"},
+		},
+		{
+			"k1": []string{"v1"},
+			"k2": []string{"v1"},
+			"k3": []string{"ignored"},
+		},
+	}
+
+	expected := map[attribute.Set]int64{
+		// We should have aggregated the metrics with no metadata
+		// and with only ignored metadata together.
+		attribute.NewSet( /*empty*/ ): 20,
+
+		attribute.NewSet(attribute.StringSlice("k1", []string{"v1"})):       10,
+		attribute.NewSet(attribute.StringSlice("k1", []string{"v2"})):       10,
+		attribute.NewSet(attribute.StringSlice("k2", []string{"v1"})):       10,
+		attribute.NewSet(attribute.StringSlice("k2", []string{"v1", "v2"})): 10,
+		attribute.NewSet(
+			attribute.StringSlice("k1", []string{"v1"}),
+			attribute.StringSlice("k2", []string{"v1"}),
+			// k3 should have been dropped
+		): 10,
+	}
+
+	// Create a single metric data point to aggregate per combination of client metadata.
+	for _, metadata := range metadataCombinations {
+		info := client.Info{Metadata: client.NewMetadata(metadata)}
+		ctx := client.NewContext(context.Background(), info)
+
+		for i := 0; i < N; i++ {
+			// We must create a new pmetric.Metrics per iteration because
+			// p.ConsumeMetrics is mutating.
+			metrics := pmetric.NewMetrics()
+			rm := metrics.ResourceMetrics().AppendEmpty()
+			sm := rm.ScopeMetrics().AppendEmpty()
+			m := sm.Metrics().AppendEmpty()
+			m.SetName("metric_name")
+			sum := m.SetEmptySum()
+			sum.SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
+			sum.DataPoints().AppendEmpty().SetIntValue(1)
+
+			err = p.ConsumeMetrics(ctx, metrics)
+			require.NoError(t, err)
+		}
+	}
+
+	// Shutdown forces all consumed data to be immediately finalised.
+	err = p.Shutdown(context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, expected, received)
 }
 
 func BenchmarkAggregation(b *testing.B) {


### PR DESCRIPTION
This enables persisting client metadata from the incoming metrics, through aggregation, and into the produced metrics.

CPU overhead in the case where there's no metadata is within margin of error. Slight reduction in allocs because we're now using an AppendBinary method for marshalling keys.

```
goos: linux
goarch: amd64
pkg: github.com/elastic/opentelemetry-collector-components/processor/lsmintervalprocessor
cpu: AMD Ryzen 7 PRO 5850U with Radeon Graphics     
                                               │ /tmp/old.txt │            /tmp/new.txt             │
                                               │    sec/op    │    sec/op     vs base               │
Aggregation/sum_cumulative-16                    18.99µ ±  7%   18.24µ ± 14%        ~ (p=0.485 n=6)
Aggregation/sum_delta-16                         19.01µ ±  5%   19.05µ ±  9%        ~ (p=0.818 n=6)
Aggregation/histogram_cumulative-16              21.92µ ±  4%   21.99µ ± 13%        ~ (p=0.937 n=6)
Aggregation/histogram_delta-16                   20.55µ ± 10%   20.99µ ±  6%        ~ (p=0.589 n=6)
Aggregation/exphistogram_cumulative-16           22.54µ ± 11%   20.80µ ±  6%   -7.69% (p=0.009 n=6)
Aggregation/exphistogram_delta-16                21.25µ ± 16%   22.79µ ± 11%        ~ (p=0.180 n=6)
Aggregation/summary_enabled-16                   19.92µ ±  6%   21.11µ ± 11%   +5.97% (p=0.041 n=6)
Aggregation/summary_passthrough-16               2.279µ ± 11%   2.448µ ± 12%        ~ (p=0.143 n=6)
AggregationWithOTTL/sum_cumulative-16            21.78µ ±  3%   20.95µ ± 12%        ~ (p=0.394 n=6)
AggregationWithOTTL/sum_delta-16                 23.72µ ±  6%   23.13µ ±  7%        ~ (p=0.589 n=6)
AggregationWithOTTL/histogram_cumulative-16      24.46µ ± 12%   23.86µ ±  4%   -2.46% (p=0.041 n=6)
AggregationWithOTTL/histogram_delta-16           23.18µ ± 11%   25.56µ ±  7%        ~ (p=0.065 n=6)
AggregationWithOTTL/exphistogram_cumulative-16   21.72µ ±  3%   24.11µ ±  8%  +10.99% (p=0.004 n=6)
AggregationWithOTTL/exphistogram_delta-16        22.22µ ±  2%   24.25µ ±  9%   +9.13% (p=0.009 n=6)
AggregationWithOTTL/summary_enabled-16           22.54µ ±  7%   22.20µ ± 11%        ~ (p=0.818 n=6)
AggregationWithOTTL/summary_passthrough-16       2.266µ ±  6%   2.310µ ±  9%        ~ (p=0.143 n=6)
geomean                                          16.33µ         16.65µ         +1.95%

                                               │ /tmp/old.txt │            /tmp/new.txt            │
                                               │     B/op     │     B/op      vs base              │
Aggregation/sum_cumulative-16                    13.49Ki ± 6%   13.49Ki ± 9%       ~ (p=0.818 n=6)
Aggregation/sum_delta-16                         13.54Ki ± 8%   13.56Ki ± 2%       ~ (p=0.937 n=6)
Aggregation/histogram_cumulative-16              15.89Ki ± 3%   15.75Ki ± 2%       ~ (p=0.132 n=6)
Aggregation/histogram_delta-16                   15.81Ki ± 2%   15.70Ki ± 2%       ~ (p=0.699 n=6)
Aggregation/exphistogram_cumulative-16           16.02Ki ± 6%   15.84Ki ± 2%       ~ (p=0.132 n=6)
Aggregation/exphistogram_delta-16                15.97Ki ± 4%   15.95Ki ± 6%       ~ (p=0.818 n=6)
Aggregation/summary_enabled-16                   13.95Ki ± 1%   13.99Ki ± 5%       ~ (p=0.589 n=6)
Aggregation/summary_passthrough-16               1.305Ki ± 1%   1.286Ki ± 1%  -1.42% (p=0.002 n=6)
AggregationWithOTTL/sum_cumulative-16            15.86Ki ± 2%   15.60Ki ± 5%       ~ (p=0.143 n=6)
AggregationWithOTTL/sum_delta-16                 16.20Ki ± 2%   16.06Ki ± 4%       ~ (p=0.937 n=6)
AggregationWithOTTL/histogram_cumulative-16      18.27Ki ± 3%   18.05Ki ± 3%       ~ (p=0.310 n=6)
AggregationWithOTTL/histogram_delta-16           18.04Ki ± 2%   18.31Ki ± 2%       ~ (p=0.093 n=6)
AggregationWithOTTL/exphistogram_cumulative-16   18.01Ki ± 1%   18.38Ki ± 3%  +2.03% (p=0.026 n=6)
AggregationWithOTTL/exphistogram_delta-16        18.18Ki ± 1%   18.43Ki ± 8%       ~ (p=0.394 n=6)
AggregationWithOTTL/summary_enabled-16           16.27Ki ± 3%   16.12Ki ± 7%       ~ (p=0.180 n=6)
AggregationWithOTTL/summary_passthrough-16       1.309Ki ± 1%   1.280Ki ± 1%  -2.24% (p=0.002 n=6)
geomean                                          11.72Ki        11.67Ki       -0.36%

                                               │ /tmp/old.txt │           /tmp/new.txt           │
                                               │  allocs/op   │ allocs/op   vs base              │
Aggregation/sum_cumulative-16                      147.0 ± 0%   146.0 ± 0%  -0.68% (p=0.002 n=6)
Aggregation/sum_delta-16                           148.0 ± 0%   147.0 ± 0%  -0.68% (p=0.002 n=6)
Aggregation/histogram_cumulative-16                161.0 ± 0%   160.0 ± 0%  -0.62% (p=0.002 n=6)
Aggregation/histogram_delta-16                     162.0 ± 0%   161.0 ± 0%  -0.62% (p=0.002 n=6)
Aggregation/exphistogram_cumulative-16             165.0 ± 0%   164.0 ± 0%  -0.61% (p=0.002 n=6)
Aggregation/exphistogram_delta-16                  166.0 ± 0%   165.0 ± 0%  -0.60% (p=0.002 n=6)
Aggregation/summary_enabled-16                     156.0 ± 0%   155.0 ± 0%  -0.64% (p=0.002 n=6)
Aggregation/summary_passthrough-16                 35.00 ± 0%   34.00 ± 0%  -2.86% (p=0.002 n=6)
AggregationWithOTTL/sum_cumulative-16              174.0 ± 0%   173.0 ± 0%  -0.57% (p=0.002 n=6)
AggregationWithOTTL/sum_delta-16                   175.0 ± 0%   174.0 ± 0%  -0.57% (p=0.002 n=6)
AggregationWithOTTL/histogram_cumulative-16        188.0 ± 0%   187.0 ± 0%  -0.53% (p=0.002 n=6)
AggregationWithOTTL/histogram_delta-16             189.0 ± 0%   188.0 ± 0%  -0.53% (p=0.002 n=6)
AggregationWithOTTL/exphistogram_cumulative-16     192.0 ± 0%   191.0 ± 0%  -0.52% (p=0.002 n=6)
AggregationWithOTTL/exphistogram_delta-16          193.0 ± 0%   192.0 ± 0%  -0.52% (p=0.002 n=6)
AggregationWithOTTL/summary_enabled-16             183.0 ± 0%   182.0 ± 0%  -0.55% (p=0.002 n=6)
AggregationWithOTTL/summary_passthrough-16         35.00 ± 0%   34.00 ± 0%  -2.86% (p=0.002 n=6)
geomean                                            140.0        138.8       -0.87%
```