### PR TITLE
[ratelimiter] Remove wrong error, remove duplicate code

### DIFF
--- a/processor/ratelimitprocessor/documentation.md
+++ b/processor/ratelimitprocessor/documentation.md
@@ -19,5 +19,4 @@ Number of rate-limiting requests
 | Name | Description | Values |
 | ---- | ----------- | ------ |
 | decision | rate limit decision | Any Str |
-| limit_threshold | rate limit threshold | Any Double |
 | reason | rate limit reason | Any Str |

--- a/processor/ratelimitprocessor/factory.go
+++ b/processor/ratelimitprocessor/factory.go
@@ -57,15 +57,10 @@ func getRateLimiter(
 	set processor.Settings,
 ) (*sharedcomponent.Component[rateLimiterComponent], error) {
 	return rateLimiters.LoadOrStore(config, func() (rateLimiterComponent, error) {
-		telemetryBuilder, err := metadata.NewTelemetryBuilder(set.TelemetrySettings)
-		if err != nil {
-			return nil, err
-		}
-
 		if config.Gubernator != nil {
-			return newGubernatorRateLimiter(config, set, telemetryBuilder)
+			return newGubernatorRateLimiter(config, set)
 		}
-		return newLocalRateLimiter(config, set, telemetryBuilder)
+		return newLocalRateLimiter(config, set)
 	})
 }
 
@@ -82,11 +77,12 @@ func createLogsProcessor(
 	}
 	return NewLogsRateLimiterProcessor(
 		rateLimiter,
+		set.TelemetrySettings,
 		config.Strategy,
 		func(ctx context.Context, ld plog.Logs) error {
 			return nextConsumer.ConsumeLogs(ctx, ld)
 		},
-	), nil
+	)
 }
 
 func createMetricsProcessor(
@@ -102,11 +98,12 @@ func createMetricsProcessor(
 	}
 	return NewMetricsRateLimiterProcessor(
 		rateLimiter,
+		set.TelemetrySettings,
 		config.Strategy,
 		func(ctx context.Context, md pmetric.Metrics) error {
 			return nextConsumer.ConsumeMetrics(ctx, md)
 		},
-	), nil
+	)
 }
 
 func createTracesProcessor(
@@ -122,11 +119,12 @@ func createTracesProcessor(
 	}
 	return NewTracesRateLimiterProcessor(
 		rateLimiter,
+		set.TelemetrySettings,
 		config.Strategy,
 		func(ctx context.Context, td ptrace.Traces) error {
 			return nextConsumer.ConsumeTraces(ctx, td)
 		},
-	), nil
+	)
 }
 
 func createProfilesProcessor(
@@ -142,9 +140,10 @@ func createProfilesProcessor(
 	}
 	return NewProfilesRateLimiterProcessor(
 		rateLimiter,
+		set.TelemetrySettings,
 		config.Strategy,
 		func(ctx context.Context, td pprofile.Profiles) error {
 			return nextConsumer.ConsumeProfiles(ctx, td)
 		},
-	), nil
+	)
 }

--- a/processor/ratelimitprocessor/gubernator.go
+++ b/processor/ratelimitprocessor/gubernator.go
@@ -34,8 +34,6 @@ import (
 
 var _ RateLimiter = (*gubernatorRateLimiter)(nil)
 
-var limitPercentDims = []float64{0.95, 0.90, 0.85, 0.75, 0.50, 0.25}
-
 type gubernatorRateLimiter struct {
 	cfg      *Config
 	set      processor.Settings

--- a/processor/ratelimitprocessor/gubernator_test.go
+++ b/processor/ratelimitprocessor/gubernator_test.go
@@ -20,10 +20,11 @@ package ratelimitprocessor
 import (
 	"context"
 	"errors"
-	"go.opentelemetry.io/collector/client"
 	"net"
 	"testing"
 	"time"
+
+	"go.opentelemetry.io/collector/client"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/processor/ratelimitprocessor/internal/telemetry/attributes.go
+++ b/processor/ratelimitprocessor/internal/telemetry/attributes.go
@@ -32,7 +32,6 @@ const (
 
 	StatusUnderLimit Reason = "under_limit"
 
-	LimitError Reason = "limit_error"
 	RequestErr Reason = "request_error"
 )
 

--- a/processor/ratelimitprocessor/local_test.go
+++ b/processor/ratelimitprocessor/local_test.go
@@ -25,13 +25,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/client"
-	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/processor/processortest"
-	"go.opentelemetry.io/otel/metric/noop"
-	"go.uber.org/zap"
-
-	"github.com/elastic/opentelemetry-collector-components/processor/ratelimitprocessor/internal/metadata"
 )
 
 // newTestLocalRateLimiter creates a new localRateLimiter.
@@ -41,14 +36,7 @@ func newTestLocalRateLimiter(t *testing.T, cfg *Config) *localRateLimiter {
 	}
 	require.Nil(t, cfg.Gubernator)
 
-	telemetrySettings := component.TelemetrySettings{
-		MeterProvider: noop.NewMeterProvider(),
-		Logger:        zap.NewNop(),
-	}
-	telemetryBuilder, err := metadata.NewTelemetryBuilder(telemetrySettings)
-	assert.NoError(t, err)
-
-	rl, err := newLocalRateLimiter(cfg, processortest.NewNopSettings(processortest.NopType), telemetryBuilder)
+	rl, err := newLocalRateLimiter(cfg, processortest.NewNopSettings(processortest.NopType))
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		err := rl.Shutdown(context.Background())

--- a/processor/ratelimitprocessor/metadata.yaml
+++ b/processor/ratelimitprocessor/metadata.yaml
@@ -20,15 +20,12 @@ telemetry:
       sum:
         value_type: int
         monotonic: true
-      attributes: ["decision", "limit_threshold", "reason"]
+      attributes: ["decision", "reason"]
 
 attributes:
   decision:
     description: rate limit decision
     type: string
-  limit_threshold:
-    description: rate limit threshold
-    type: double
   reason:
     description: rate limit reason
     type: string

--- a/processor/ratelimitprocessor/processor.go
+++ b/processor/ratelimitprocessor/processor.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/elastic/opentelemetry-collector-components/processor/ratelimitprocessor/internal/metadata"
 	"github.com/elastic/opentelemetry-collector-components/processor/ratelimitprocessor/internal/telemetry"
@@ -181,14 +180,14 @@ func getTelemetryAttrs(ctx context.Context, metadataKeys []string, err error) []
 			telemetry.WithReason(telemetry.StatusUnderLimit),
 			telemetry.WithDecision("accepted"),
 		)
-	case errors.Is(err, errRateLimitInternalError) || strings.HasPrefix(err.Error(), "expected 1 response"):
-		attrs = append(attrs,
-			telemetry.WithReason(telemetry.RequestErr),
-			telemetry.WithDecision("accepted"),
-		)
 	case errors.Is(err, errTooManyRequests):
 		attrs = append(attrs,
 			telemetry.WithDecision("throttled"),
+		)
+	default:
+		attrs = append(attrs,
+			telemetry.WithReason(telemetry.RequestErr),
+			telemetry.WithDecision("accepted"),
 		)
 	}
 

