### PR TITLE
Bump go version to 1.22.11 to pass govulncheck

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22.7"
+          go-version: "1.22.11"
           cache: false
       - name: Cache Go
         id: go-cache
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22.7"
+          go-version: "1.22.11"
           cache: false
       - name: Cache Go
         id: go-cache
@@ -107,7 +107,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22.7"
+          go-version: "1.22.11"
           cache: false
       - name: Cache Go
         id: go-cache
@@ -130,7 +130,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22.7"
+          go-version: "1.22.11"
           cache: false
       - name: Cache Go
         id: go-cache
@@ -169,7 +169,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ["1.22.7", "1.23.1"] # 1.20 is interpreted as 1.2 without quotes
+        go-version: ["1.22.11", "1.23.1"] # 1.20 is interpreted as 1.2 without quotes
         runner: [ubuntu-latest]
         group:
           - all


### PR DESCRIPTION
Fix CI govulncheck.

```
=== Symbol Results ===

Vulnerability #1: GO-2025-3373
    Usage of IPv6 zone IDs can bypass URI name constraints in crypto/x509
  More info: https://pkg.go.dev/vuln/GO-2025-3373
  Standard library
    Found in: crypto/x509@go1.22.7
    Fixed in: crypto/x509@go1.22.11
    Example traces found:
Error:       #1: config/config.go:33:2: config.init calls zap.init, which eventually calls x509.CertPool.AppendCertsFromPEM
Error:       #2: config/config.go:273:37: config.validateMetricInfo[github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlspan.TransformContext] calls ottl.Parser[github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlspan.TransformContext].ParseConditions[github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlspan.TransformContext], which eventually calls x509.Certificate.Verify
Error:       #3: config/config.go:273:37: config.validateMetricInfo[github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlspan.TransformContext] calls ottl.Parser[github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlspan.TransformContext].ParseConditions[github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlspan.TransformContext], which eventually calls x509.Certificate.VerifyHostname
Error:       #4: config/config.go:118:37: config.Config.Unmarshal calls confmap.Conf.Unmarshal, which eventually calls x509.HostnameError.Error
Error:       #5: config/config.go:33:2: config.init calls zap.init, which eventually calls x509.ParseCertificate

Your code is affected by 1 vulnerability from the Go standard library.
This scan also found 2 vulnerabilities in packages you import and 0
vulnerabilities in modules you require, but your code doesn't appear to call
these vulnerabilities.
Use '-show verbose' for more details.
make[2]: *** [../../Makefile.Common:82: govulncheck] Error 3
make[2]: Leaving directory '/home/runner/work/opentelemetry-collector-components/opentelemetry-collector-components/connector/signaltometricsconnector'
make[1]: *** [Makefile:25: connector/signaltometricsconnector] Error 2
make[1]: *** Waiting for unfinished jobs....
=== Symbol Results ===

Vulnerability #1: GO-2025-3420
    Sensitive headers incorrectly sent after cross-domain redirect in net/http
  More info: https://pkg.go.dev/vuln/GO-2025-3420
  Standard library
    Found in: net/http@go1.22.7
    Fixed in: net/http@go1.22.11
    Example traces found:
Error:       #1: main.go:60:26: loadgen.runBench calls testing.Benchmark, which eventually calls http.Client.Do

Vulnerability #2: GO-2025-3373
    Usage of IPv6 zone IDs can bypass URI name constraints in crypto/x509
  More info: https://pkg.go.dev/vuln/GO-2025-3373
  Standard library
    Found in: crypto/x509@go1.22.7
    Fixed in: crypto/x509@go1.22.11
    Example traces found:
Error:       #1: main.go:60:26: loadgen.runBench calls testing.Benchmark, which eventually calls x509.CertPool.AppendCertsFromPEM
Error:       #2: main.go:132:62: loadgen.main calls testing.BenchmarkResult.String, which eventually calls x509.Certificate.Verify
Error:       #3: main.go:132:62: loadgen.main calls testing.BenchmarkResult.String, which eventually calls x509.Certificate.VerifyHostname
Error:       #4: main.go:109:15: loadgen.main calls fmt.Fprintln, which eventually calls x509.HostnameError.Error
Error:       #5: main.go:60:26: loadgen.runBench calls testing.Benchmark, which eventually calls x509.ParseCertificate
Error:       #6: main.go:132:62: loadgen.main calls testing.BenchmarkResult.String, which eventually calls x509.ParseECPrivateKey
Error:       #7: main.go:132:62: loadgen.main calls testing.BenchmarkResult.String, which eventually calls x509.ParsePKCS1PrivateKey
Error:       #8: main.go:132:62: loadgen.main calls testing.BenchmarkResult.String, which eventually calls x509.ParsePKCS8PrivateKey
Error:       #9: collector.go:60:16: loadgen.RunCollector calls otelcol.Collector.Run, which eventually calls x509.SystemCertPool

Your code is affected by 2 vulnerabilities from the Go standard library.
This scan found no other vulnerabilities in packages you import or modules you
require.
Use '-show verbose' for more details.
make[2]: *** [../../../Makefile.Common:82: govulncheck] Error 3
make[2]: Leaving directory '/home/runner/work/opentelemetry-collector-components/opentelemetry-collector-components/loadgen/cmd/otelbench'
make[1]: *** [Makefile:25: loadgen/cmd/otelbench] Error 2
make[1]: Leaving directory '/home/runner/work/opentelemetry-collector-components/opentelemetry-collector-components'
make: *** [Makefile:62: gogovulncheck] Error 2
Error: Process completed with exit code 2.
```