### PR TITLE
otelbench: fix benchmark name format to be compliant with x/tools/benchmark

### DIFF
--- a/loadgen/cmd/otelbench/.chloggen/loadgen-otelbench-fix-bench-name-format.yaml
+++ b/loadgen/cmd/otelbench/.chloggen/loadgen-otelbench-fix-bench-name-format.yaml
@@ -1,0 +1,19 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix otelbench benchmark name format to be compliant with x/tools/benchmark
+
+# It is mandatory to specify the component. Do not change this.
+component: otelbench
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues:
+  - 515
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/loadgen/cmd/otelbench/main.go
+++ b/loadgen/cmd/otelbench/main.go
@@ -55,7 +55,7 @@ func getExporters() (exporters []string) {
 }
 
 func fullBenchmarkName(signal, exporter string, concurrency int) string {
-	return fmt.Sprintf("%s-%s-%d", signal, exporter, concurrency)
+	return fmt.Sprintf("BenchmarkOTelbench/%s-%s-%d", signal, exporter, concurrency)
 }
 
 func runBench(ctx context.Context, signal, exporter string, concurrency int, reporter func(b *testing.B)) testing.BenchmarkResult {


### PR DESCRIPTION
Fix loadgen/otelbench benchmark name format so it's compliant with [x/tools/benchmark](https://cs.opensource.google/go/x/tools/+/refs/tags/v0.31.0:benchmark/parse/parse.go;l=48).