### PR TITLE
[ratelimit] Add concurrent_requests and request_duration telemetry metrics

### DIFF
--- a/processor/ratelimitprocessor/documentation.md
+++ b/processor/ratelimitprocessor/documentation.md
@@ -6,6 +6,22 @@
 
 The following telemetry is emitted by this component.
 
+### otelcol_ratelimit.concurrent_requests
+
+Number of in-flight requests at any given time
+
+| Unit | Metric Type | Value Type |
+| ---- | ----------- | ---------- |
+| {requests} | Gauge | Int |
+
+### otelcol_ratelimit.request_duration
+
+Time(in seconds) taken to process a rate limit request
+
+| Unit | Metric Type | Value Type |
+| ---- | ----------- | ---------- |
+| {seconds} | Histogram | Double |
+
 ### otelcol_ratelimit.requests
 
 Number of rate-limiting requests

--- a/processor/ratelimitprocessor/factory.go
+++ b/processor/ratelimitprocessor/factory.go
@@ -99,6 +99,7 @@ func createMetricsProcessor(
 	if err != nil {
 		return nil, err
 	}
+	var inflight int64
 	return NewMetricsRateLimiterProcessor(
 		rateLimiter,
 		set.TelemetrySettings,
@@ -106,6 +107,7 @@ func createMetricsProcessor(
 		func(ctx context.Context, md pmetric.Metrics) error {
 			return nextConsumer.ConsumeMetrics(ctx, md)
 		},
+		&inflight,
 	)
 }
 
@@ -120,6 +122,7 @@ func createTracesProcessor(
 	if err != nil {
 		return nil, err
 	}
+	var inflight int64
 	return NewTracesRateLimiterProcessor(
 		rateLimiter,
 		set.TelemetrySettings,
@@ -127,6 +130,7 @@ func createTracesProcessor(
 		func(ctx context.Context, td ptrace.Traces) error {
 			return nextConsumer.ConsumeTraces(ctx, td)
 		},
+		&inflight,
 	)
 }
 
@@ -141,6 +145,7 @@ func createProfilesProcessor(
 	if err != nil {
 		return nil, err
 	}
+	var inflight int64
 	return NewProfilesRateLimiterProcessor(
 		rateLimiter,
 		set.TelemetrySettings,
@@ -148,5 +153,6 @@ func createProfilesProcessor(
 		func(ctx context.Context, td pprofile.Profiles) error {
 			return nextConsumer.ConsumeProfiles(ctx, td)
 		},
+		&inflight,
 	)
 }

--- a/processor/ratelimitprocessor/factory.go
+++ b/processor/ratelimitprocessor/factory.go
@@ -75,6 +75,8 @@ func createLogsProcessor(
 	if err != nil {
 		return nil, err
 	}
+
+	var inflight int64
 	return NewLogsRateLimiterProcessor(
 		rateLimiter,
 		set.TelemetrySettings,
@@ -82,6 +84,7 @@ func createLogsProcessor(
 		func(ctx context.Context, ld plog.Logs) error {
 			return nextConsumer.ConsumeLogs(ctx, ld)
 		},
+		&inflight,
 	)
 }
 

--- a/processor/ratelimitprocessor/internal/metadatatest/generated_telemetrytest.go
+++ b/processor/ratelimitprocessor/internal/metadatatest/generated_telemetrytest.go
@@ -38,6 +38,35 @@ func NewSettings(tt *componenttest.Telemetry) processor.Settings {
 	return set
 }
 
+func AssertEqualRatelimitConcurrentRequests(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol_ratelimit.concurrent_requests",
+		Description: "Number of in-flight requests at any given time",
+		Unit:        "{requests}",
+		Data: metricdata.Gauge[int64]{
+			DataPoints: dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol_ratelimit.concurrent_requests")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}
+
+func AssertEqualRatelimitRequestDuration(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.HistogramDataPoint[float64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol_ratelimit.request_duration",
+		Description: "Time(in seconds) taken to process a rate limit request",
+		Unit:        "{seconds}",
+		Data: metricdata.Histogram[float64]{
+			Temporality: metricdata.CumulativeTemporality,
+			DataPoints:  dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol_ratelimit.request_duration")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}
+
 func AssertEqualRatelimitRequests(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_ratelimit.requests",

--- a/processor/ratelimitprocessor/internal/metadatatest/generated_telemetrytest_test.go
+++ b/processor/ratelimitprocessor/internal/metadatatest/generated_telemetrytest_test.go
@@ -36,7 +36,15 @@ func TestSetupTelemetry(t *testing.T) {
 	tb, err := metadata.NewTelemetryBuilder(testTel.NewTelemetrySettings())
 	require.NoError(t, err)
 	defer tb.Shutdown()
+	tb.RatelimitConcurrentRequests.Record(context.Background(), 1)
+	tb.RatelimitRequestDuration.Record(context.Background(), 1)
 	tb.RatelimitRequests.Add(context.Background(), 1)
+	AssertEqualRatelimitConcurrentRequests(t, testTel,
+		[]metricdata.DataPoint[int64]{{Value: 1}},
+		metricdatatest.IgnoreTimestamp())
+	AssertEqualRatelimitRequestDuration(t, testTel,
+		[]metricdata.HistogramDataPoint[float64]{{}}, metricdatatest.IgnoreValue(),
+		metricdatatest.IgnoreTimestamp())
 	AssertEqualRatelimitRequests(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())

--- a/processor/ratelimitprocessor/metadata.yaml
+++ b/processor/ratelimitprocessor/metadata.yaml
@@ -21,7 +21,21 @@ telemetry:
         value_type: int
         monotonic: true
       attributes: ["decision", "reason"]
-
+    ratelimit.request_duration:
+      enabled: true
+      description: Time(in seconds) taken to process a rate limit request
+      unit: "{seconds}"
+      histogram:
+        value_type: double
+        monotonic: true
+        bucket_boundaries: [ 0.0001, 0.0005, 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0 ]
+    ratelimit.concurrent_requests:
+      enabled: true
+      description: Number of in-flight requests at any given time
+      unit: "{requests}"
+      gauge:
+        value_type: int
+        monotonic: true
 attributes:
   decision:
     description: rate limit decision

--- a/processor/ratelimitprocessor/processor.go
+++ b/processor/ratelimitprocessor/processor.go
@@ -214,6 +214,7 @@ func rateLimit(
 	inflight *int64,
 ) error {
 	startTime := time.Now()
+	atomic.AddInt64(inflight, 1)
 	current := atomic.LoadInt64(inflight)
 	telemetryBuilder.RatelimitConcurrentRequests.Record(ctx, current)
 	defer func() {

--- a/processor/ratelimitprocessor/processor.go
+++ b/processor/ratelimitprocessor/processor.go
@@ -214,8 +214,8 @@ func rateLimit(
 	inflight *int64,
 ) error {
 	startTime := time.Now()
-	atomic.AddInt64(inflight, 1)
-	telemetryBuilder.RatelimitConcurrentRequests.Record(ctx, *inflight)
+	current := atomic.LoadInt64(inflight)
+	telemetryBuilder.RatelimitConcurrentRequests.Record(ctx, current)
 	defer func() {
 		duration := time.Since(startTime).Seconds()
 		telemetryBuilder.RatelimitRequestDuration.Record(ctx, duration)

--- a/processor/ratelimitprocessor/processor.go
+++ b/processor/ratelimitprocessor/processor.go
@@ -99,6 +99,7 @@ func NewMetricsRateLimiterProcessor(
 	telemetrySettings component.TelemetrySettings,
 	strategy Strategy,
 	next func(ctx context.Context, metrics pmetric.Metrics) error,
+	inflight *int64,
 ) (*MetricsRateLimiterProcessor, error) {
 	telemetryBuilder, err := metadata.NewTelemetryBuilder(telemetrySettings)
 	if err != nil {
@@ -110,6 +111,7 @@ func NewMetricsRateLimiterProcessor(
 			Component:        rateLimiter,
 			rl:               rateLimiter.Unwrap(),
 			telemetryBuilder: telemetryBuilder,
+			inflight:         inflight,
 		},
 		count: getMetricsCountFunc(strategy),
 		next:  next,
@@ -121,6 +123,7 @@ func NewTracesRateLimiterProcessor(
 	telemetrySettings component.TelemetrySettings,
 	strategy Strategy,
 	next func(ctx context.Context, traces ptrace.Traces) error,
+	inflight *int64,
 ) (*TracesRateLimiterProcessor, error) {
 	telemetryBuilder, err := metadata.NewTelemetryBuilder(telemetrySettings)
 	if err != nil {
@@ -132,6 +135,7 @@ func NewTracesRateLimiterProcessor(
 			Component:        rateLimiter,
 			rl:               rateLimiter.Unwrap(),
 			telemetryBuilder: telemetryBuilder,
+			inflight:         inflight,
 		},
 		count: getTracesCountFunc(strategy),
 		next:  next,
@@ -143,6 +147,7 @@ func NewProfilesRateLimiterProcessor(
 	telemetrySettings component.TelemetrySettings,
 	strategy Strategy,
 	next func(ctx context.Context, profiles pprofile.Profiles) error,
+	inflight *int64,
 ) (*ProfilesRateLimiterProcessor, error) {
 	telemetryBuilder, err := metadata.NewTelemetryBuilder(telemetrySettings)
 	if err != nil {
@@ -154,6 +159,7 @@ func NewProfilesRateLimiterProcessor(
 			Component:        rateLimiter,
 			rl:               rateLimiter.Unwrap(),
 			telemetryBuilder: telemetryBuilder,
+			inflight:         inflight,
 		},
 		count: getProfilesCountFunc(strategy),
 		next:  next,


### PR DESCRIPTION
## Description
This PR is to add two more telemetry metrics for rate limit processor:

- `otelcol_ratelimit.concurrent_requests`: records the number of requests that are being processed by the rate limiter at any given moment. 
- `otelcol_ratelimit.request_duration`: Measures the duration of time taken to process each rate limiting request.

## Sample documents
```
{
  "_index": ".ds-metrics-apm.app.hosted_otel_collector-default-2025.05.29-000001",
  "_id": "nfKmH5cBiYL18_Vh6pN_",
  "_version": 1,
  "_source": {
    "@timestamp": "2025-05-30T05:25:21.304Z",
    "agent": {
      "name": "otlp",
      "version": "unknown"
    },
    "data_stream": {
      "dataset": "apm.app.hosted_otel_collector",
      "namespace": "default",
      "type": "metrics"
    },
    "event": {
      "ingested": "2025-05-30T05:25:22.000Z"
    },
    "labels": {
      "orchestrator_cluster_name": "default",
      "orchestrator_deploymentslice": "",
      "orchestrator_environment": "default"
    },
    "metricset": {
      "name": "app"
    },
    "observer": {
      "hostname": "apm-server-apm-server-7c84d6c6bf-rgbkp",
      "type": "apm-server",
      "version": "8.18.1"
    },
    "otelcol_ratelimit": {
      "request_duration": {
        "values": [
          0.00030000000000000003,
          0.00075,
          0.003,
          0.0075,
          0.0175,
          0.037500000000000006,
          0.07500000000000001,
          0.30000000000000004,
          0.75
        ],
        "counts": [
          45,
          110,
          233,
          43,
          29,
          54,
          1229,
          367,
          6
        ]
      }
    },
    "service": {
      "framework": {
        "name": "github.com/elastic/opentelemetry-collector-components/processor/ratelimitprocessor"
      },
      "language": {
        "name": "unknown"
      },
      "name": "hosted-otel-collector",
      "node": {
        "name": "e79e6174-23eb-476e-8fa3-02a735596876"
      },
      "version": "git"
    }
  }
}
```
and 
```
{
  "_index": ".ds-metrics-apm.app.hosted_otel_collector-default-2025.05.29-000001",
  "_id": "nPKmH5cBiYL18_Vh6pN_",
  "_version": 1,
  "_source": {
    "@timestamp": "2025-05-30T05:25:21.304Z",
    "agent": {
      "name": "otlp",
      "version": "unknown"
    },
    "data_stream": {
      "dataset": "apm.app.hosted_otel_collector",
      "namespace": "default",
      "type": "metrics"
    },
    "event": {
      "ingested": "2025-05-30T05:25:22.000Z"
    },
    "labels": {
      "orchestrator_cluster_name": "default",
      "orchestrator_deploymentslice": "",
      "orchestrator_environment": "default"
    },
    "metricset": {
      "name": "app"
    },
    "observer": {
      "hostname": "apm-server-apm-server-7c84d6c6bf-rgbkp",
      "type": "apm-server",
      "version": "8.18.1"
    },
    "otelcol_ratelimit": {
      "concurrent_requests": 10
    },
    "service": {
      "framework": {
        "name": "github.com/elastic/opentelemetry-collector-components/processor/ratelimitprocessor"
      },
      "language": {
        "name": "unknown"
      },
      "name": "hosted-otel-collector",
      "node": {
        "name": "e79e6174-23eb-476e-8fa3-02a735596876"
      },
      "version": "git"
    }
  }
}
```