### PR TITLE
connector/elasticapmconnector: fix component types

### DIFF
--- a/connector/elasticapmconnector/connector.go
+++ b/connector/elasticapmconnector/connector.go
@@ -46,9 +46,11 @@ func newElasticAPMConnector(
 	set connector.Settings,
 	nextConsumer consumer.Metrics,
 ) (*elasticapmConnector, error) {
+	lsmintervalSettings := processor.Settings(set)
+	lsmintervalSettings.ID = component.NewIDWithName(lsmintervalFactory.Type(), set.ID.Name())
 	lsminterval, err := lsmintervalFactory.CreateMetrics(
 		ctx,
-		processor.Settings(set),
+		lsmintervalSettings,
 		cfg.lsmConfig(),
 		nextConsumer,
 	)
@@ -71,13 +73,22 @@ func (c *elasticapmConnector) Shutdown(ctx context.Context) error {
 }
 
 func (c *elasticapmConnector) newLogsConsumer(ctx context.Context) (consumer.Logs, error) {
-	return signaltometricsFactory.CreateLogsToMetrics(ctx, c.set, c.cfg.signaltometricsConfig(), c.lsminterval)
+	set := c.signaltometricsSettings()
+	return signaltometricsFactory.CreateLogsToMetrics(ctx, set, c.cfg.signaltometricsConfig(), c.lsminterval)
 }
 
 func (c *elasticapmConnector) newMetricsConsumer(ctx context.Context) (consumer.Metrics, error) {
-	return signaltometricsFactory.CreateMetricsToMetrics(ctx, c.set, c.cfg.signaltometricsConfig(), c.lsminterval)
+	set := c.signaltometricsSettings()
+	return signaltometricsFactory.CreateMetricsToMetrics(ctx, set, c.cfg.signaltometricsConfig(), c.lsminterval)
 }
 
 func (c *elasticapmConnector) newTracesToMetrics(ctx context.Context) (consumer.Traces, error) {
-	return signaltometricsFactory.CreateTracesToMetrics(ctx, c.set, c.cfg.signaltometricsConfig(), c.lsminterval)
+	set := c.signaltometricsSettings()
+	return signaltometricsFactory.CreateTracesToMetrics(ctx, set, c.cfg.signaltometricsConfig(), c.lsminterval)
+}
+
+func (c *elasticapmConnector) signaltometricsSettings() connector.Settings {
+	signaltometricsSettings := c.set
+	signaltometricsSettings.ID = component.NewIDWithName(signaltometricsFactory.Type(), c.set.ID.Name())
+	return signaltometricsSettings
 }


### PR DESCRIPTION
When constructing the internal lsminterval processor and signaltometrics connector, use the correct component type in the processor/connector settings. This is necessary for us to update to newer versions of opentelemetry-collector core, which is strict about the component type.