### PR TITLE
refactor: rename agent_config to source config option

### DIFF
--- a/extension/apmconfigextension/README.md
+++ b/extension/apmconfigextension/README.md
@@ -75,7 +75,7 @@ extensions:
     token: "<ENCODED_ELASTICSEACH_APIKEY>"
 
   apmconfig:
-    fetcher:
+    source:
      elasticsearch:
        endpoint: "<ELASTICSEACH_ENDPOINT>"
        auth:
@@ -89,9 +89,9 @@ extensions:
 
 ## Advanced configuration
 
-### Remote configurations fetcher
+### Remote configurations source
 
-The apmconfig extension fetches remote configuration data from an Elasticsearch cluster. This is configured under the `fetcher::elasticsearch` section.
+The apmconfig extension retrieves remote configuration data from an Elasticsearch cluster. This is configured under the `source::elasticsearch` section.
 
 All available Elasticsearch client configuration options can be found [here](https://github.com/elastic/opentelemetry-lib/blob/v0.18.0/config/configelasticsearch/configclient.go#L69). The configuration embeds the [configauth authenticator](https://github.com/open-telemetry/opentelemetry-collector/blob/v0.125.0/config/configauth/README.md), allowing the use of standard authentication extensions such as [bearertokenauth](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.125.0/extension/bearertokenauthextension) and [basicauth](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.125.0/extension/basicauthextension).
 

--- a/extension/apmconfigextension/config.go
+++ b/extension/apmconfigextension/config.go
@@ -34,14 +34,14 @@ const (
 )
 
 type Config struct {
-	// Fetcher defines the remote configuration fetcher settings.
-	Fetcher FetcherConfig `mapstructure:"fetcher"`
+	// Source defines the remote configuration source settings.
+	Source SourceConfig `mapstructure:"source"`
 
 	// OpAMP defines the configuration for the embedded OpAMP server.
 	OpAMP OpAMPConfig `mapstructure:"opamp"`
 }
 
-type FetcherConfig struct {
+type SourceConfig struct {
 	// Elasticsearch configures a fetcher that retrieves remote configuration
 	// data from an Elasticsearch cluster.
 	Elasticsearch *ElasticsearchFetcher `mapstructure:"elasticsearch"`

--- a/extension/apmconfigextension/config_test.go
+++ b/extension/apmconfigextension/config_test.go
@@ -34,7 +34,7 @@ func TestUnmarshalDefaultConfig(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	require.NoError(t, cm.Unmarshal(&cfg))
 	assert.Equal(t, factory.CreateDefaultConfig(), cfg)
-	assert.EqualError(t, xconfmap.Validate(cfg), "fetcher::elasticsearch::clientconfig: exactly one of [endpoint, endpoints, cloudid] must be specified")
+	assert.EqualError(t, xconfmap.Validate(cfg), "source::elasticsearch::clientconfig: exactly one of [endpoint, endpoints, cloudid] must be specified")
 }
 
 func TestUnmarshalConfigInvalidProtocol(t *testing.T) {
@@ -60,5 +60,5 @@ func TestUnmarshalConfigInvalidCacheDuration(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 	require.NoError(t, cm.Unmarshal(&cfg))
-	assert.EqualError(t, xconfmap.Validate(cfg), "fetcher::elasticsearch: cache_duration requires positive value")
+	assert.EqualError(t, xconfmap.Validate(cfg), "source::elasticsearch: cache_duration requires positive value")
 }

--- a/extension/apmconfigextension/factory.go
+++ b/extension/apmconfigextension/factory.go
@@ -49,7 +49,7 @@ func createDefaultConfig() component.Config {
 	httpCfg.TLSSetting = nil
 
 	return &Config{
-		Fetcher: FetcherConfig{
+		Source: SourceConfig{
 			Elasticsearch: &ElasticsearchFetcher{
 				ClientConfig: defaultElasticSearchClient,
 				// using apm-server default
@@ -67,11 +67,11 @@ func createDefaultConfig() component.Config {
 func createExtension(_ context.Context, set extension.Settings, cfg component.Config) (extension.Extension, error) {
 	extCfg := cfg.(*Config)
 	elasticsearchRemoteConfig := func(ctx context.Context, host component.Host, telemetry component.TelemetrySettings) (apmconfig.RemoteConfigClient, error) {
-		esClient, err := extCfg.Fetcher.Elasticsearch.ClientConfig.ToClient(ctx, host, telemetry)
+		esClient, err := extCfg.Source.Elasticsearch.ClientConfig.ToClient(ctx, host, telemetry)
 		if err != nil {
 			return nil, err
 		}
-		fetcher := agentcfg.NewElasticsearchFetcher(esClient, extCfg.Fetcher.Elasticsearch.CacheDuration, telemetry.Logger)
+		fetcher := agentcfg.NewElasticsearchFetcher(esClient, extCfg.Source.Elasticsearch.CacheDuration, telemetry.Logger)
 
 		var wg sync.WaitGroup
 		wg.Add(1)

--- a/extension/apmconfigextension/integration_test.go
+++ b/extension/apmconfigextension/integration_test.go
@@ -372,7 +372,7 @@ func apmConfigintegrationTest(name string) func(t *testing.T) {
 
 		extFactory := NewFactory()
 		cfg := &Config{
-			Fetcher: FetcherConfig{
+			Source: SourceConfig{
 				Elasticsearch: &ElasticsearchFetcher{
 					ClientConfig: configelasticsearch.ClientConfig{
 						Endpoints: []string{esEndpoint},

--- a/extension/apmconfigextension/metadata.yaml
+++ b/extension/apmconfigextension/metadata.yaml
@@ -14,6 +14,6 @@ tests:
       protocols:
         http:
           endpoint: localhost:8200
-    fetcher:
+    source:
       elasticsearch:
         endpoint: http://localhost:8200

--- a/extension/apmconfigextension/testdata/bad_no_proto_config.yaml
+++ b/extension/apmconfigextension/testdata/bad_no_proto_config.yaml
@@ -1,5 +1,5 @@
 opamp:
   protocols:
-fetcher:
+source:
   elasticsearch:
     endpoint: "https://testing/opamp"

--- a/extension/apmconfigextension/testdata/unsupported_duration.yaml
+++ b/extension/apmconfigextension/testdata/unsupported_duration.yaml
@@ -1,4 +1,4 @@
-fetcher:
+source:
   elasticsearch:
     endpoint: "https://test"
     cache_duration: 0s


### PR DESCRIPTION
Looking for opinions on this configuration rename: `agent_config` → `source`

In addition, it embeds the `cache_duration` option inside the `elasticsearch` section as being specific to it. 