--- a/processor/ratelimitprocessor/processor.go
+++ b/processor/ratelimitprocessor/processor.go
@@ -21,6 +21,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
+
 	"github.com/elastic/opentelemetry-collector-components/processor/ratelimitprocessor/internal/metadata"
 	"github.com/elastic/opentelemetry-collector-components/processor/ratelimitprocessor/internal/telemetry"
 	"go.opentelemetry.io/collector/component"
@@ -31,7 +33,6 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
-	"strings"
 
 	"github.com/elastic/opentelemetry-collector-components/internal/sharedcomponent"
 )

--- a/processor/ratelimitprocessor/processor_test.go
+++ b/processor/ratelimitprocessor/processor_test.go
@@ -19,13 +19,14 @@ package ratelimitprocessor
 
 import (
 	"context"
+	"testing"
+
 	"github.com/elastic/opentelemetry-collector-components/processor/ratelimitprocessor/internal/metadata"
 	"github.com/elastic/opentelemetry-collector-components/processor/ratelimitprocessor/internal/telemetry"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
-	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/processor/ratelimitprocessor/ratelimiter.go
+++ b/processor/ratelimitprocessor/ratelimiter.go
@@ -20,8 +20,9 @@ package ratelimitprocessor // import "github.com/elastic/opentelemetry-collector
 import (
 	"context"
 	"errors"
-	"go.opentelemetry.io/otel/attribute"
 	"strings"
+
+	"go.opentelemetry.io/otel/attribute"
 
 	"go.opentelemetry.io/collector/client"
 )

--- a/processor/ratelimitprocessor/ratelimiter.go
+++ b/processor/ratelimitprocessor/ratelimiter.go
@@ -20,10 +20,10 @@ package ratelimitprocessor // import "github.com/elastic/opentelemetry-collector
 import (
 	"context"
 	"errors"
+	"go.opentelemetry.io/otel/attribute"
 	"strings"
 
 	"go.opentelemetry.io/collector/client"
-	"go.opentelemetry.io/otel/attribute"
 )
 
 var (
@@ -52,20 +52,6 @@ type RateLimiter interface {
 // high cardinality: tenant ID would be a good choice. For rate
 // limiting by IP (e.g. to avoid DDoS), consider running OpenTelemetry
 // Collector behind a WAF/API Gateway/proxy.
-
-func attrsFromMetadata(ctx context.Context, metadataKeys []string, attrs []attribute.KeyValue) []attribute.KeyValue {
-	clientInfo := client.FromContext(ctx)
-
-	for _, key := range metadataKeys {
-		values := clientInfo.Metadata.Get(key)
-		if len(values) > 0 {
-			attrs = append(attrs, attribute.String(key, strings.Join(values, ",")))
-		}
-	}
-
-	return attrs
-}
-
 func getUniqueKey(ctx context.Context, metadataKeys []string) string {
 	if len(metadataKeys) == 0 {
 		return "default"
@@ -89,4 +75,19 @@ func getUniqueKey(ctx context.Context, metadataKeys []string) string {
 		}
 	}
 	return uniqueKey.String()
+}
+
+// getAttrsFromContext looks up for the metadata keys in the
+// context and returns the values as attributes.
+func getAttrsFromContext(ctx context.Context, metadataKeys []string) []attribute.KeyValue {
+	clientInfo := client.FromContext(ctx)
+
+	attrs := make([]attribute.KeyValue, 0, len(metadataKeys))
+	for _, key := range metadataKeys {
+		values := clientInfo.Metadata.Get(key)
+		if len(values) > 0 {
+			attrs = append(attrs, attribute.String(key, strings.Join(values, ",")))
+		}
+	}
+	return attrs
 }


### PR DESCRIPTION
This PR:

- Removes the too many requests error wrongly introduced in https://github.com/elastic/opentelemetry-collector-components/pull/562.
- Removes the duplicate code to declare metrics