### PR TITLE
Fix changelog otelbench workflow gomod path

### DIFF
--- a/.github/workflows/bump_otelbench.yaml
+++ b/.github/workflows/bump_otelbench.yaml
@@ -66,7 +66,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version-file: internal/tools/go.mod
           cache: 'false'
 
       - name: Cache go tools

--- a/.github/workflows/changelog_otelbench.yaml
+++ b/.github/workflows/changelog_otelbench.yaml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version-file: internal/tools/go.mod
           cache: 'false'
 
       - name: Cache go tools


### PR DESCRIPTION
root go.mod is deleted. Use tools go.mod.
