### PR TITLE
[workflow/release_otelbench] Remove workflow_dispatch trigger

### DIFF
--- a/.github/workflows/release_otelbench.yaml
+++ b/.github/workflows/release_otelbench.yaml
@@ -8,11 +8,6 @@ on:
     paths:
       - loadgen/cmd/otelbench/CHANGELOG.md
 
-  # TODO Please remove this once
-  # it is clear that the push trigger
-  # works
-  workflow_dispatch:
-
 
 permissions:
   contents: read


### PR DESCRIPTION
The workflow_dispatch trigger was added so we could trigger the release after the CHANGELOG was updated. We now need to remove this, because otherwise we can start releasing the `otelbench` image with different changes for the same version.

This way, the workflow to release is:

- Have at least one change in otelbench (this forces a new changelog fragment).
- Bump a new release - this will update the CHANGELOG, only if there are any new changes.
- The previous step will create a PR that once merged triggers the workflow to release a new image.