### PR TITLE
Group all dependabot directories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,9 @@
 ---
 version: 2
 updates:
-  # TODO: Replace go directories with wildcard https://github.com/dependabot/dependabot-core/issues/2178
-  # All the directories are grouped by ownership
-
-  # Owned by elastic/obs-ds-intake-services
   - package-ecosystem: "gomod"
     directories:
-      - "/processor/lsmintervalprocessor/"
-      - "/processor/elastictraceprocessor/"
-      - "/connector/elasticapmconnector"
+      - "**/*"
     schedule:
       interval: "daily"
     labels:
@@ -19,59 +13,6 @@ updates:
         patterns:
           - "go.opentelemetry.io/*"
           - "github.com/open-telemetry/opentelemetry-collector-contrib/*"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-
-  # Owned by elastic/obs-infraobs-integrations
-  - package-ecosystem: "gomod"
-    directory: "/processor/elasticinframetricsprocessor/"
-    schedule:
-      interval: "daily"
-    labels:
-      - automation
-    groups:
-      otel-dependencies:
-        patterns:
-          - "go.opentelemetry.io/*"
-          - "github.com/open-telemetry/opentelemetry-collector-contrib/*"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-
-  # Owned by elastic/otel-devs (the default)
-  - package-ecosystem: "gomod"
-    directories:
-      - "/processor/ratelimitprocessor/"
-      - "/receiver/loadgenreceiver"
-      - "/receiver/elasticapmreceiver"
-      - "/extension/beatsauthextension"
-    schedule:
-      interval: "daily"
-    labels:
-      - automation
-    groups:
-      otel-dependencies:
-        patterns:
-          - "go.opentelemetry.io/*"
-          - "github.com/open-telemetry/opentelemetry-collector-contrib/*"
-    ignore:
-      - dependency-name: "*"
-        update-types: [ "version-update:semver-major" ]
-
-  # Tools owned by elastic/otel-devs (the default)
-  - package-ecosystem: "gomod"
-    directories:
-      - "/internal/tools/"
-      - "/internal/testutil/"
-    schedule:
-      interval: "daily"
-    labels:
-      - automation
-      - tools
-    groups:
-      otel-dependencies:
-        patterns: ["go.opentelemetry.io/*"]
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION
There have been multiple breaking changes on tools like `mdatagen` which has made it incredibly difficult to keep the versions updated as a breaking change in mdatagen requires all components to update together but our dependabot settings doesn't allow that. So, I am bringing back the proposal in https://github.com/elastic/opentelemetry-collector-components/pull/267/files.