### PR TITLE
IntakeV2 receiver - Fix [span|transaction].duration.us and timestamp.us attributes

### DIFF
--- a/receiver/elasticapmreceiver/internal/mappers/intakeV2ToDerivedFields.go
+++ b/receiver/elasticapmreceiver/internal/mappers/intakeV2ToDerivedFields.go
@@ -41,14 +41,14 @@ func SetDerivedFieldsForTransaction(event *modelpb.APMEvent, attributes pcommon.
 	attributes.PutBool("transaction.root", event.ParentId == "")
 	attributes.PutStr("transaction.type", event.Transaction.Type)
 	attributes.PutStr("transaction.result", event.Transaction.Result)
-	attributes.PutInt("transaction.duration.us", int64(event.Event.Duration))
+	attributes.PutInt("transaction.duration.us", int64(event.Event.Duration/1_000))
 }
 
 // Sets fields that are NOT part of OTel for spans. These fields are derived by the Enrichment lib in case of OTLP input
 func SetDerivedFieldsForSpan(event *modelpb.APMEvent, attributes pcommon.Map) {
 
 	attributes.PutStr("processor.event", "span")
-	attributes.PutInt("span.duration.us", int64(event.Event.Duration))
+	attributes.PutInt("span.duration.us", int64(event.Event.Duration/1_000))
 	attributes.PutStr("span.id", event.Span.Id)
 	attributes.PutStr("span.name", event.Span.Name)
 	attributes.PutStr("span.type", event.Span.Type)
@@ -74,7 +74,7 @@ func SetDerivedResourceAttributes(event *modelpb.APMEvent, attributes pcommon.Ma
 
 // Shared across spans and transactions
 func SetDerivedFieldsCommon(event *modelpb.APMEvent, attributes pcommon.Map) {
-	attributes.PutInt("timestamp.us", int64(event.Timestamp))
+	attributes.PutInt("timestamp.us", int64(event.Timestamp/1_000))
 
 	if strings.EqualFold(event.Event.Outcome, "success") {
 		attributes.PutStr("event.outcome", "success")


### PR DESCRIPTION
Adding missing conversion to attributes:
- `span.duration.us`
- `transaction..duration.us`
- timestamp.us

Noticed that UI uses these values and it seem to expect microsecond values (as the attribute name suggests). Prior to this PR, the UI looked like this:

<img width="396" alt="Screenshot 2025-02-25 at 14 43 45" src="https://github.com/user-attachments/assets/8ffea130-d0d7-4f37-81a2-489f3311e631" />


The PR fixes this.

Note that we in `receiver.go` we call `SetStartTimestamp` and SetEndTimestamp` on the span - that was fine before, just these attributes had the wrong value (1000x more due to the missing conversion). 