### PR TITLE
Fix sharedcomponent module version

### DIFF
--- a/connector/elasticapmconnector/go.mod
+++ b/connector/elasticapmconnector/go.mod
@@ -3,9 +3,9 @@ module github.com/elastic/opentelemetry-collector-components/connector/elasticap
 go 1.23.6
 
 require (
-	github.com/elastic/opentelemetry-collector-components/connector/signaltometricsconnector v0.0.0
-	github.com/elastic/opentelemetry-collector-components/internal/sharedcomponent v0.0.0
-	github.com/elastic/opentelemetry-collector-components/processor/lsmintervalprocessor v0.0.0
+	github.com/elastic/opentelemetry-collector-components/connector/signaltometricsconnector v0.3.0
+	github.com/elastic/opentelemetry-collector-components/internal/sharedcomponent v0.0.0-20250220025958-386ba0c4bced
+	github.com/elastic/opentelemetry-collector-components/processor/lsmintervalprocessor v0.4.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.120.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.120.0
 	github.com/stretchr/testify v1.10.0

--- a/distributions/elastic-components/manifest.yaml
+++ b/distributions/elastic-components/manifest.yaml
@@ -71,5 +71,4 @@ replaces:
   - github.com/elastic/opentelemetry-collector-components/processor/ratelimitprocessor => ../processor/ratelimitprocessor
   - github.com/elastic/opentelemetry-collector-components/extension/beatsauthextension => ../extension/beatsauthextension
   - github.com/elastic/opentelemetry-collector-components/connector/elasticapmconnector => ../connector/elasticapmconnector
-  - github.com/elastic/opentelemetry-collector-components/internal/sharedcomponent => ../internal/sharedcomponent
 

--- a/processor/ratelimitprocessor/go.mod
+++ b/processor/ratelimitprocessor/go.mod
@@ -3,7 +3,7 @@ module github.com/elastic/opentelemetry-collector-components/processor/ratelimit
 go 1.23.6
 
 require (
-	github.com/elastic/opentelemetry-collector-components/internal/sharedcomponent v0.0.0
+	github.com/elastic/opentelemetry-collector-components/internal/sharedcomponent v0.0.0-20250220025958-386ba0c4bced
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/client v1.26.0
 	go.opentelemetry.io/collector/component v0.120.0


### PR DESCRIPTION
Depending on v0.0.0 is a problem for downstream components.

e.g.

```
$ go mod tidy -v
go: finding module for package github.com/elastic/opentelemetry-collector-components/connector/elasticapmconnector
go: found github.com/elastic/opentelemetry-collector-components/connector/elasticapmconnector in github.com/elastic/opentelemetry-collector-components/connector/elasticapmconnector v0.0.0-20250220025958-386ba0c4bced
go: downloading github.com/elastic/opentelemetry-collector-components/internal/sharedcomponent v0.0.0
go: <...> imports
        github.com/elastic/opentelemetry-collector-components/connector/elasticapmconnector imports
        github.com/elastic/opentelemetry-collector-components/internal/sharedcomponent: reading github.com/elastic/opentelemetry-collector-components/internal/sharedcomponent/go.mod at revision internal/sharedcomponent/v0.0.0: unknown revision internal/sharedcomponent/v0.0.0
```