### PR TITLE
Add config `metrics::add_counter_attr` (default=true) to workaround TSDB version conflict by adding loadgenreceiver_counter resource attribute

### DIFF
--- a/receiver/loadgenreceiver/config.go
+++ b/receiver/loadgenreceiver/config.go
@@ -52,6 +52,13 @@ type MetricsConfig struct {
 	// doneCh is only non-nil when the receiver is created with NewFactoryWithDone.
 	// It is to notify the caller of collector that receiver finished replaying the file for MaxReplay number of times.
 	doneCh chan Stats
+
+	// AddCounterAttr, if true, adds a loadgenreceiver_counter resource attribute containing increasing counter value to the generated metrics.
+	// It can be used to workaround timestamp precision and duplication detection of backends,
+	// e.g. Elasticsearch TSDB version_conflict_engine_exception with millisecond-precision timestamp mapping,
+	// which will be triggered when loadgenreceiver generates metrics too quickly such that
+	// there exists data points of the same metric with the same dimensions within a millisecond but different nanoseconds.
+	AddCounterAttr bool `mapstructure:"add_counter_attr"`
 }
 
 type LogsConfig struct {

--- a/receiver/loadgenreceiver/factory.go
+++ b/receiver/loadgenreceiver/factory.go
@@ -34,7 +34,8 @@ func createDefaultReceiverConfig(logsDone, metricsDone, tracesDone chan Stats) c
 			doneCh: logsDone,
 		},
 		Metrics: MetricsConfig{
-			doneCh: metricsDone,
+			doneCh:         metricsDone,
+			AddCounterAttr: true,
 		},
 		Traces: TracesConfig{
 			doneCh: tracesDone,


### PR DESCRIPTION
AddCounterAttr, if true, adds a loadgenreceiver_counter resource attribute containing increasing counter value to the generated metrics.
It can be used to workaround timestamp precision and duplication detection of backends,
e.g. Elasticsearch TSDB version_conflict_engine_exception with millisecond-precision timestamp mapping,
which will be triggered when loadgenreceiver generates metrics too quickly such that
there exists data points of the same metric with the same dimensions within a millisecond but different nanoseconds.
Defaults to true.

Alternative to #493 but with little to no perf overhead.
