### PR TITLE
elasticapmconnector: allow setting custom lsm intervals

### DIFF
--- a/connector/elasticapmconnector/config.go
+++ b/connector/elasticapmconnector/config.go
@@ -18,6 +18,7 @@
 package elasticapmconnector // import "github.com/elastic/opentelemetry-collector-components/connector/elasticapmconnector"
 
 import (
+	"fmt"
 	"time"
 
 	lsmconfig "github.com/elastic/opentelemetry-collector-components/processor/lsmintervalprocessor/config"
@@ -26,6 +27,12 @@ import (
 )
 
 var _ component.Config = (*Config)(nil)
+
+var defaultIntervals []time.Duration = []time.Duration{
+	time.Minute,
+	10 * time.Minute,
+	60 * time.Minute,
+}
 
 type Config struct {
 	// Aggregation holds configuration related to aggregation of Elastic APM
@@ -46,6 +53,15 @@ type AggregationConfig struct {
 	// Entries are case-insensitive, and duplicated entries will trigger
 	// a validation error.
 	MetadataKeys []string `mapstructure:"metadata_keys"`
+
+	// Intervals holds an optional list of time intervals that the processor
+	// will aggregate over. The interval duration must be in increasing
+	// order and must be a factor of the smallest interval duration.
+	// The default aggregation intervals are 1m, 10m and 60m.
+	// These intervals should only be overridden for testing purposes when
+	// faster processor feedback is required, the default intervals
+	// should be always prefered otherwise.
+	Intervals []time.Duration `mapstructure:"intervals"`
 }
 
 func (cfg Config) Validate() error {
@@ -54,29 +70,23 @@ func (cfg Config) Validate() error {
 }
 
 func (cfg Config) lsmConfig() *lsmconfig.Config {
+	intervals := defaultIntervals
+	if cfg.Aggregation != nil && len(cfg.Aggregation.Intervals) != 0 {
+		intervals = cfg.Aggregation.Intervals
+	}
+	intervalConfig := make([]lsmconfig.IntervalConfig, 0, len(intervals))
+	for _, i := range intervals {
+		intervalConfig = append(intervalConfig, lsmconfig.IntervalConfig{
+			Duration: i,
+			Statements: []string{
+				fmt.Sprintf(`set(attributes["metricset.interval"], "%s")`, i),
+				fmt.Sprintf(`set(attributes["data_stream.dataset"], Concat([attributes["metricset.name"], "%s"], "."))`, i),
+				`set(attributes["processor.event"], "metric")`,
+			},
+		})
+	}
 	lsmConfig := &lsmconfig.Config{
-		Intervals: []lsmconfig.IntervalConfig{{
-			Duration: time.Minute,
-			Statements: []string{
-				`set(attributes["metricset.interval"], "1m")`,
-				`set(attributes["data_stream.dataset"], Concat([attributes["metricset.name"], "1m"], "."))`,
-				`set(attributes["processor.event"], "metric")`,
-			},
-		}, {
-			Duration: 10 * time.Minute,
-			Statements: []string{
-				`set(attributes["metricset.interval"], "10m")`,
-				`set(attributes["data_stream.dataset"], Concat([attributes["metricset.name"], "10m"], "."))`,
-				`set(attributes["processor.event"], "metric")`,
-			},
-		}, {
-			Duration: 60 * time.Minute,
-			Statements: []string{
-				`set(attributes["metricset.interval"], "60m")`,
-				`set(attributes["data_stream.dataset"], Concat([attributes["metricset.name"], "60m"], "."))`,
-				`set(attributes["processor.event"], "metric")`,
-			},
-		}},
+		Intervals:                      intervalConfig,
 		ExponentialHistogramMaxBuckets: 160,
 	}
 	if cfg.Aggregation != nil {

--- a/connector/elasticapmconnector/config.go
+++ b/connector/elasticapmconnector/config.go
@@ -79,8 +79,8 @@ func (cfg Config) lsmConfig() *lsmconfig.Config {
 		intervalsConfig = append(intervalsConfig, lsmconfig.IntervalConfig{
 			Duration: i,
 			Statements: []string{
-				fmt.Sprintf(`set(attributes["metricset.interval"], "%s")`, i),
-				fmt.Sprintf(`set(attributes["data_stream.dataset"], Concat([attributes["metricset.name"], "%s"], "."))`, i),
+				fmt.Sprintf(`set(attributes["metricset.interval"], "%dm")`, int(i.Minutes())),
+				fmt.Sprintf(`set(attributes["data_stream.dataset"], Concat([attributes["metricset.name"], "%dm"], "."))`, int(i.Minutes())),
 				`set(attributes["processor.event"], "metric")`,
 			},
 		})

--- a/connector/elasticapmconnector/config.go
+++ b/connector/elasticapmconnector/config.go
@@ -58,9 +58,11 @@ type AggregationConfig struct {
 	// will aggregate over. The interval duration must be in increasing
 	// order and must be a factor of the smallest interval duration.
 	// The default aggregation intervals are 1m, 10m and 60m.
-	// These intervals should only be overridden for testing purposes when
-	// faster processor feedback is required, the default intervals
-	// should be always prefered otherwise.
+	//
+	// NOTE: these intervals should only be overridden for testing purposes when
+	// faster processor feedback is required. The default intervals should be preferred
+	// in all other cases -- using this configuration may lead to invalid behavior,
+	// and will not be supported.
 	Intervals []time.Duration `mapstructure:"intervals"`
 }
 

--- a/connector/elasticapmconnector/config.go
+++ b/connector/elasticapmconnector/config.go
@@ -74,9 +74,9 @@ func (cfg Config) lsmConfig() *lsmconfig.Config {
 	if cfg.Aggregation != nil && len(cfg.Aggregation.Intervals) != 0 {
 		intervals = cfg.Aggregation.Intervals
 	}
-	intervalConfig := make([]lsmconfig.IntervalConfig, 0, len(intervals))
+	intervalsConfig := make([]lsmconfig.IntervalConfig, 0, len(intervals))
 	for _, i := range intervals {
-		intervalConfig = append(intervalConfig, lsmconfig.IntervalConfig{
+		intervalsConfig = append(intervalsConfig, lsmconfig.IntervalConfig{
 			Duration: i,
 			Statements: []string{
 				fmt.Sprintf(`set(attributes["metricset.interval"], "%s")`, i),
@@ -86,7 +86,7 @@ func (cfg Config) lsmConfig() *lsmconfig.Config {
 		})
 	}
 	lsmConfig := &lsmconfig.Config{
-		Intervals:                      intervalConfig,
+		Intervals:                      intervalsConfig,
 		ExponentialHistogramMaxBuckets: 160,
 	}
 	if cfg.Aggregation != nil {

--- a/connector/elasticapmconnector/config_test.go
+++ b/connector/elasticapmconnector/config_test.go
@@ -20,6 +20,7 @@ package elasticapmconnector // import "github.com/elastic/opentelemetry-collecto
 import (
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/elastic/opentelemetry-collector-components/connector/elasticapmconnector/internal/metadata"
 	"github.com/stretchr/testify/assert"
@@ -45,6 +46,7 @@ func TestConfig(t *testing.T) {
 				Aggregation: &AggregationConfig{
 					Directory:    "/path/to/aggregation/state",
 					MetadataKeys: []string{"a", "B", "c"},
+					Intervals:    []time.Duration{time.Second, time.Minute},
 				},
 			},
 		},

--- a/connector/elasticapmconnector/testdata/config/full.yaml
+++ b/connector/elasticapmconnector/testdata/config/full.yaml
@@ -2,3 +2,4 @@ elasticapm:
   aggregation:
     directory: /path/to/aggregation/state
     metadata_keys: [a, B, c]
+    intervals: [1s, 1m]


### PR DESCRIPTION
This PR is exposing lsm intervals configuration to `elasticapmconnector` which makes it possible to configure custom aggregation intervals. This is useful in integration testing where the default intervals are not practical to use. If custom intervals were not provided the config will default to the old intervals values.