### PR TITLE
[loadgen/otelbench] Add release otelbench workflow

### DIFF
--- a/.github/workflows/release_otelbench.yaml
+++ b/.github/workflows/release_otelbench.yaml
@@ -1,0 +1,106 @@
+run-name: release-otelbench
+name: Release otelbench docker image on elastic container library
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version of the otelbench image to release, should follow format "vN.N.N".
+        required: true
+  push:
+    branches:
+      - main
+    paths:
+      - ./loadgen/cmd/otelbench/Makefile
+
+jobs:
+  check-release:
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.get-new-version.outputs.new_version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: '0'
+
+      - name: Checks if release is required.
+        id: get-new-version
+        run: ./scripts/check_release.sh "${{ github.event_name }}" "${{ github.event.inputs.version }}"
+
+  release-otelbench:
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    needs:
+      - check-release
+    if: needs.check-release.result == 'success'
+    permissions:
+      contents: write
+    env:
+      ELASTIC_REGISTRY: "docker.elastic.co/observability-ci"
+      IMAGE_NAME: "otelbench"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: '0'
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: 'false'
+
+      - name: Cache go tools
+        id: go-tools-cache
+        uses: actions/cache@v4
+        with:
+          path: ./.tools
+          key: go-tools-${{ runner.os }}-${{ hashFiles('internal/tools/go.sum') }}
+
+      # If there is no cache with the go tools,
+      # install them. We need the changelog
+      # tool for this workflow to work.
+      - name: Install tools
+        if: steps.go-tools-cache.outputs.cache-hit != 'true'
+        run: |
+          make install-tools
+
+      - name: Update otelbench changelog and delete changelog fragments
+        working-directory: ./loadgen/cmd/otelbench
+        run: ../../../.tools/chloggen update --version ${{ needs.check-release.outputs.version }}
+
+      - name: Update Makefile version if dispatched
+        if: github.event_name == 'workflow_dispatch'
+        working-directory: ./loadgen/cmd/otelbench
+        run: sed -i "s/^VERSION := .*/VERSION := ${{ github.event.inputs.version }}/" Makefile
+
+      - name: Commit changes
+        run: |
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          
+          git checkout main
+          git pull --rebase origin main
+          git add ./loadgen/cmd/otelbench
+          if ! git diff --quiet ./loadgen/cmd/otelbench; then
+            git commit -m "Update otelbench changelog and delete changelog fragments."
+            git push origin main
+          fi
+
+      - name: Login to Elastic container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.ELASTIC_REGISTRY }}
+          username: ${{ secrets.DOCKER_AUTH_USERNAME }}
+          password: ${{ secrets.DOCKER_AUTH_PASSWORD }}
+
+      - uses: ko-build/setup-ko@v0.8
+        env:
+          KO_DOCKER_REPO: ${{ env.ELASTIC_REGISTRY }}
+
+      - name: Build container image and push to Elastic registry
+        working-directory: ./loadgen/cmd/otelbench
+        run: |
+          export KO_DOCKER_REPO=${{ env.ELASTIC_REGISTRY }}
+          local_platform="linux/$(go env GOARCH)"
+          KO_IMAGE=$(ko build --platform=$local_platform)
+          docker tag "$KO_IMAGE" "${{ env.ELASTIC_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.check-release.outputs.version }}"

--- a/.github/workflows/scripts/check_release.sh
+++ b/.github/workflows/scripts/check_release.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -eo pipefail
+
+# This script gets the previous version from the
+# previous commit, by running make get-version.
+# Then it compares this previous version with the
+# new given version. If there was an increase
+# in version, then a release is required.
+
+GITHUB_EVENT_NAME=$1
+GITHUB_INPUT_VERSION=$2
+
+WORKING_DIR="../../../loadgen/cmd/otelbench"
+
+# Get new version
+if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+  NEW_VERSION="$GITHUB_INPUT_VERSION"
+else
+  NEW_VERSION=$(make -C "$WORKING_DIR" get-version 2>/dev/null || echo "v0.0.0")
+fi
+
+# Get previous version
+PREV_VERSION="v0.0.0"
+if git cat-file -e HEAD~1:"$WORKING_DIR/Makefile" 2>/dev/null; then
+  PREV_VERSION=$(git show HEAD~1:"$WORKING_DIR/Makefile" | make -f - get-version 2>/dev/null || echo "v0.0.0")
+fi
+
+echo "Previous version: $PREV_VERSION."
+echo "New version, obtained from $GITHUB_EVENT_NAME: $NEW_VERSION."
+echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+
+# Check if a release is required.
+# For a release to be required, the previous
+# version needs to be smaller than the
+# given one.
+# v0.0.0 -> v0.1.0 -> works
+# v0.1.0 -> v0.0.0 -> does not work
+if [ "$(printf "%s\n%s" "$PREV_VERSION" "$NEW_VERSION" | sort -V | head -n1)" != "$NEW_VERSION" ]; then
+  echo "Release required: $PREV_VERSION < $NEW_VERSION."
+  exit 0
+else
+  echo "No release needed: $PREV_VERSION > $NEW_VERSION."
+  exit 1
+fi


### PR DESCRIPTION
Add a release workflow that can be triggered manually, or by updating the version inside the MAKEFILE in otelbench directory.

The workflow will update the changelog and release the docker image in elastic container registry.