### PR TITLE
[ratelimit] Add concurrent_requests&request_duration telemetry metrics

### DIFF
--- a/processor/ratelimitprocessor/documentation.md
+++ b/processor/ratelimitprocessor/documentation.md
@@ -6,6 +6,22 @@
 
 The following telemetry is emitted by this component.
 
+### otelcol_ratelimit.concurrent_requests
+
+Number of in-flight requests at any given time
+
+| Unit | Metric Type | Value Type |
+| ---- | ----------- | ---------- |
+| {requests} | Gauge | Int |
+
+### otelcol_ratelimit.request_duration
+
+Time(in seconds) taken to process a rate limit request
+
+| Unit | Metric Type | Value Type |
+| ---- | ----------- | ---------- |
+| {seconds} | Histogram | Double |
+
 ### otelcol_ratelimit.requests
 
 Number of rate-limiting requests

--- a/processor/ratelimitprocessor/factory.go
+++ b/processor/ratelimitprocessor/factory.go
@@ -82,7 +82,7 @@ func createLogsProcessor(
 	}
 	return NewLogsRateLimiterProcessor(
 		rateLimiter,
-		config,
+		config.Strategy,
 		func(ctx context.Context, ld plog.Logs) error {
 			return nextConsumer.ConsumeLogs(ctx, ld)
 		},
@@ -102,7 +102,7 @@ func createMetricsProcessor(
 	}
 	return NewMetricsRateLimiterProcessor(
 		rateLimiter,
-		config,
+		config.Strategy,
 		func(ctx context.Context, md pmetric.Metrics) error {
 			return nextConsumer.ConsumeMetrics(ctx, md)
 		},
@@ -122,7 +122,7 @@ func createTracesProcessor(
 	}
 	return NewTracesRateLimiterProcessor(
 		rateLimiter,
-		config,
+		config.Strategy,
 		func(ctx context.Context, td ptrace.Traces) error {
 			return nextConsumer.ConsumeTraces(ctx, td)
 		},
@@ -142,7 +142,7 @@ func createProfilesProcessor(
 	}
 	return NewProfilesRateLimiterProcessor(
 		rateLimiter,
-		config,
+		config.Strategy,
 		func(ctx context.Context, td pprofile.Profiles) error {
 			return nextConsumer.ConsumeProfiles(ctx, td)
 		},

--- a/processor/ratelimitprocessor/factory.go
+++ b/processor/ratelimitprocessor/factory.go
@@ -82,7 +82,7 @@ func createLogsProcessor(
 	}
 	return NewLogsRateLimiterProcessor(
 		rateLimiter,
-		config.Strategy,
+		config,
 		func(ctx context.Context, ld plog.Logs) error {
 			return nextConsumer.ConsumeLogs(ctx, ld)
 		},
@@ -102,7 +102,7 @@ func createMetricsProcessor(
 	}
 	return NewMetricsRateLimiterProcessor(
 		rateLimiter,
-		config.Strategy,
+		config,
 		func(ctx context.Context, md pmetric.Metrics) error {
 			return nextConsumer.ConsumeMetrics(ctx, md)
 		},
@@ -122,7 +122,7 @@ func createTracesProcessor(
 	}
 	return NewTracesRateLimiterProcessor(
 		rateLimiter,
-		config.Strategy,
+		config,
 		func(ctx context.Context, td ptrace.Traces) error {
 			return nextConsumer.ConsumeTraces(ctx, td)
 		},
@@ -142,7 +142,7 @@ func createProfilesProcessor(
 	}
 	return NewProfilesRateLimiterProcessor(
 		rateLimiter,
-		config.Strategy,
+		config,
 		func(ctx context.Context, td pprofile.Profiles) error {
 			return nextConsumer.ConsumeProfiles(ctx, td)
 		},

--- a/processor/ratelimitprocessor/internal/metadata/generated_telemetry.go
+++ b/processor/ratelimitprocessor/internal/metadata/generated_telemetry.go
@@ -40,10 +40,12 @@ func Tracer(settings component.TelemetrySettings) trace.Tracer {
 // TelemetryBuilder provides an interface for components to report telemetry
 // as defined in metadata and user config.
 type TelemetryBuilder struct {
-	meter             metric.Meter
-	mu                sync.Mutex
-	registrations     []metric.Registration
-	RatelimitRequests metric.Int64Counter
+	meter                       metric.Meter
+	mu                          sync.Mutex
+	registrations               []metric.Registration
+	RatelimitConcurrentRequests metric.Int64Gauge
+	RatelimitRequestDuration    metric.Float64Histogram
+	RatelimitRequests           metric.Int64Counter
 }
 
 // TelemetryBuilderOption applies changes to default builder.
@@ -75,6 +77,19 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 	}
 	builder.meter = Meter(settings)
 	var err, errs error
+	builder.RatelimitConcurrentRequests, err = builder.meter.Int64Gauge(
+		"otelcol_ratelimit.concurrent_requests",
+		metric.WithDescription("Number of in-flight requests at any given time"),
+		metric.WithUnit("{requests}"),
+	)
+	errs = errors.Join(errs, err)
+	builder.RatelimitRequestDuration, err = builder.meter.Float64Histogram(
+		"otelcol_ratelimit.request_duration",
+		metric.WithDescription("Time(in seconds) taken to process a rate limit request"),
+		metric.WithUnit("{seconds}"),
+		metric.WithExplicitBucketBoundaries([]float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10}...),
+	)
+	errs = errors.Join(errs, err)
 	builder.RatelimitRequests, err = builder.meter.Int64Counter(
 		"otelcol_ratelimit.requests",
 		metric.WithDescription("Number of rate-limiting requests"),

--- a/processor/ratelimitprocessor/internal/metadatatest/generated_telemetrytest.go
+++ b/processor/ratelimitprocessor/internal/metadatatest/generated_telemetrytest.go
@@ -38,6 +38,35 @@ func NewSettings(tt *componenttest.Telemetry) processor.Settings {
 	return set
 }
 
+func AssertEqualRatelimitConcurrentRequests(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol_ratelimit.concurrent_requests",
+		Description: "Number of in-flight requests at any given time",
+		Unit:        "{requests}",
+		Data: metricdata.Gauge[int64]{
+			DataPoints: dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol_ratelimit.concurrent_requests")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}
+
+func AssertEqualRatelimitRequestDuration(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.HistogramDataPoint[float64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol_ratelimit.request_duration",
+		Description: "Time(in seconds) taken to process a rate limit request",
+		Unit:        "{seconds}",
+		Data: metricdata.Histogram[float64]{
+			Temporality: metricdata.CumulativeTemporality,
+			DataPoints:  dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol_ratelimit.request_duration")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}
+
 func AssertEqualRatelimitRequests(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_ratelimit.requests",

--- a/processor/ratelimitprocessor/internal/metadatatest/generated_telemetrytest_test.go
+++ b/processor/ratelimitprocessor/internal/metadatatest/generated_telemetrytest_test.go
@@ -36,7 +36,15 @@ func TestSetupTelemetry(t *testing.T) {
 	tb, err := metadata.NewTelemetryBuilder(testTel.NewTelemetrySettings())
 	require.NoError(t, err)
 	defer tb.Shutdown()
+	tb.RatelimitConcurrentRequests.Record(context.Background(), 1)
+	tb.RatelimitRequestDuration.Record(context.Background(), 1)
 	tb.RatelimitRequests.Add(context.Background(), 1)
+	AssertEqualRatelimitConcurrentRequests(t, testTel,
+		[]metricdata.DataPoint[int64]{{Value: 1}},
+		metricdatatest.IgnoreTimestamp())
+	AssertEqualRatelimitRequestDuration(t, testTel,
+		[]metricdata.HistogramDataPoint[float64]{{}}, metricdatatest.IgnoreValue(),
+		metricdatatest.IgnoreTimestamp())
 	AssertEqualRatelimitRequests(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())

--- a/processor/ratelimitprocessor/metadata.yaml
+++ b/processor/ratelimitprocessor/metadata.yaml
@@ -21,7 +21,21 @@ telemetry:
         value_type: int
         monotonic: true
       attributes: ["decision", "limit_threshold", "reason"]
-
+    ratelimit.request_duration:
+      enabled: true
+      description: Time(in seconds) taken to process a rate limit request
+      unit: "{seconds}"
+      histogram:
+        value_type: double
+        monotonic: true
+        bucket_boundaries: [ 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0 ]
+    ratelimit.concurrent_requests:
+      enabled: true
+      description: Number of in-flight requests at any given time
+      unit: "{requests}"
+      gauge:
+        value_type: int
+        monotonic: true
 attributes:
   decision:
     description: rate limit decision


### PR DESCRIPTION
WIP

This PR is to add two more telemetry metrics for rate limit processor:

- `otelcol_ratelimit.concurrent_requests`: records the number of requests that are being processed by the rate limiter at any given moment. 
- `otelcol_ratelimit.request_duration`: Measures the duration of time taken to process each rate limiting request.
