### PR TITLE
Bump golang version in CI to fix govulncheck

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.23.8"
+          go-version: "1.23.10"
           cache: false
       - name: Cache Go
         id: go-cache
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.23.8"
+          go-version: "1.23.10"
           cache: false
       - name: Cache Go
         id: go-cache
@@ -107,7 +107,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23.8"
+          go-version: "1.23.10"
           cache: false
       - name: Cache Go
         id: go-cache
@@ -130,7 +130,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.23.8"
+          go-version: "1.23.10"
           cache: false
       - name: Cache Go
         id: go-cache
@@ -242,7 +242,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.23.8"
+          go-version: "1.23.10"
           cache: false
       - name: Cache Go
         id: go-cache


### PR DESCRIPTION
https://pkg.go.dev/vuln/GO-2025-3750 was announced earlier today
https://groups.google.com/g/golang-announce/c/ufZ8WpEsA3A fix is in go 1.24.4 and 1.23.10
