### PR TITLE
Update unsafe usage of variable in run command

### DIFF
--- a/.github/workflows/bump_otelbench.yaml
+++ b/.github/workflows/bump_otelbench.yaml
@@ -30,9 +30,12 @@ jobs:
       - name: Checks if release is required.
         id: get-new-version
         shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
           chmod +x ./.github/workflows/scripts/check_release.sh
-          ./.github/workflows/scripts/check_release.sh "${{ github.event_name }}" "${{ github.event.inputs.version }}"
+          ./.github/workflows/scripts/check_release.sh "$EVENT_NAME" "$INPUT_VERSION"
 
   update-changelog:
     timeout-minutes: 15


### PR DESCRIPTION
Fix for unsafe usage of input variable inside run step.
![image](https://github.com/user-attachments/assets/e0f33a0f-8939-4aa3-a0d4-dd3d1368f779)
