### PR TITLE
Add metadata keys for rate limiter telemetry metrics

### DIFF
--- a/processor/ratelimitprocessor/factory.go
+++ b/processor/ratelimitprocessor/factory.go
@@ -85,6 +85,7 @@ func createLogsProcessor(
 			return nextConsumer.ConsumeLogs(ctx, ld)
 		},
 		&inflight,
+		config.MetadataKeys,
 	)
 }
 
@@ -108,6 +109,7 @@ func createMetricsProcessor(
 			return nextConsumer.ConsumeMetrics(ctx, md)
 		},
 		&inflight,
+		config.MetadataKeys,
 	)
 }
 
@@ -131,6 +133,7 @@ func createTracesProcessor(
 			return nextConsumer.ConsumeTraces(ctx, td)
 		},
 		&inflight,
+		config.MetadataKeys,
 	)
 }
 
@@ -154,5 +157,6 @@ func createProfilesProcessor(
 			return nextConsumer.ConsumeProfiles(ctx, td)
 		},
 		&inflight,
+		config.MetadataKeys,
 	)
 }

--- a/processor/ratelimitprocessor/metadata.yaml
+++ b/processor/ratelimitprocessor/metadata.yaml
@@ -27,6 +27,7 @@ telemetry:
       unit: "{seconds}"
       histogram:
         value_type: double
+        monotonic: true
         bucket_boundaries: [ 0.0001, 0.0005, 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0 ]
     ratelimit.concurrent_requests:
       enabled: true

--- a/processor/ratelimitprocessor/metadata.yaml
+++ b/processor/ratelimitprocessor/metadata.yaml
@@ -27,7 +27,6 @@ telemetry:
       unit: "{seconds}"
       histogram:
         value_type: double
-        monotonic: true
         bucket_boundaries: [ 0.0001, 0.0005, 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0 ]
     ratelimit.concurrent_requests:
       enabled: true

--- a/processor/ratelimitprocessor/processor_test.go
+++ b/processor/ratelimitprocessor/processor_test.go
@@ -40,12 +40,14 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
 )
 
-var inflight int64
-
-var clientContext = client.NewContext(context.Background(), client.Info{
-	Metadata: client.NewMetadata(map[string][]string{
-		"x-elastic-project-id": {"TestProjectID"},
-	})})
+var (
+	inflight      int64
+	clientContext = client.NewContext(context.Background(), client.Info{
+		Metadata: client.NewMetadata(map[string][]string{
+			"x-elastic-project-id": {"TestProjectID"},
+		}),
+	})
+)
 
 func TestGetCountFunc_Logs(t *testing.T) {
 	logs := plog.NewLogs()


### PR DESCRIPTION
With this fix, we can see metadata keys in documents, for example:
```
{
  "_index": ".ds-metrics-apm.app.hosted_otel_collector-default-2025.05.31-000001",
  "_id": "S51jMpcBnkooZBdL-MnS",
  "_version": 1,
  "_source": {
    "@timestamp": "2025-06-02T20:45:01.030Z",
    "agent": {
      "name": "otlp",
      "version": "unknown"
    },
    "data_stream": {
      "dataset": "apm.app.hosted_otel_collector",
      "namespace": "default",
      "type": "metrics"
    },
    "event": {
      "ingested": "2025-06-02T20:45:02.000Z"
    },
    "labels": {
      "orchestrator_cluster_name": "default",
      "orchestrator_deploymentslice": "",
      "orchestrator_environment": "default",
      "x-elastic-project-id": "local"
    },
    "metricset": {
      "name": "app"
    },
    "otelcol_ratelimit": {
      "concurrent_requests": 8
    }
  }
}
```