### PR TITLE
fix: return empty remote configurations

### DIFF
--- a/extension/apmconfigextension/elastic/centralconfig/fetcher.go
+++ b/extension/apmconfigextension/elastic/centralconfig/fetcher.go
@@ -29,8 +29,10 @@ import (
 	"go.uber.org/zap"
 )
 
-const configContentType = "application/json"
-const configFileName = "elastic"
+const (
+	configContentType = "application/json"
+	configFileName    = "elastic"
+)
 
 var _ apmconfig.RemoteConfigClient = (*fetcherAPMWatcher)(nil)
 
@@ -65,8 +67,6 @@ func (fw *fetcherAPMWatcher) RemoteConfig(ctx context.Context, agentUid apmconfi
 	})
 	if err != nil {
 		return nil, err
-	} else if len(result.Source.Settings) == 0 {
-		return nil, nil
 	}
 
 	marshallConfig, err := json.Marshal(result.Source.Settings)

--- a/extension/apmconfigextension/elastic/centralconfig/fetcher_test.go
+++ b/extension/apmconfigextension/elastic/centralconfig/fetcher_test.go
@@ -99,6 +99,35 @@ func TestRemoteConfig(t *testing.T) {
 			},
 			expectedError: nil,
 		},
+		"empty remote config for all services": {
+			agentUid: apmconfig.InstanceUid("test-agent"),
+			agentAttrs: apmconfig.IdentifyingAttributes{
+				&protobufs.KeyValue{
+					Key:   "service.name",
+					Value: &protobufs.AnyValue{Value: &protobufs.AnyValue_StringValue{StringValue: "dev"}},
+				},
+			},
+			mockedFetchFn: func(context.Context, agentcfg.Query) (agentcfg.Result, error) {
+				return agentcfg.Result{
+					Source: agentcfg.Source{
+						Etag:     "-",
+						Settings: agentcfg.Settings{},
+					},
+				}, nil
+			},
+			expectedRemoteConfig: &protobufs.AgentRemoteConfig{
+				ConfigHash: []byte("-"),
+				Config: &protobufs.AgentConfigMap{
+					ConfigMap: map[string]*protobufs.AgentConfigFile{
+						"elastic": {
+							Body:        []byte(`{}`),
+							ContentType: "application/json",
+						},
+					},
+				},
+			},
+			expectedError: nil,
+		},
 		"fetcher error": {
 			agentUid: apmconfig.InstanceUid("test-agent"),
 			agentAttrs: apmconfig.IdentifyingAttributes{

--- a/extension/apmconfigextension/integration_test.go
+++ b/extension/apmconfigextension/integration_test.go
@@ -123,6 +123,53 @@ func apmConfigintegrationTest(name string) func(t *testing.T) {
 				agentCfgIndexModifier: func(t *testing.T, client *elasticsearch.Client) {},
 			},
 			{
+				name: "agent receives empty remote config",
+				opampMessages: []inOutOpamp{
+					{
+						agentToServer: &protobufs.AgentToServer{
+							InstanceUid: []byte("test"),
+							AgentDescription: &protobufs.AgentDescription{
+								IdentifyingAttributes: []*protobufs.KeyValue{
+									{
+										Key:   "service.name",
+										Value: &protobufs.AnyValue{Value: &protobufs.AnyValue_StringValue{StringValue: "test-agent-empty"}},
+									},
+								},
+							},
+						},
+						expectedServerToAgent: &protobufs.ServerToAgent{
+							InstanceUid:  []byte("test"),
+							Capabilities: uint64(protobufs.ServerCapabilities_ServerCapabilities_OffersRemoteConfig),
+							RemoteConfig: &protobufs.AgentRemoteConfig{
+								ConfigHash: []byte("-"),
+								Config: &protobufs.AgentConfigMap{
+									ConfigMap: map[string]*protobufs.AgentConfigFile{
+										"elastic": {
+											Body:        []byte(`{}`),
+											ContentType: "application/json",
+										},
+									},
+								},
+							},
+						},
+					},
+					{
+						agentToServer: &protobufs.AgentToServer{
+							InstanceUid: []byte("test"),
+							RemoteConfigStatus: &protobufs.RemoteConfigStatus{
+								LastRemoteConfigHash: []byte("-"),
+								Status:               protobufs.RemoteConfigStatuses_RemoteConfigStatuses_APPLIED,
+							},
+						},
+						expectedServerToAgent: &protobufs.ServerToAgent{
+							InstanceUid:  []byte("test"),
+							Capabilities: uint64(protobufs.ServerCapabilities_ServerCapabilities_OffersRemoteConfig),
+						},
+					},
+				},
+				agentCfgIndexModifier: func(t *testing.T, client *elasticsearch.Client) {},
+			},
+			{
 				name: "agent without config applies remote",
 				opampMessages: []inOutOpamp{
 					{
@@ -287,6 +334,17 @@ func apmConfigintegrationTest(name string) func(t *testing.T) {
 						expectedServerToAgent: &protobufs.ServerToAgent{
 							InstanceUid:  []byte("test-3"),
 							Capabilities: uint64(protobufs.ServerCapabilities_ServerCapabilities_OffersRemoteConfig),
+							RemoteConfig: &protobufs.AgentRemoteConfig{
+								ConfigHash: []byte("-"),
+								Config: &protobufs.AgentConfigMap{
+									ConfigMap: map[string]*protobufs.AgentConfigFile{
+										"elastic": {
+											Body:        []byte(`{}`),
+											ContentType: "application/json",
+										},
+									},
+								},
+							},
 						},
 					},
 					{
@@ -308,6 +366,17 @@ func apmConfigintegrationTest(name string) func(t *testing.T) {
 						expectedServerToAgent: &protobufs.ServerToAgent{
 							InstanceUid:  []byte("test-3"),
 							Capabilities: uint64(protobufs.ServerCapabilities_ServerCapabilities_OffersRemoteConfig),
+							RemoteConfig: &protobufs.AgentRemoteConfig{
+								ConfigHash: []byte("-"),
+								Config: &protobufs.AgentConfigMap{
+									ConfigMap: map[string]*protobufs.AgentConfigFile{
+										"elastic": {
+											Body:        []byte(`{}`),
+											ContentType: "application/json",
+										},
+									},
+								},
+							},
 						},
 					},
 					{


### PR DESCRIPTION
Fixes https://github.com/elastic/opentelemetry-collector-components/issues/606