### PR TITLE
[processor/ratelimitprocessor] Do not leak ratelimiter errors to the client

### DIFF
--- a/processor/ratelimitprocessor/gubernator.go
+++ b/processor/ratelimitprocessor/gubernator.go
@@ -112,7 +112,7 @@ func (r *gubernatorRateLimiter) RateLimit(ctx context.Context, hits int) error {
 	}
 	resp := responses[0]
 	if resp.GetError() != "" {
-		r.set.Logger.Error("failed to get valid response from gubernator", zap.Error(errors.New(resp.GetError())))
+		r.set.Logger.Error("failed to get response from gubernator", zap.Error(errors.New(resp.GetError())))
 		return errRateLimitInternalError
 	}
 

--- a/processor/ratelimitprocessor/gubernator.go
+++ b/processor/ratelimitprocessor/gubernator.go
@@ -101,7 +101,8 @@ func (r *gubernatorRateLimiter) RateLimit(ctx context.Context, hits int) error {
 		}},
 	})
 	if err != nil {
-		return fmt.Errorf("error executing gubernator rate limit request: %w", err)
+		r.set.Logger.Error("error executing gubernator rate limit request", zap.Error(err))
+		return errors.New("error executing gubernator rate limit request")
 	}
 
 	// Inside the gRPC response, we should have a single-item list of responses.
@@ -111,7 +112,8 @@ func (r *gubernatorRateLimiter) RateLimit(ctx context.Context, hits int) error {
 	}
 	resp := responses[0]
 	if resp.GetError() != "" {
-		return errors.New(resp.GetError())
+		r.set.Logger.Error("failed to get valid response from gubernator", zap.Error(errors.New(resp.GetError())))
+		return errors.New("failed to get valid response from gubernator")
 	}
 
 	if resp.GetStatus() != gubernator.Status_UNDER_LIMIT {

--- a/processor/ratelimitprocessor/gubernator.go
+++ b/processor/ratelimitprocessor/gubernator.go
@@ -102,7 +102,7 @@ func (r *gubernatorRateLimiter) RateLimit(ctx context.Context, hits int) error {
 	})
 	if err != nil {
 		r.set.Logger.Error("error executing gubernator rate limit request", zap.Error(err))
-		return errors.New("error executing gubernator rate limit request")
+		return errRateLimitInternalError
 	}
 
 	// Inside the gRPC response, we should have a single-item list of responses.
@@ -113,7 +113,7 @@ func (r *gubernatorRateLimiter) RateLimit(ctx context.Context, hits int) error {
 	resp := responses[0]
 	if resp.GetError() != "" {
 		r.set.Logger.Error("failed to get valid response from gubernator", zap.Error(errors.New(resp.GetError())))
-		return errors.New("failed to get valid response from gubernator")
+		return errRateLimitInternalError
 	}
 
 	if resp.GetStatus() != gubernator.Status_UNDER_LIMIT {

--- a/processor/ratelimitprocessor/ratelimiter.go
+++ b/processor/ratelimitprocessor/ratelimiter.go
@@ -26,7 +26,8 @@ import (
 )
 
 var (
-	errTooManyRequests = errors.New("too many requests")
+	errTooManyRequests        = errors.New("too many requests")
+	errRateLimitInternalError = errors.New("rate limiter failed")
 )
 
 // RateLimiter provides an interface for rate limiting by some number


### PR DESCRIPTION
Closes https://github.com/elastic/hosted-otel-collector/issues/425.

Rate limit errors are now printed using the logger. The returned error is something more simple and generic indicating a failure from gubernator.