### PR TITLE
Add support for bearertokenauth

### DIFF
--- a/distributions/elastic-components/manifest.yaml
+++ b/distributions/elastic-components/manifest.yaml
@@ -7,6 +7,7 @@ dist:
 
 extensions:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension v0.120.1
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension v0.120.1
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.120.1
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension v0.120.1
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage v0.120.1


### PR DESCRIPTION
This PR introduces support for `bearertokenauth` as an authentication extension, allowing the `elasticapmreceiver` to authenticate clients using secret tokens.

## Example testing

- Build an OTel collector using the manifest in this PR
- Add the following to your OTel collector configuration
```
receivers:
  otlp/withauth:
    protocols:
      grpc:
        endpoint: $MY_ENDPOINT
        auth:
          authenticator: bearertokenauth/withscheme
      http:
        endpoint: $MY_ENDPOINT
        auth:
          authenticator: bearertokenauth/withscheme

extensions:
  bearertokenauth/withscheme:
    scheme: "Bearer"
    token: "my_token"
```
- Use [`sendotlp`](https://github.com/elastic/otel-apm-e2e-poc/tree/main/sendotlp) to send test data
```
OTEL_RESOURCE_ATTRIBUTES="service.name=sendotlp,some.resource.attribute=resource.attr" go run ./ -endpoint="MY_ENDPOINT" -secret-token="my_token"
```

- relates to https://github.com/elastic/opentelemetry-dev/issues/668