### PR TITLE
extension/apmconfigextension: fix typo in Agent instance_uid attribute

### DIFF
--- a/extension/apmconfigextension/README.md
+++ b/extension/apmconfigextension/README.md
@@ -9,7 +9,7 @@ connect into. The extension will reply with an [OpAMP ServerToAgent
 message](https://github.com/open-telemetry/opamp-spec/blob/main/specification.md#servertoagent-message)
 with the corresponding remote configuration fields.
 
-Central configuration was build for Elastic's APM agents which are identified by
+Central configuration was built for Elastic's APM agents which are identified by
 the
 [service.name](https://www.elastic.co/guide/en/ecs/1.12/ecs-service.html#field-service-name)
 and
@@ -23,8 +23,8 @@ These attributes (`service.name` and optionally `deployment.environment.name`) *
 [AgentDescription.identifying_attributes](https://github.com/open-telemetry/opamp-spec/blob/main/specification.md#agentdescriptionidentifying_attributes)
 field during the first send
 [AgentToServer](https://github.com/open-telemetry/opamp-spec/blob/main/specification.md#agenttoserver-message)
-message. As the `AgentDescription` should not be send if not changed, the
-extension will maintain an internal mapping between the `agent.instance_id` and
+message. As the `AgentDescription` should not be sent if not changed, the
+extension will maintain an internal mapping between the `Agent.instance_uid` and
 its service identifing attributes.
 
 The [ServerToAgent.ReportFullState
@@ -34,7 +34,7 @@ will be set in the following cases:
 - The agent did not include the `service.name` identifing attributes during the
 first message.
 - The OpAMP server was not able to identify the agent (undefined
-`agent.instance_id`).
+`Agent.instance_uid`).
 
 The agent **must** return a message with the corresponding
 `AgentDescription.identifying_attributes`.


### PR DESCRIPTION
Also capitalize Agent so it's more clear it's not a semantic convention attribute.