### PR TITLE
[IntakeV2 receiver] Use elasticattr constants from opentelemetry-lib

### DIFF
--- a/receiver/elasticapmreceiver/internal/mappers/intakeV2ToDerivedFields.go
+++ b/receiver/elasticapmreceiver/internal/mappers/intakeV2ToDerivedFields.go
@@ -18,9 +18,6 @@
 // This file contains mappings where we move intakeV2 fields into Attributes and Resource attributes on OTel events
 // These fields are not covered by SemConv and are specific to Elastic
 
-// TODO: attribute names should be pulled in from https://github.com/elastic/opentelemetry-lib/blob/main/enrichments/trace/internal/elastic/attributes.go
-// `opentelemetry-lib` already has a PR to do so, after the next release of that repo, we can update this file to use those constants
-
 package mappers // import "github.com/elastic/opentelemetry-collector-components/receiver/elasticapmreceiver/internal/mappers"
 
 import (

--- a/receiver/elasticapmreceiver/internal/mappers/intakeV2ToDerivedFields.go
+++ b/receiver/elasticapmreceiver/internal/mappers/intakeV2ToDerivedFields.go
@@ -27,32 +27,32 @@ import (
 	"strings"
 
 	"github.com/elastic/apm-data/model/modelpb"
+	"github.com/elastic/opentelemetry-lib/elasticattr"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 )
 
 // Sets fields that are NOT part of OTel for transactions. These fields are derived by the Enrichment lib in case of OTLP input
 func SetDerivedFieldsForTransaction(event *modelpb.APMEvent, attributes pcommon.Map) {
-
-	attributes.PutStr("processor.event", "transaction")
-	attributes.PutStr("transaction.id", event.Transaction.Id)
-	attributes.PutStr("transaction.name", event.Transaction.Name)
-	attributes.PutBool("transaction.sampled", event.Transaction.Sampled)
+	attributes.PutStr(elasticattr.ProcessorEvent, "transaction")
+	attributes.PutStr(elasticattr.TransactionID, event.Transaction.Id)
+	attributes.PutStr(elasticattr.TransactionName, event.Transaction.Name)
+	attributes.PutBool(elasticattr.TransactionSampled, event.Transaction.Sampled)
 	// from whatever reason Transaction.Root is always false. That seems to be a derived field already - I don't see that fields directly on IntakeV2 - there is only ParentId
-	attributes.PutBool("transaction.root", event.ParentId == "")
-	attributes.PutStr("transaction.type", event.Transaction.Type)
-	attributes.PutStr("transaction.result", event.Transaction.Result)
-	attributes.PutInt("transaction.duration.us", int64(event.Event.Duration/1_000))
+	attributes.PutBool(elasticattr.TransactionRoot, event.ParentId == "")
+	attributes.PutStr(elasticattr.TransactionType, event.Transaction.Type)
+	attributes.PutStr(elasticattr.TransactionResult, event.Transaction.Result)
+	attributes.PutInt(elasticattr.TransactionDurationUs, int64(event.Event.Duration/1_000))
 }
 
 // Sets fields that are NOT part of OTel for spans. These fields are derived by the Enrichment lib in case of OTLP input
 func SetDerivedFieldsForSpan(event *modelpb.APMEvent, attributes pcommon.Map) {
 
-	attributes.PutStr("processor.event", "span")
-	attributes.PutInt("span.duration.us", int64(event.Event.Duration/1_000))
+	attributes.PutStr(elasticattr.ProcessorEvent, "span")
+	attributes.PutInt(elasticattr.SpanDurationUs, int64(event.Event.Duration/1_000))
 	attributes.PutStr("span.id", event.Span.Id)
-	attributes.PutStr("span.name", event.Span.Name)
-	attributes.PutStr("span.type", event.Span.Type)
-	attributes.PutStr("span.subtype", event.Span.Subtype)
+	attributes.PutStr(elasticattr.SpanName, event.Span.Name)
+	attributes.PutStr(elasticattr.SpanType, event.Span.Type)
+	attributes.PutStr(elasticattr.SpanSubtype, event.Span.Subtype)
 	attributes.PutStr("span.action", event.Span.Action)
 
 	if event.Span.Sync != nil {
@@ -60,16 +60,16 @@ func SetDerivedFieldsForSpan(event *modelpb.APMEvent, attributes pcommon.Map) {
 	}
 
 	if event.Span.DestinationService != nil {
-		attributes.PutStr("service.target.name", event.Span.DestinationService.Name)
-		attributes.PutStr("service.target.type", event.Span.DestinationService.Type)
-		attributes.PutStr("span.destination.service.resource", event.Span.DestinationService.Resource)
+		attributes.PutStr(elasticattr.ServiceTargetName, event.Span.DestinationService.Name)
+		attributes.PutStr(elasticattr.ServiceTargetType, event.Span.DestinationService.Type)
+		attributes.PutStr(elasticattr.SpanDestinationServiceResource, event.Span.DestinationService.Resource)
 	}
 }
 
 // Sets resource fields that are NOT part of OTel. These fields are derived by the Enrichment lib in case of OTLP input
 func SetDerivedResourceAttributes(event *modelpb.APMEvent, attributes pcommon.Map) {
-	attributes.PutStr("agent.name", event.Agent.Name)
-	attributes.PutStr("agent.version", event.Agent.Version)
+	attributes.PutStr(elasticattr.AgentName, event.Agent.Name)
+	attributes.PutStr(elasticattr.AgentVersion, event.Agent.Version)
 	if event.Service != nil && event.Service.Language != nil {
 		if event.Service.Language.Name != "" {
 			attributes.PutStr("service.language.name", event.Service.Language.Name)
@@ -82,13 +82,13 @@ func SetDerivedResourceAttributes(event *modelpb.APMEvent, attributes pcommon.Ma
 
 // Shared across spans and transactions
 func SetDerivedFieldsCommon(event *modelpb.APMEvent, attributes pcommon.Map) {
-	attributes.PutInt("timestamp.us", int64(event.Timestamp/1_000))
+	attributes.PutInt(elasticattr.TimestampUs, int64(event.Timestamp/1_000))
 
 	if strings.EqualFold(event.Event.Outcome, "success") {
-		attributes.PutStr("event.outcome", "success")
+		attributes.PutStr(elasticattr.EventOutcome, "success")
 	} else if strings.EqualFold(event.Event.Outcome, "failure") {
-		attributes.PutStr("event.outcome", "failure")
+		attributes.PutStr(elasticattr.EventOutcome, "failure")
 	} else {
-		attributes.PutStr("event.outcome", "unknown")
+		attributes.PutStr(elasticattr.EventOutcome, "unknown")
 	}
 }


### PR DESCRIPTION
With the latest release of `opentelemetry-lib` we can now reuse elastic specific attributes defined as constants in the `elasticattr` package.

This PR replaces in-place strings with the constants defined in `opentelemetry-lib`.