### PR TITLE
test: add testutil internal package

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -121,6 +121,20 @@ updates:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
 
+  - package-ecosystem: "gomod"
+    directory: "/internal/testutil/"
+    schedule:
+      interval: "daily"
+    labels:
+      - automation
+      - tools
+    groups:
+      otel-dependencies:
+        patterns: ["go.opentelemetry.io/*"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -169,7 +169,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ["1.22.12", "1.23.1"] # 1.20 is interpreted as 1.2 without quotes
+        go-version: ["1.22.12", "1.23.6"] # 1.20 is interpreted as 1.2 without quotes
         runner: [ubuntu-latest]
         group:
           - all

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22.11"
+          go-version: "1.22.12"
           cache: false
       - name: Cache Go
         id: go-cache
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22.11"
+          go-version: "1.22.12"
           cache: false
       - name: Cache Go
         id: go-cache
@@ -107,7 +107,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22.11"
+          go-version: "1.22.12"
           cache: false
       - name: Cache Go
         id: go-cache
@@ -130,7 +130,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22.11"
+          go-version: "1.22.12"
           cache: false
       - name: Cache Go
         id: go-cache
@@ -169,7 +169,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ["1.22.11", "1.23.1"] # 1.20 is interpreted as 1.2 without quotes
+        go-version: ["1.22.12", "1.23.1"] # 1.20 is interpreted as 1.2 without quotes
         runner: [ubuntu-latest]
         group:
           - all

--- a/internal/testutil/Makefile
+++ b/internal/testutil/Makefile
@@ -1,0 +1,1 @@
+include ../../Makefile.Common

--- a/internal/testutil/go.mod
+++ b/internal/testutil/go.mod
@@ -1,6 +1,6 @@
 module github.com/elastic/opentelemetry-collector-components/internal/testutil
 
-go 1.23.4
+go 1.22.3
 
 require github.com/stretchr/testify v1.10.0
 

--- a/internal/testutil/go.mod
+++ b/internal/testutil/go.mod
@@ -1,6 +1,6 @@
 module github.com/elastic/opentelemetry-collector-components/internal/testutil
 
-go 1.22.3
+go 1.22.12
 
 require github.com/stretchr/testify v1.10.0
 

--- a/internal/testutil/go.mod
+++ b/internal/testutil/go.mod
@@ -1,0 +1,11 @@
+module github.com/elastic/opentelemetry-collector-components/internal/testutil
+
+go 1.23.4
+
+require github.com/stretchr/testify v1.10.0
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/internal/testutil/go.sum
+++ b/internal/testutil/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// This is a copy of the internal module from opentelemetry-collector:
+// https://github.com/open-telemetry/opentelemetry-collector/tree/main/internal/testutil
+
 package testutil // import "github.com/elastic/opentelemetry-collector-components/internal/testutil"
 
 import (

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package testutil // import "github.com/elastic/opentelemetry-collector-components/receiver/elasticapmreceiver/internal/testutil"
+package testutil // import "github.com/elastic/opentelemetry-collector-components/internal/testutil"
 
 import (
 	"net"

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -1,0 +1,135 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package testutil // import "github.com/elastic/opentelemetry-collector-components/receiver/elasticapmreceiver/internal/testutil"
+
+import (
+	"net"
+	"os/exec"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type portpair struct {
+	first string
+	last  string
+}
+
+// GetAvailableLocalAddress finds an available local port and returns an endpoint
+// describing it. The port is available for opening when this function returns
+// provided that there is no race by some other code to grab the same port
+// immediately.
+func GetAvailableLocalAddress(t testing.TB) string {
+	return findAvailable(t, "tcp4")
+}
+
+func findAvailable(t testing.TB, network string) string {
+	// Retry has been added for windows as net.Listen can return a port that is not actually available. Details can be
+	// found in https://github.com/docker/for-win/issues/3171 but to summarize Hyper-V will reserve ranges of ports
+	// which do not show up under the "netstat -ano" but can only be found by
+	// "netsh interface ipv4 show excludedportrange protocol=tcp".  We'll use []exclusions to hold those ranges and
+	// retry if the port returned by GetAvailableLocalAddress falls in one of those them.
+	var exclusions []portpair
+	portFound := false
+	if runtime.GOOS == "windows" {
+		exclusions = getExclusionsList(network, t)
+	}
+
+	var endpoint string
+	for !portFound {
+		endpoint = findAvailableAddress(network, t)
+		_, port, err := net.SplitHostPort(endpoint)
+		require.NoError(t, err)
+		portFound = true
+		if runtime.GOOS == "windows" {
+			for _, pair := range exclusions {
+				if port >= pair.first && port <= pair.last {
+					portFound = false
+					break
+				}
+			}
+		}
+	}
+
+	return endpoint
+}
+
+func findAvailableAddress(network string, t testing.TB) string {
+	var host string
+	switch network {
+	case "tcp", "tcp4":
+		host = "localhost"
+	case "tcp6":
+		host = "[::1]"
+	}
+	require.NotZero(t, host, "network must be either of tcp, tcp4 or tcp6")
+
+	ln, err := net.Listen("tcp", host+":0")
+	require.NoError(t, err, "Failed to get a free local port")
+	// There is a possible race if something else takes this same port before
+	// the test uses it, however, that is unlikely in practice.
+	defer func() {
+		assert.NoError(t, ln.Close())
+	}()
+	return ln.Addr().String()
+}
+
+// Get excluded ports on Windows from the command: netsh interface ipv4 show excludedportrange protocol=tcp
+func getExclusionsList(network string, t testing.TB) []portpair {
+	var cmdTCP *exec.Cmd
+	switch network {
+	case "tcp", "tcp4":
+		cmdTCP = exec.Command("netsh", "interface", "ipv4", "show", "excludedportrange", "protocol=tcp")
+	case "tcp6":
+		cmdTCP = exec.Command("netsh", "interface", "ipv6", "show", "excludedportrange", "protocol=tcp")
+	}
+	require.NotZero(t, cmdTCP, "network must be either of tcp, tcp4 or tcp6")
+
+	outputTCP, errTCP := cmdTCP.CombinedOutput()
+	require.NoError(t, errTCP)
+	exclusions := createExclusionsList(t, string(outputTCP))
+
+	cmdUDP := exec.Command("netsh", "interface", "ipv4", "show", "excludedportrange", "protocol=udp")
+	outputUDP, errUDP := cmdUDP.CombinedOutput()
+	require.NoError(t, errUDP)
+	exclusions = append(exclusions, createExclusionsList(t, string(outputUDP))...)
+
+	return exclusions
+}
+
+func createExclusionsList(t testing.TB, exclusionsText string) []portpair {
+	var exclusions []portpair
+
+	parts := strings.Split(exclusionsText, "--------")
+	require.Len(t, parts, 3)
+	portsText := strings.Split(parts[2], "*")
+	require.Greater(t, len(portsText), 1) // original text may have a suffix like " - Administered port exclusions."
+	lines := strings.Split(portsText[0], "\n")
+	for _, line := range lines {
+		if strings.TrimSpace(line) != "" {
+			entries := strings.Fields(strings.TrimSpace(line))
+			require.Len(t, entries, 2)
+			pair := portpair{entries[0], entries[1]}
+			exclusions = append(exclusions, pair)
+		}
+	}
+	return exclusions
+}

--- a/internal/testutil/testutil_test.go
+++ b/internal/testutil/testutil_test.go
@@ -1,0 +1,71 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package testutil
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetAvailableLocalAddress(t *testing.T) {
+	endpoint := GetAvailableLocalAddress(t)
+
+	// Endpoint should be free.
+	ln0, err := net.Listen("tcp", endpoint)
+	require.NoError(t, err)
+	require.NotNil(t, ln0)
+	t.Cleanup(func() {
+		assert.NoError(t, ln0.Close())
+	})
+
+	// Ensure that the endpoint wasn't something like ":0" by checking that a
+	// second listener will fail.
+	ln1, err := net.Listen("tcp", endpoint)
+	require.Error(t, err)
+	require.Nil(t, ln1)
+}
+
+func TestCreateExclusionsList(t *testing.T) {
+	// Test two examples of typical output from "netsh interface ipv4 show excludedportrange protocol=tcp"
+	emptyExclusionsText := `
+
+Protocol tcp Port Exclusion Ranges
+
+Start Port    End Port
+----------    --------
+
+* - Administered port exclusions.`
+
+	exclusionsText := `
+
+Start Port    End Port
+----------    --------
+     49697       49796
+     49797       49896
+
+* - Administered port exclusions.
+`
+	exclusions := createExclusionsList(t, exclusionsText)
+	require.Len(t, exclusions, 2)
+
+	emptyExclusions := createExclusionsList(t, emptyExclusionsText)
+	require.Empty(t, emptyExclusions)
+}


### PR DESCRIPTION
Exposes and internal function to get a local endpoint: `GetAvailableLocalAddress`. Ipv4 code from https://github.com/open-telemetry/opentelemetry-collector/tree/main/internal/testutil

Used at:
- https://github.com/elastic/opentelemetry-collector-components/pull/324
- https://github.com/elastic/opentelemetry-collector-components/pull/39

