### PR TITLE
Revert "Add @elastic/ingest-tech-lead as code owners"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,8 @@
 # Default owners
-* @elastic/otel-devs @elastic/ingest-tech-lead
+* @elastic/otel-devs
 
 # Per-component owners
-processor/elasticinframetricsprocessor @elastic/obs-infraobs-integrations @elastic/ingest-tech-lead
-processor/elastictraceprocessor        @elastic/obs-ds-intake-services @elastic/ingest-tech-lead
-processor/lsmintervalprocessor         @elastic/obs-ds-intake-services @elastic/ingest-tech-lead
-connector/elasticapmconnector          @elastic/obs-ds-intake-services @elastic/ingest-tech-lead
+processor/elasticinframetricsprocessor @elastic/obs-infraobs-integrations
+processor/elastictraceprocessor        @elastic/obs-ds-intake-services
+processor/lsmintervalprocessor         @elastic/obs-ds-intake-services
+connector/elasticapmconnector          @elastic/obs-ds-intake-services


### PR DESCRIPTION
Reverts elastic/opentelemetry-collector-components#505

Adding ingest-tech-lead everywhere had the unintended effect of pinging the leads on every change, which is too much.