### PR TITLE
Add cumulativetodelta processor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ remove-toolchain:
 # Build a collector based on the Elastic components (generate Elastic collector)
 .PHONY: genelasticcol
 genelasticcol: $(BUILDER)
-	$(BUILDER) --config ./distributions/elastic-components/manifest.yaml
+	GOOS=${TARGET_GOOS} GOARCH=${TARGET_GOARCH} $(BUILDER) --config ./distributions/elastic-components/manifest.yaml
 
 # Validate that the Elastic components collector can run with the example configuration.
 .PHONY: elasticcol-validate

--- a/README.md
+++ b/README.md
@@ -19,13 +19,11 @@ In order to build a collector with a custom component, e.g. for testing purposes
    - If you are testing a non-published version of the component, add an entry to the `replace` section, pointing to the local path of 
      the component's source.
 2. Build the collector through the `genelasticcol` target of the root [Makefile](Makefile). 
-   Make sure to provide `GOOS` and/or `GOARCH` environment variables if you are building for a different platform. 
+   Make sure to provide `TARGET_GOOS` and/or `TARGET_GOARCH` environment variables if you are building for a different platform. 
    For example, when building on macOS in order to run through the Linux Docker image that is built by the `builddocker` make target 
    (see next bullet) - use the following command:
    ```shell
-   make install-tools
-   make install-tools
-   GOOS=linux CGO_ENABLED=0 make genelasticcol
+   TARGET_GOOS=linux CGO_ENABLED=0 make genelasticcol
    ```
    The resulting binary will be placed in the `_build` directory.
 3. In order to build a Docker image with the collector, run the `builddocker` target of the root [Makefile](Makefile). 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ In order to build a collector with a custom component, e.g. for testing purposes
    For example, when building on macOS in order to run through the Linux Docker image that is built by the `builddocker` make target 
    (see next bullet) - use the following command:
    ```shell
+   make install-tools
+   make install-tools
    GOOS=linux CGO_ENABLED=0 make genelasticcol
    ```
    The resulting binary will be placed in the `_build` directory.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ In order to build a collector with a custom component, e.g. for testing purposes
    - If you are testing a non-published version of the component, add an entry to the `replace` section, pointing to the local path of 
      the component's source.
 2. Build the collector through the `genelasticcol` target of the root [Makefile](Makefile). 
-   Make sure to provide `TARGET_GOOS` and/or `TARGET_GOARCH` environment variables if you are building for a different platform. 
+   Make sure to provide `TARGET_GOOS` and/or `TARGET_GOARCH` environment variables if you are building for a different platform.
    For example, when building on macOS in order to run through the Linux Docker image that is built by the `builddocker` make target 
    (see next bullet) - use the following command:
    ```shell

--- a/distributions/elastic-components/manifest.yaml
+++ b/distributions/elastic-components/manifest.yaml
@@ -42,6 +42,7 @@ receivers:
 processors:
   - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.127.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.127.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor v0.127.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.127.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor v0.127.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.127.0


### PR DESCRIPTION
I noticed EDOT collector doesn't have `cumulativetodelta` processor. It seems useful to include it because currently APM only supports delta metrics FWIU. For example, if scraping prometheus endpoints with the collector, this processor can be used to get them into APM.

I also fixed cross compile on MacOS - `builder` was also being built with the provided `GOOS` causing it to be not executable.

/cc @codefromthecrypt 