### PR TITLE
lsmintervalprocessor: make processor non-mutating

### DIFF
--- a/processor/lsmintervalprocessor/processor_test.go
+++ b/processor/lsmintervalprocessor/processor_test.go
@@ -353,26 +353,24 @@ func benchmarkAggregation(b *testing.B, ottlStatements []string) {
 			md, err := golden.ReadMetrics(filepath.Join(dir, "input.yaml"))
 			require.NoError(b, err)
 			md.MarkReadOnly()
-			benchFunc := func(highCardinalityValue string) {
-				// Copy the metric as the ConsumeMetric call is mutating
-				mdCopy := pmetric.NewMetrics()
-				md.CopyTo(mdCopy)
-				// Overwrites the asdf attribute in metrics such that it becomes high cardinality
-				mdCopy.ResourceMetrics().At(0).Resource().Attributes().PutStr("asdf", highCardinalityValue)
-
-				err := mgp.ConsumeMetrics(ctx, mdCopy)
-				require.NoError(b, err)
-			}
 
 			b.ResetTimer()
 			err = mgp.Start(context.Background(), componenttest.NewNopHost())
 			require.NoError(b, err)
 
 			b.RunParallel(func(pb *testing.PB) {
+				// Create a copy of the metrics for each goroutine,
+				// so they can set their own resource attributes.
+				mdCopy := pmetric.NewMetrics()
+				md.CopyTo(mdCopy)
 				highCardinalityValuePrefix := fmt.Sprint("rand_", rand.Int())
+
 				for i := 0; pb.Next(); i++ {
 					highCardinalityValue := fmt.Sprintf("%s_%d", highCardinalityValuePrefix, i)
-					benchFunc(highCardinalityValue)
+					mdCopy.ResourceMetrics().At(0).Resource().Attributes().PutStr("asdf", highCardinalityValue)
+					if err := mgp.ConsumeMetrics(ctx, mdCopy); err != nil {
+						b.Fatal(err)
+					}
 				}
 			})
 


### PR DESCRIPTION
The processor is no longer mutating, and will instead create a new pmetric.Metrics with just the metrics that will not be aggregated. This should be more efficient in the case where no or few metrics passed through.

This also allows us to remove some memory allocations from the benchmark code since it no longer needs to copy the input for each iteration.