### PR TITLE
[otelbench] Add concurrency flag to simulate multiple agents

### DIFF
--- a/loadgen/cmd/otelbench/README.md
+++ b/loadgen/cmd/otelbench/README.md
@@ -4,6 +4,7 @@ otelbench wraps the collector inside a Go test benchmark. It outputs throughput 
 
 ## Usage
 
+// FIXME
 ```
 Usage of ./otelbench:
   -api-key string

--- a/loadgen/cmd/otelbench/README.md
+++ b/loadgen/cmd/otelbench/README.md
@@ -4,11 +4,12 @@ otelbench wraps the collector inside a Go test benchmark. It outputs throughput 
 
 ## Usage
 
-// FIXME
 ```
 Usage of ./otelbench:
   -api-key string
         API key for target server
+  -concurrency list
+        comma-separated list of concurrency (number of simulated agents) to run each benchmark with
   -config string
         path to collector config yaml (default "config.yaml")
   -endpoint value

--- a/loadgen/cmd/otelbench/flags.go
+++ b/loadgen/cmd/otelbench/flags.go
@@ -42,6 +42,8 @@ var Config struct {
 
 	ExporterOTLP     bool
 	ExporterOTLPHTTP bool
+
+	Concurrency int
 }
 
 func Init() error {
@@ -103,6 +105,10 @@ func Init() error {
 	flag.BoolVar(&Config.Logs, "logs", true, "benchmark logs")
 	flag.BoolVar(&Config.Metrics, "metrics", true, "benchmark metrics")
 	flag.BoolVar(&Config.Traces, "traces", true, "benchmark traces")
+
+	// Similar to `agents` config in apmbench
+	// The value will be used as loadgenreceiver `concurrency` config
+	flag.IntVar(&Config.Concurrency, "concurrency", 1, "amount of concurrency, or number of agents simulated")
 
 	// For configs that can be set via environment variables, set the required
 	// flags from env if they are not explicitly provided via command line
@@ -203,5 +209,11 @@ func SetIterations(iterations int) (configFiles []string) {
 		fmt.Sprintf("receivers.loadgen.logs.max_replay=%d", iterations),
 		fmt.Sprintf("receivers.loadgen.metrics.max_replay=%d", iterations),
 		fmt.Sprintf("receivers.loadgen.traces.max_replay=%d", iterations),
+	})
+}
+
+func SetConcurrency(concurrency int) (configFiles []string) {
+	return setsToConfigs([]string{
+		fmt.Sprintf("receivers.loadgen.concurrency=%d", concurrency),
 	})
 }

