### PR TITLE
[loadgen/otelbench] Add println on error

### DIFF
--- a/loadgen/cmd/otelbench/.chloggen/add-println-otelbench.yaml
+++ b/loadgen/cmd/otelbench/.chloggen/add-println-otelbench.yaml
@@ -1,0 +1,18 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Print error in case of failure.
+
+# It is mandatory to specify the component. Do not change this.
+component: otelbench
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [405]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Print an error in case of failure if it is outside the benchmarking context.

--- a/loadgen/cmd/otelbench/main.go
+++ b/loadgen/cmd/otelbench/main.go
@@ -98,6 +98,7 @@ func runBench(signal, exporter string, concurrency int) testing.BenchmarkResult 
 
 		err := RunCollector(context.Background(), stop, configs(exporter, signal, b.N, concurrency), logsDone, metricsDone, tracesDone)
 		if err != nil {
+			fmt.Println(err.Error())
 			b.Fatal(err)
 		}
 	})

--- a/loadgen/cmd/otelbench/main.go
+++ b/loadgen/cmd/otelbench/main.go
@@ -98,7 +98,7 @@ func runBench(signal, exporter string, concurrency int) testing.BenchmarkResult 
 
 		err := RunCollector(context.Background(), stop, configs(exporter, signal, b.N, concurrency), logsDone, metricsDone, tracesDone)
 		if err != nil {
-			fmt.Println(err.Error())
+			fmt.Fprintln(os.Stderr, err.Error())
 			b.Fatal(err)
 		}
 	})


### PR DESCRIPTION
Closes https://github.com/elastic/opentelemetry-collector-components/issues/391.

If we ran otelbench directly (example `go build -o otelbench . && ./otelbench --config=my-config.yaml`), there are no printing lines in case of error since there is only a log in the benchmark context. This PR fixes that.

Example output in case of error:

```
$ go build -o otelbench . && ./otelbench --config=my-config.yaml 
failed to create SDK: binding address localhost:8888 for Prometheus exporter: listen tcp 127.0.0.1:8888: bind: address already in use
logs-otlp-1                    0                       NaN ns/op
failed to create SDK: binding address localhost:8888 for Prometheus exporter: listen tcp 127.0.0.1:8888: bind: address already in use
logs-otlphttp-1                0                       NaN ns/op
failed to create SDK: binding address localhost:8888 for Prometheus exporter: listen tcp 127.0.0.1:8888: bind: address already in use
metrics-otlp-1                 0                       NaN ns/op
failed to create SDK: binding address localhost:8888 for Prometheus exporter: listen tcp 127.0.0.1:8888: bind: address already in use
metrics-otlphttp-1             0                       NaN ns/op
failed to create SDK: binding address localhost:8888 for Prometheus exporter: listen tcp 127.0.0.1:8888: bind: address already in use
traces-otlp-1                  0                       NaN ns/op
failed to create SDK: binding address localhost:8888 for Prometheus exporter: listen tcp 127.0.0.1:8888: bind: address already in use
traces-otlphttp-1              0                       NaN ns/op
```

This is the before:
```
$ go build -o otelbench . && ./otelbench --config=my-config.yaml 
logs-otlp-1                    0                       NaN ns/op
logs-otlphttp-1                0                       NaN ns/op
metrics-otlp-1                 0                       NaN ns/op
metrics-otlphttp-1             0                       NaN ns/op
traces-otlp-1                  0                       NaN ns/op
traces-otlphttp-1              0                       NaN ns/op
```