### PR TITLE
[workflow/otelbench] Add execute permissions to script files

### DIFF
--- a/.github/workflows/bump_otelbench.yaml
+++ b/.github/workflows/bump_otelbench.yaml
@@ -29,7 +29,10 @@ jobs:
 
       - name: Checks if release is required.
         id: get-new-version
-        run: ./.github/workflows/scripts/check_release.sh "${{ github.event_name }}" "${{ github.event.inputs.version }}"
+        shell: bash
+        run: |
+          chmod +x ./.github/workflows/scripts/check_release.sh
+          ./.github/workflows/scripts/check_release.sh "${{ github.event_name }}" "${{ github.event.inputs.version }}"
 
   update-changelog:
     timeout-minutes: 15
@@ -82,6 +85,9 @@ jobs:
           make install-tools
 
       - name: Update CHANGELOG and open PR.
-        run: ./.github/workflows/scripts/create_pr.sh "${{ needs.check-release.outputs.version }}" "${{ github.event_name }}"
+        shell: bash
+        run: |
+          chmod +x ./.github/workflows/scripts/create_pr.sh
+          ./.github/workflows/scripts/create_pr.sh "${{ needs.check-release.outputs.version }}" "${{ github.event_name }}"
         env:
           GH_TOKEN: ${{ steps.get_token.outputs.token }}


### PR DESCRIPTION
One of the script files failed with lack of permissions. To ensure this does not happen, let's make sure that we add execute permissions before executing any script file.

Example failure: https://github.com/elastic/opentelemetry-collector-components/actions/runs/13700451370/job/38312682930