--- a/loadgen/cmd/otelbench/main.go
+++ b/loadgen/cmd/otelbench/main.go
@@ -68,61 +68,65 @@ func main() {
 	// TODO(carsonip): configurable warm up
 
 	var maxLen int
-	for _, signal := range getSignals() {
-		for _, exporter := range getExporters() {
-			maxLen = max(maxLen, len(fullBenchmarkName(signal, exporter, Config.Concurrency)))
+	for _, concurrency := range Config.ConcurrencyList {
+		for _, signal := range getSignals() {
+			for _, exporter := range getExporters() {
+				maxLen = max(maxLen, len(fullBenchmarkName(signal, exporter, concurrency)))
+			}
 		}
 	}
 
-	for _, signal := range getSignals() {
-		for _, exporter := range getExporters() {
-			benchName := fullBenchmarkName(signal, exporter, Config.Concurrency)
-			result := testing.Benchmark(func(b *testing.B) {
-				// loadgenreceiver will send stats about generated telemetry when it finishes sending b.N iterations
-				logsDone := make(chan loadgenreceiver.Stats)
-				metricsDone := make(chan loadgenreceiver.Stats)
-				tracesDone := make(chan loadgenreceiver.Stats)
-				if signal != "logs" {
-					close(logsDone)
-				}
-				if signal != "metrics" {
-					close(metricsDone)
-				}
-				if signal != "traces" {
-					close(tracesDone)
-				}
+	for _, concurrency := range Config.ConcurrencyList {
+		for _, signal := range getSignals() {
+			for _, exporter := range getExporters() {
+				benchName := fullBenchmarkName(signal, exporter, concurrency)
+				result := testing.Benchmark(func(b *testing.B) {
+					// loadgenreceiver will send stats about generated telemetry when it finishes sending b.N iterations
+					logsDone := make(chan loadgenreceiver.Stats)
+					metricsDone := make(chan loadgenreceiver.Stats)
+					tracesDone := make(chan loadgenreceiver.Stats)
+					if signal != "logs" {
+						close(logsDone)
+					}
+					if signal != "metrics" {
+						close(metricsDone)
+					}
+					if signal != "traces" {
+						close(tracesDone)
+					}
 
-				stop := make(chan struct{}) // close channel to stop the loadgen collector
+					stop := make(chan struct{}) // close channel to stop the loadgen collector
 
-				go func() {
-					logsStats := <-logsDone
-					metricsStats := <-metricsDone
-					tracesStats := <-tracesDone
-					b.StopTimer()
+					go func() {
+						logsStats := <-logsDone
+						metricsStats := <-metricsDone
+						tracesStats := <-tracesDone
+						b.StopTimer()
 
-					stats := logsStats.Add(metricsStats).Add(tracesStats)
+						stats := logsStats.Add(metricsStats).Add(tracesStats)
 
-					elapsedSeconds := b.Elapsed().Seconds()
-					b.ReportMetric(float64(stats.LogRecords)/elapsedSeconds, "logs/s")
-					b.ReportMetric(float64(stats.MetricDataPoints)/elapsedSeconds, "metric_points/s")
-					b.ReportMetric(float64(stats.Spans)/elapsedSeconds, "spans/s")
-					b.ReportMetric(float64(stats.Requests)/elapsedSeconds, "requests/s")
-					b.ReportMetric(float64(stats.FailedLogRecords)/elapsedSeconds, "failed_logs/s")
-					b.ReportMetric(float64(stats.FailedMetricDataPoints)/elapsedSeconds, "failed_metric_points/s")
-					b.ReportMetric(float64(stats.FailedSpans)/elapsedSeconds, "failed_spans/s")
-					b.ReportMetric(float64(stats.FailedRequests)/elapsedSeconds, "failed_requests/s")
-					// TODO(carsonip): optionally retrieve metrics (e.g. memory, cpu) of target server from Elasticsearch
+						elapsedSeconds := b.Elapsed().Seconds()
+						b.ReportMetric(float64(stats.LogRecords)/elapsedSeconds, "logs/s")
+						b.ReportMetric(float64(stats.MetricDataPoints)/elapsedSeconds, "metric_points/s")
+						b.ReportMetric(float64(stats.Spans)/elapsedSeconds, "spans/s")
+						b.ReportMetric(float64(stats.Requests)/elapsedSeconds, "requests/s")
+						b.ReportMetric(float64(stats.FailedLogRecords)/elapsedSeconds, "failed_logs/s")
+						b.ReportMetric(float64(stats.FailedMetricDataPoints)/elapsedSeconds, "failed_metric_points/s")
+						b.ReportMetric(float64(stats.FailedSpans)/elapsedSeconds, "failed_spans/s")
+						b.ReportMetric(float64(stats.FailedRequests)/elapsedSeconds, "failed_requests/s")
+						// TODO(carsonip): optionally retrieve metrics (e.g. memory, cpu) of target server from Elasticsearch
 
-					close(stop)
-				}()
+						close(stop)
+					}()
 
-				err := RunCollector(context.Background(), stop, configs(exporter, signal, b.N, Config.Concurrency), logsDone, metricsDone, tracesDone)
-				if err != nil {
-					b.Fatal(err)
-				}
-			})
-			// write benchmark result to stdout, as stderr may be cluttered with collector logs
-			fmt.Printf("%-*s\t%s\n", maxLen, benchName, result.String())
+					err := RunCollector(context.Background(), stop, configs(exporter, signal, b.N, concurrency), logsDone, metricsDone, tracesDone)
+					if err != nil {
+						b.Fatal(err)
+					}
+				})
+				// write benchmark result to stdout, as stderr may be cluttered with collector logs
+				fmt.Printf("%-*s\t%s\n", maxLen, benchName, result.String())
+			}
 		}
 	}
 }

--- a/loadgen/cmd/otelbench/main.go
+++ b/loadgen/cmd/otelbench/main.go
@@ -56,6 +56,53 @@ func fullBenchmarkName(signal, exporter string, concurrency int) string {
 	return fmt.Sprintf("%s-%s-%d", signal, exporter, concurrency)
 }
 
+func runBench(signal, exporter string, concurrency int) testing.BenchmarkResult {
+	return testing.Benchmark(func(b *testing.B) {
+		// loadgenreceiver will send stats about generated telemetry when it finishes sending b.N iterations
+		logsDone := make(chan loadgenreceiver.Stats)
+		metricsDone := make(chan loadgenreceiver.Stats)
+		tracesDone := make(chan loadgenreceiver.Stats)
+		if signal != "logs" {
+			close(logsDone)
+		}
+		if signal != "metrics" {
+			close(metricsDone)
+		}
+		if signal != "traces" {
+			close(tracesDone)
+		}
+
+		stop := make(chan struct{}) // close channel to stop the loadgen collector
+
+		go func() {
+			logsStats := <-logsDone
+			metricsStats := <-metricsDone
+			tracesStats := <-tracesDone
+			b.StopTimer()
+
+			stats := logsStats.Add(metricsStats).Add(tracesStats)
+
+			elapsedSeconds := b.Elapsed().Seconds()
+			b.ReportMetric(float64(stats.LogRecords)/elapsedSeconds, "logs/s")
+			b.ReportMetric(float64(stats.MetricDataPoints)/elapsedSeconds, "metric_points/s")
+			b.ReportMetric(float64(stats.Spans)/elapsedSeconds, "spans/s")
+			b.ReportMetric(float64(stats.Requests)/elapsedSeconds, "requests/s")
+			b.ReportMetric(float64(stats.FailedLogRecords)/elapsedSeconds, "failed_logs/s")
+			b.ReportMetric(float64(stats.FailedMetricDataPoints)/elapsedSeconds, "failed_metric_points/s")
+			b.ReportMetric(float64(stats.FailedSpans)/elapsedSeconds, "failed_spans/s")
+			b.ReportMetric(float64(stats.FailedRequests)/elapsedSeconds, "failed_requests/s")
+			// TODO(carsonip): optionally retrieve metrics (e.g. memory, cpu) of target server from Elasticsearch
+
+			close(stop)
+		}()
+
+		err := RunCollector(context.Background(), stop, configs(exporter, signal, b.N, concurrency), logsDone, metricsDone, tracesDone)
+		if err != nil {
+			b.Fatal(err)
+		}
+	})
+}
+
 func main() {
 	testing.Init()
 	if err := Init(); err != nil {
@@ -80,50 +127,7 @@ func main() {
 		for _, signal := range getSignals() {
 			for _, exporter := range getExporters() {
 				benchName := fullBenchmarkName(signal, exporter, concurrency)
-				result := testing.Benchmark(func(b *testing.B) {
-					// loadgenreceiver will send stats about generated telemetry when it finishes sending b.N iterations
-					logsDone := make(chan loadgenreceiver.Stats)
-					metricsDone := make(chan loadgenreceiver.Stats)
-					tracesDone := make(chan loadgenreceiver.Stats)
-					if signal != "logs" {
-						close(logsDone)
-					}
-					if signal != "metrics" {
-						close(metricsDone)
-					}
-					if signal != "traces" {
-						close(tracesDone)
-					}
-
-					stop := make(chan struct{}) // close channel to stop the loadgen collector
-
-					go func() {
-						logsStats := <-logsDone
-						metricsStats := <-metricsDone
-						tracesStats := <-tracesDone
-						b.StopTimer()
-
-						stats := logsStats.Add(metricsStats).Add(tracesStats)
-
-						elapsedSeconds := b.Elapsed().Seconds()
-						b.ReportMetric(float64(stats.LogRecords)/elapsedSeconds, "logs/s")
-						b.ReportMetric(float64(stats.MetricDataPoints)/elapsedSeconds, "metric_points/s")
-						b.ReportMetric(float64(stats.Spans)/elapsedSeconds, "spans/s")
-						b.ReportMetric(float64(stats.Requests)/elapsedSeconds, "requests/s")
-						b.ReportMetric(float64(stats.FailedLogRecords)/elapsedSeconds, "failed_logs/s")
-						b.ReportMetric(float64(stats.FailedMetricDataPoints)/elapsedSeconds, "failed_metric_points/s")
-						b.ReportMetric(float64(stats.FailedSpans)/elapsedSeconds, "failed_spans/s")
-						b.ReportMetric(float64(stats.FailedRequests)/elapsedSeconds, "failed_requests/s")
-						// TODO(carsonip): optionally retrieve metrics (e.g. memory, cpu) of target server from Elasticsearch
-
-						close(stop)
-					}()
-
-					err := RunCollector(context.Background(), stop, configs(exporter, signal, b.N, concurrency), logsDone, metricsDone, tracesDone)
-					if err != nil {
-						b.Fatal(err)
-					}
-				})
+				result := runBench(signal, exporter, concurrency)
 				// write benchmark result to stdout, as stderr may be cluttered with collector logs
 				fmt.Printf("%-*s\t%s\n", maxLen, benchName, result.String())
 			}


### PR DESCRIPTION
Make otelbench set the `concurrency` config in loadgenreceiver.

With `-concurrency=1,64`, output:
```
logs-otlp-1    	       3	6434488201 ns/op	         0 failed_logs/s	         0 failed_metric_points/s	         0 failed_requests/s	         0 failed_spans/s	       224.3 logs/s	         0 metric_points/s	        95.89 requests/s	         0 spans/s
metrics-otlp-1 	       8	1464059695 ns/op	         0 failed_logs/s	         0 failed_metric_points/s	         0 failed_requests/s	         0 failed_spans/s	         0 logs/s	      3177 metric_points/s	        56.01 requests/s	         0 spans/s
traces-otlp-1  	       1	13914055666 ns/op	         0 failed_logs/s	         0 failed_metric_points/s	         0 failed_requests/s	         0 failed_spans/s	         0 logs/s	         0 metric_points/s	        71.87 requests/s	       723.7 spans/s
logs-otlp-64   	      52	 238490217 ns/op	         0 failed_logs/s	         0 failed_metric_points/s	         0 failed_requests/s	         0 failed_spans/s	      6051 logs/s	         0 metric_points/s	      2587 requests/s	         0 spans/s
metrics-otlp-64	     442	 100702281 ns/op	         0 failed_logs/s	         0 failed_metric_points/s	         0 failed_requests/s	         0 failed_spans/s	         0 logs/s	     46186 metric_points/s	       814.3 requests/s	         0 spans/s
traces-otlp-64 	       9	3287110577 ns/op	         0 failed_logs/s	         0 failed_metric_points/s	         0 failed_requests/s	         0 failed_spans/s	         0 logs/s	         0 metric_points/s	       304.2 requests/s	      3063 spans/s
```
