### PR TITLE
EIMP: update opentelemetry-lib

### DIFF
--- a/processor/elasticinframetricsprocessor/go.mod
+++ b/processor/elasticinframetricsprocessor/go.mod
@@ -3,7 +3,7 @@ module github.com/elastic/opentelemetry-collector-components/processor/elasticin
 go 1.23.6
 
 require (
-	github.com/elastic/opentelemetry-lib v0.13.0
+	github.com/elastic/opentelemetry-lib v0.16.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.122.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.122.0
 	github.com/stretchr/testify v1.10.0

--- a/processor/elasticinframetricsprocessor/go.sum
+++ b/processor/elasticinframetricsprocessor/go.sum
@@ -3,8 +3,8 @@ github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/elastic/opentelemetry-lib v0.13.0 h1:XVVi09kADu5BNnylc+9c/2uYYErnm7UhnLZlsuYPqdE=
-github.com/elastic/opentelemetry-lib v0.13.0/go.mod h1:WqVSRgczt6XEwr6KJKxB/gxxLpCpfSKLAa1ahTtuc4Y=
+github.com/elastic/opentelemetry-lib v0.16.1 h1:O+E5d6MRjQN5ggRYtaorHcZPzcZHvkz31kwlUFls72M=
+github.com/elastic/opentelemetry-lib v0.16.1/go.mod h1:auZpyxu1jsRUPSYOli6uGbrVZSOFI9ovzzY0Sken3ac=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=


### PR DESCRIPTION
Brings in https://github.com/elastic/opentelemetry-lib/pull/177