### PR TITLE
[receiver/loadgen] Benchmark generators

### DIFF
--- a/receiver/loadgenreceiver/logs_bench_test.go
+++ b/receiver/loadgenreceiver/logs_bench_test.go
@@ -29,11 +29,11 @@ import (
 	"go.uber.org/zap"
 )
 
-func BenchmarkTracesGenerator(b *testing.B) {
+func BenchmarkLogsGenerator(b *testing.B) {
 	doneCh := make(chan Stats)
-	cfg := createDefaultReceiverConfig(nil, nil, doneCh)
-	cfg.(*Config).Traces.MaxReplay = b.N
-	r, _ := createTracesReceiver(context.Background(), receiver.Settings{
+	cfg := createDefaultReceiverConfig(doneCh, nil, nil)
+	cfg.(*Config).Logs.MaxReplay = b.N
+	r, _ := createLogsReceiver(context.Background(), receiver.Settings{
 		ID: component.ID{},
 		TelemetrySettings: component.TelemetrySettings{
 			Logger: zap.NewNop(),

--- a/receiver/loadgenreceiver/metrics_bench_test.go
+++ b/receiver/loadgenreceiver/metrics_bench_test.go
@@ -29,11 +29,11 @@ import (
 	"go.uber.org/zap"
 )
 
-func BenchmarkTracesGenerator(b *testing.B) {
+func BenchmarkMetricsGenerator(b *testing.B) {
 	doneCh := make(chan Stats)
-	cfg := createDefaultReceiverConfig(nil, nil, doneCh)
-	cfg.(*Config).Traces.MaxReplay = b.N
-	r, _ := createTracesReceiver(context.Background(), receiver.Settings{
+	cfg := createDefaultReceiverConfig(nil, doneCh, nil)
+	cfg.(*Config).Metrics.MaxReplay = b.N
+	r, _ := createMetricsReceiver(context.Background(), receiver.Settings{
 		ID: component.ID{},
 		TelemetrySettings: component.TelemetrySettings{
 			Logger: zap.NewNop(),

--- a/receiver/loadgenreceiver/traces_bench_test.go
+++ b/receiver/loadgenreceiver/traces_bench_test.go
@@ -1,0 +1,52 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package loadgenreceiver // import "github.com/elastic/opentelemetry-collector-components/receiver/loadgenreceiver"
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/receiver"
+	"go.uber.org/zap"
+)
+
+func BenchmarkTracesGenerator(b *testing.B) {
+	doneCh := make(chan Stats)
+	sink := &consumertest.TracesSink{}
+	cfg := createDefaultReceiverConfig(nil, nil, doneCh)
+	cfg.(*Config).Traces.MaxReplay = b.N
+	r, _ := createTracesReceiver(context.Background(), receiver.Settings{
+		ID: component.ID{},
+		TelemetrySettings: component.TelemetrySettings{
+			Logger: zap.NewNop(),
+		},
+		BuildInfo: component.BuildInfo{},
+	}, cfg, sink)
+	b.ResetTimer()
+	err := r.Start(context.Background(), componenttest.NewNopHost())
+	require.NoError(b, err)
+	defer func() {
+		err := r.Shutdown(context.Background())
+		require.NoError(b, err)
+	}()
+	<-doneCh
+}


### PR DESCRIPTION
Add benchmarks to facilitate upcoming loadgenreceiver performance improvements

Output
```
goos: linux
goarch: amd64
pkg: github.com/elastic/opentelemetry-collector-components/receiver/loadgenreceiver
cpu: 11th Gen Intel(R) Core(TM) i7-11800H @ 2.30GHz
BenchmarkLogsGenerator-16                   1453            820531 ns/op          541745 B/op       6447 allocs/op
BenchmarkMetricsGenerator-16                 663           1744985 ns/op         1418378 B/op      17053 allocs/op
BenchmarkTracesGenerator-16                  187           6486743 ns/op         7378511 B/op      29728 allocs/op
PASS
ok      github.com/elastic/opentelemetry-collector-components/receiver/loadgenreceiver  5.067s
```