### PR TITLE
Delete go.mod in root

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,0 @@
-module github.com/gregkalapos/opentelemetry-collector-components
-
-go 1.22.3


### PR DESCRIPTION
This file is not used and was accidentally added in https://github.com/elastic/opentelemetry-collector-components/pull/294. 