### PR TITLE
[processor/elasticinframetrics] Add support for auto mapping mode

### DIFF
--- a/processor/elasticinframetricsprocessor/factory.go
+++ b/processor/elasticinframetricsprocessor/factory.go
@@ -24,10 +24,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/processor"
-	"go.opentelemetry.io/collector/processor/processorhelper"
 )
-
-var processorCapabilities = consumer.Capabilities{MutatesData: true}
 
 // NewFactory returns a new factory for the Filter processor.
 func NewFactory() processor.Factory {
@@ -46,17 +43,10 @@ func createDefaultConfig() component.Config {
 }
 
 func createMetricsProcessor(
-	ctx context.Context,
+	_ context.Context,
 	set processor.Settings,
 	cfg component.Config,
 	nextConsumer consumer.Metrics,
 ) (processor.Metrics, error) {
-	elasticinframetricsProcessor := newProcessor(set, cfg.(*Config))
-	return processorhelper.NewMetrics(
-		ctx,
-		set,
-		cfg,
-		nextConsumer,
-		elasticinframetricsProcessor.processMetrics,
-		processorhelper.WithCapabilities(processorCapabilities))
+	return newProcessor(set, cfg.(*Config), nextConsumer), nil
 }

--- a/processor/elasticinframetricsprocessor/go.mod
+++ b/processor/elasticinframetricsprocessor/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.120.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.120.0
 	github.com/stretchr/testify v1.10.0
+	go.opentelemetry.io/collector/client v1.26.0
 	go.opentelemetry.io/collector/component v0.120.0
 	go.opentelemetry.io/collector/component/componenttest v0.120.0
 	go.opentelemetry.io/collector/confmap v1.26.0

--- a/processor/elasticinframetricsprocessor/go.sum
+++ b/processor/elasticinframetricsprocessor/go.sum
@@ -62,6 +62,8 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
 go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
+go.opentelemetry.io/collector/client v1.26.0 h1:m/rXHfGzHx4RcETswnm5Y2r1uPv6q0lY+M4btNxbLnE=
+go.opentelemetry.io/collector/client v1.26.0/go.mod h1:H7dkvh+4BbglV1QiyI+AD/aWuqJ3iE5oiYr5oDKtBLw=
 go.opentelemetry.io/collector/component v0.120.0 h1:YHEQ6NuBI6FQHKW24OwrNg2IJ0EUIg4RIuwV5YQ6PSI=
 go.opentelemetry.io/collector/component v0.120.0/go.mod h1:Ya5O+5NWG9XdhJPnOVhKtBrNXHN3hweQbB98HH4KPNU=
 go.opentelemetry.io/collector/component/componentstatus v0.120.0 h1:hzKjI9+AIl8A/saAARb47JqabWsge0kMp8NSPNiCNOQ=

--- a/processor/elasticinframetricsprocessor/testdata/k8smetrics/output-metrics.yaml
+++ b/processor/elasticinframetricsprocessor/testdata/k8smetrics/output-metrics.yaml
@@ -12,6 +12,17 @@ resourceMetrics:
                 - asDouble: 345
                   timeUnixNano: "1000000"
             name: k8s.pod.cpu_limit_utilization
+        schemaUrl: https://test-scope-schema.com/schema
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
+          version: 1.2.3
+  - resource:
+      attributes:
+        - key: k8s.pod.name
+          value:
+            stringValue: test-pod
+    scopeMetrics:
+      - metrics:
           - gauge:
               dataPoints:
                 - asDouble: 345
@@ -120,7 +131,4 @@ resourceMetrics:
                       value:
                         stringValue: kubernetes
                   timeUnixNano: "1000000"
-        schemaUrl: https://test-scope-schema.com/schema
-        scope:
-          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
-          version: 1.2.3
+        scope: {}


### PR DESCRIPTION
With https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/38114, @axw  has added support for controlling the mapping mode of the ES exporter with client metadata (`X-Elastic-Mapping-Mode="<mode>"`).

This PR leverages that in EIMP so that the processor automatically sets the mapping mode to `ecs` for the remapped metrics. This should simplify the overall EDOT configuration because we can just use the default configuration of the ES exporter, without having to create another instance of the exporter with the `ecs` mapping mode.

TODOs:
- [ ] end-to-end testing