### PR TITLE
otelbench: Log warning if concurrency is unset

### DIFF
--- a/loadgen/cmd/otelbench/README.md
+++ b/loadgen/cmd/otelbench/README.md
@@ -124,6 +124,8 @@ Usage of ./otelbench:
 
 ## Example usage
 
+**It is recommended to explicitly configure `concurrency` to roughly the number of threads of the system running otelbench. Otherwise, `concurrency` will default to 1, and load generation will be single threaded and will send to target with only 1 connection, resulting in an underestimated throughput.**
+
 To send to a local apm-server
 
 ```shell

--- a/loadgen/cmd/otelbench/flags.go
+++ b/loadgen/cmd/otelbench/flags.go
@@ -133,7 +133,6 @@ func Init() error {
 
 	// `concurrency` is similar to `agents` config in apmbench
 	// Each value passed into `concurrency` list will be used as loadgenreceiver `concurrency` config
-	Config.ConcurrencyList = []int{1} // default
 	flag.Func("concurrency", "comma-separated `list` of concurrency (number of simulated agents) to run each benchmark with",
 		func(input string) error {
 			var concurrencyList []int

--- a/loadgen/cmd/otelbench/main.go
+++ b/loadgen/cmd/otelbench/main.go
@@ -116,6 +116,12 @@ func main() {
 	}
 	flag.Parse()
 
+	// default to running with concurrency=1
+	if Config.ConcurrencyList == nil {
+		fmt.Fprintln(os.Stderr, "concurrency is unset, defaulting to 1. This may result in lower throughput")
+		Config.ConcurrencyList = []int{1}
+	}
+
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer cancel()
 


### PR DESCRIPTION
Log a warning when concurrency is unset to make user aware of a possible underestimation of throughput.
