### PR TITLE
[extension/apmconfig]: use "application/json" content type for remote config, rather than deprecated "text/json"

### DIFF
--- a/extension/apmconfigextension/README.md
+++ b/extension/apmconfigextension/README.md
@@ -53,7 +53,7 @@ agents use only a single configuration file or section, meaning the map will
 contain only one entry—and in this case, the key may be an empty string.
 - Since the configuration is encoded in JSON, the
 [content_type](https://github.com/open-telemetry/opamp-spec/blob/v0.11.0/proto/opamp.proto#L948C12-L948C24)
-field in the `AgentRemoteConfig` is set to `text/json`.
+field in the `AgentRemoteConfig` is set to `application/json`.
 - Each `AgentRemoteConfig` message should contain a [hash
 identifier](https://github.com/open-telemetry/opamp-spec/blob/v0.11.0/proto/opamp.proto#L929)
 that the Agent SHOULD include value in subsequent

--- a/extension/apmconfigextension/elastic/centralconfig/fetcher.go
+++ b/extension/apmconfigextension/elastic/centralconfig/fetcher.go
@@ -29,7 +29,7 @@ import (
 	"go.uber.org/zap"
 )
 
-const configContentType = "text/json"
+const configContentType = "application/json"
 const configFileName = "elastic"
 
 var _ apmconfig.RemoteConfigClient = (*fetcherAPMWatcher)(nil)

--- a/extension/apmconfigextension/elastic/centralconfig/fetcher_test.go
+++ b/extension/apmconfigextension/elastic/centralconfig/fetcher_test.go
@@ -92,7 +92,7 @@ func TestRemoteConfig(t *testing.T) {
 					ConfigMap: map[string]*protobufs.AgentConfigFile{
 						"elastic": {
 							Body:        []byte(`{"test":"aaa"}`),
-							ContentType: "text/json",
+							ContentType: "application/json",
 						},
 					},
 				},

--- a/extension/apmconfigextension/integration_test.go
+++ b/extension/apmconfigextension/integration_test.go
@@ -146,7 +146,7 @@ func apmConfigintegrationTest(name string) func(t *testing.T) {
 									ConfigMap: map[string]*protobufs.AgentConfigFile{
 										"elastic": {
 											Body:        []byte(`{"transaction_max_spans":"124"}`),
-											ContentType: "text/json",
+											ContentType: "application/json",
 										},
 									},
 								},
@@ -196,7 +196,7 @@ func apmConfigintegrationTest(name string) func(t *testing.T) {
 									ConfigMap: map[string]*protobufs.AgentConfigFile{
 										"elastic": {
 											Body:        []byte(`{"transaction_max_spans":"124"}`),
-											ContentType: "text/json",
+											ContentType: "application/json",
 										},
 									},
 								},
@@ -250,7 +250,7 @@ func apmConfigintegrationTest(name string) func(t *testing.T) {
 									ConfigMap: map[string]*protobufs.AgentConfigFile{
 										"elastic": {
 											Body:        []byte(`{"transaction_max_spans":"2"}`),
-											ContentType: "text/json",
+											ContentType: "application/json",
 										},
 									},
 								},
@@ -335,7 +335,7 @@ func apmConfigintegrationTest(name string) func(t *testing.T) {
 									ConfigMap: map[string]*protobufs.AgentConfigFile{
 										"elastic": {
 											Body:        []byte(`{"transaction_max_spans":"2"}`),
-											ContentType: "text/json",
+											ContentType: "application/json",
 										},
 									},
 								},

--- a/extension/apmconfigextension/opamp_callbacks_test.go
+++ b/extension/apmconfigextension/opamp_callbacks_test.go
@@ -127,7 +127,7 @@ func TestOnMessage(t *testing.T) {
 								ConfigMap: map[string]*protobufs.AgentConfigFile{
 									"elastic": {
 										Body:        []byte(`{"test":"aaa"}`),
-										ContentType: "text/json",
+										ContentType: "application/json",
 									},
 								},
 							},
@@ -155,7 +155,7 @@ func TestOnMessage(t *testing.T) {
 						Config: &protobufs.AgentConfigMap{
 							ConfigMap: map[string]*protobufs.AgentConfigFile{
 								"elastic": {
-									ContentType: "text/json",
+									ContentType: "application/json",
 									Body:        []byte(`{"test":"aaa"}`),
 								},
 							},
@@ -183,7 +183,7 @@ func TestOnMessage(t *testing.T) {
 								ConfigMap: map[string]*protobufs.AgentConfigFile{
 									"elastic": {
 										Body:        []byte(`{"test":"aaa"}`),
-										ContentType: "text/json",
+										ContentType: "application/json",
 									},
 								},
 							},
@@ -198,7 +198,7 @@ func TestOnMessage(t *testing.T) {
 						Config: &protobufs.AgentConfigMap{
 							ConfigMap: map[string]*protobufs.AgentConfigFile{
 								"elastic": {
-									ContentType: "text/json",
+									ContentType: "application/json",
 									Body:        []byte(`{"test":"aaa"}`),
 								},
 							},
@@ -226,7 +226,7 @@ func TestOnMessage(t *testing.T) {
 								ConfigMap: map[string]*protobufs.AgentConfigFile{
 									"elastic": {
 										Body:        []byte(`{"test":"aaa"}`),
-										ContentType: "text/json",
+										ContentType: "application/json",
 									},
 								},
 							},
@@ -241,7 +241,7 @@ func TestOnMessage(t *testing.T) {
 						Config: &protobufs.AgentConfigMap{
 							ConfigMap: map[string]*protobufs.AgentConfigFile{
 								"elastic": {
-									ContentType: "text/json",
+									ContentType: "application/json",
 									Body:        []byte(`{"test":"aaa"}`),
 								},
 							},
@@ -273,7 +273,7 @@ func TestOnMessage(t *testing.T) {
 						Config: &protobufs.AgentConfigMap{
 							ConfigMap: map[string]*protobufs.AgentConfigFile{
 								"elastic": {
-									ContentType: "text/json",
+									ContentType: "application/json",
 									Body:        []byte(`{"test":"aaa"}`),
 								},
 							},


### PR DESCRIPTION
"text/json" is a legacy/deprecated mime type for JSON content. (Reference: https://en.wikipedia.org/wiki/JSON#Metadata_and_schema)

The in-dev central config work for EDOT Node.js is checking the contentType of remote config before parsing it. I noticed that "text/json" was being used.  FWIW to EDOT Java central-config code does not check the content type so changing it will not break the Java OTel distro at least.