### PR TITLE
[connector/elasticapm]Use exponential histogram from txn metrics

### DIFF
--- a/connector/elasticapmconnector/config.go
+++ b/connector/elasticapmconnector/config.go
@@ -166,13 +166,7 @@ func (cfg Config) signaltometricsConfig() *signaltometricsconfig.Config {
 		{Key: "metricset.name", DefaultValue: "service_destination"},
 	}
 
-	// TODO switch to exponential histogram once we have optimised
-	// exponential histogram merging.
-	transactionDurationHistogram := &signaltometricsconfig.Histogram{
-		Buckets: []float64{
-			5000, 10000, 25000, 50000, 75000, 100000, 250000, 500000,
-			750000, 1000000, 2500000, 5000000, 7500000, 10000000,
-		},
+	transactionDurationHistogram := &signaltometricsconfig.ExponentialHistogram{
 		Count: "Int(AdjustedCount())",
 		Value: "Microseconds(end_time - start_time)",
 	}
@@ -213,8 +207,8 @@ func (cfg Config) signaltometricsConfig() *signaltometricsconfig.Config {
 				Key:          "elasticsearch.mapping.hints",
 				DefaultValue: []any{"_doc_count"},
 			}),
-			Unit:      "us",
-			Histogram: transactionDurationHistogram,
+			Unit:                 "us",
+			ExponentialHistogram: transactionDurationHistogram,
 		}, {
 			Name:                      "transaction.duration.summary",
 			Description:               "APM service transaction aggregated metrics as summary",
@@ -233,8 +227,8 @@ func (cfg Config) signaltometricsConfig() *signaltometricsconfig.Config {
 				Key:          "elasticsearch.mapping.hints",
 				DefaultValue: []any{"_doc_count"},
 			}),
-			Unit:      "us",
-			Histogram: transactionDurationHistogram,
+			Unit:                 "us",
+			ExponentialHistogram: transactionDurationHistogram,
 		}, {
 			Name:                      "transaction.duration.summary",
 			Description:               "APM transaction aggregated metrics as summary",

--- a/connector/elasticapmconnector/testdata/logs/service_summary/aggregated_metrics.yaml
+++ b/connector/elasticapmconnector/testdata/logs/service_summary/aggregated_metrics.yaml
@@ -1,37 +1,35 @@
 resourceMetrics:
   - resource:
       attributes:
-        - key: service.name
-          value:
-            stringValue: foo
-        - key: deployment.environment
-          value:
-            stringValue: qa
-        - key: telemetry.sdk.language
-          value:
-            stringValue: go
         - key: agent.name
           value:
             stringValue: unknown
+        - key: deployment.environment
+          value:
+            stringValue: qa
+        - key: service.name
+          value:
+            stringValue: foo
+        - key: telemetry.sdk.language
+          value:
+            stringValue: go
     scopeMetrics:
-      - scope:
-          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/signaltometricsconnector
-        metrics:
+      - metrics:
           - name: service_summary
             sum:
               aggregationTemporality: 1
               dataPoints:
-                - asInt: 1
+                - asInt: "1"
                   attributes:
                     - key: data_stream.dataset
                       value:
                         stringValue: service_summary.1m
+                    - key: metricset.interval
+                      value:
+                        stringValue: 1m
                     - key: metricset.name
                       value:
                         stringValue: service_summary
-                    - key: metricset.interval
-                      value:
-                        stringValue: "1m"
                     - key: processor.event
                       value:
                         stringValue: metric
@@ -39,17 +37,17 @@ resourceMetrics:
             sum:
               aggregationTemporality: 1
               dataPoints:
-                - asInt: 1
+                - asInt: "1"
                   attributes:
                     - key: data_stream.dataset
                       value:
                         stringValue: service_summary.10m
+                    - key: metricset.interval
+                      value:
+                        stringValue: 10m
                     - key: metricset.name
                       value:
                         stringValue: service_summary
-                    - key: metricset.interval
-                      value:
-                        stringValue: "10m"
                     - key: processor.event
                       value:
                         stringValue: metric
@@ -57,17 +55,19 @@ resourceMetrics:
             sum:
               aggregationTemporality: 1
               dataPoints:
-                - asInt: 1
+                - asInt: "1"
                   attributes:
                     - key: data_stream.dataset
                       value:
                         stringValue: service_summary.60m
+                    - key: metricset.interval
+                      value:
+                        stringValue: 60m
                     - key: metricset.name
                       value:
                         stringValue: service_summary
-                    - key: metricset.interval
-                      value:
-                        stringValue: "60m"
                     - key: processor.event
                       value:
                         stringValue: metric
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/signaltometricsconnector

--- a/connector/elasticapmconnector/testdata/metrics/service_summary/aggregated_metrics.yaml
+++ b/connector/elasticapmconnector/testdata/metrics/service_summary/aggregated_metrics.yaml
@@ -1,6 +1,9 @@
 resourceMetrics:
   - resource:
       attributes:
+        - key: agent.name
+          value:
+            stringValue: unknown
         - key: deployment.environment
           value:
             stringValue: qa
@@ -10,9 +13,6 @@ resourceMetrics:
         - key: telemetry.sdk.language
           value:
             stringValue: go
-        - key: agent.name
-          value:
-            stringValue: unknown
     scopeMetrics:
       - metrics:
           - name: service_summary

--- a/connector/elasticapmconnector/testdata/traces/transaction_metrics/aggregated_metrics.yaml
+++ b/connector/elasticapmconnector/testdata/traces/transaction_metrics/aggregated_metrics.yaml
@@ -187,7 +187,7 @@ resourceMetrics:
                         stringValue: metric
                   timeUnixNano: "1000000"
           - description: APM service transaction aggregated metrics as histogram
-            histogram:
+            exponentialHistogram:
               aggregationTemporality: 1
               dataPoints:
                 - attributes:
@@ -214,44 +214,21 @@ resourceMetrics:
                     - key: transaction.type
                       value:
                         stringValue: request
-                  bucketCounts:
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "2"
                   count: "2"
-                  explicitBounds:
-                    - 5000
-                    - 10000
-                    - 25000
-                    - 50000
-                    - 75000
-                    - 100000
-                    - 250000
-                    - 500000
-                    - 750000
-                    - 1e+06
-                    - 2.5e+06
-                    - 5e+06
-                    - 7.5e+06
-                    - 1e+07
+                  max: 1.1e+07
+                  min: 1.1e+07
+                  negative: {}
+                  positive:
+                    bucketCounts:
+                      - "2"
+                    offset: 2.4527241e+07
+                  scale: 20
                   sum: 2.2e+07
                   timeUnixNano: "1000000"
             name: transaction.duration.histogram
             unit: us
           - description: APM service transaction aggregated metrics as histogram
-            histogram:
+            exponentialHistogram:
               aggregationTemporality: 1
               dataPoints:
                 - attributes:
@@ -278,44 +255,21 @@ resourceMetrics:
                     - key: transaction.type
                       value:
                         stringValue: request
-                  bucketCounts:
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "2"
                   count: "2"
-                  explicitBounds:
-                    - 5000
-                    - 10000
-                    - 25000
-                    - 50000
-                    - 75000
-                    - 100000
-                    - 250000
-                    - 500000
-                    - 750000
-                    - 1e+06
-                    - 2.5e+06
-                    - 5e+06
-                    - 7.5e+06
-                    - 1e+07
+                  max: 1.1e+07
+                  min: 1.1e+07
+                  negative: {}
+                  positive:
+                    bucketCounts:
+                      - "2"
+                    offset: 2.4527241e+07
+                  scale: 20
                   sum: 2.2e+07
                   timeUnixNano: "1000000"
             name: transaction.duration.histogram
             unit: us
           - description: APM service transaction aggregated metrics as histogram
-            histogram:
+            exponentialHistogram:
               aggregationTemporality: 1
               dataPoints:
                 - attributes:
@@ -342,38 +296,15 @@ resourceMetrics:
                     - key: transaction.type
                       value:
                         stringValue: request
-                  bucketCounts:
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "2"
                   count: "2"
-                  explicitBounds:
-                    - 5000
-                    - 10000
-                    - 25000
-                    - 50000
-                    - 75000
-                    - 100000
-                    - 250000
-                    - 500000
-                    - 750000
-                    - 1e+06
-                    - 2.5e+06
-                    - 5e+06
-                    - 7.5e+06
-                    - 1e+07
+                  max: 1.1e+07
+                  min: 1.1e+07
+                  negative: {}
+                  positive:
+                    bucketCounts:
+                      - "2"
+                    offset: 2.4527241e+07
+                  scale: 20
                   sum: 2.2e+07
                   timeUnixNano: "1000000"
             name: transaction.duration.histogram
@@ -514,7 +445,7 @@ resourceMetrics:
     scopeMetrics:
       - metrics:
           - description: APM transaction aggregated metrics as histogram
-            histogram:
+            exponentialHistogram:
               aggregationTemporality: 1
               dataPoints:
                 - attributes:
@@ -550,38 +481,15 @@ resourceMetrics:
                     - key: transaction.type
                       value:
                         stringValue: request
-                  bucketCounts:
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "1"
                   count: "1"
-                  explicitBounds:
-                    - 5000
-                    - 10000
-                    - 25000
-                    - 50000
-                    - 75000
-                    - 100000
-                    - 250000
-                    - 500000
-                    - 750000
-                    - 1e+06
-                    - 2.5e+06
-                    - 5e+06
-                    - 7.5e+06
-                    - 1e+07
+                  max: 1.1e+07
+                  min: 1.1e+07
+                  negative: {}
+                  positive:
+                    bucketCounts:
+                      - "1"
+                    offset: 2.4527241e+07
+                  scale: 20
                   sum: 1.1e+07
                   timeUnixNano: "1000000"
                 - attributes:
@@ -617,38 +525,15 @@ resourceMetrics:
                     - key: transaction.type
                       value:
                         stringValue: request
-                  bucketCounts:
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "1"
                   count: "1"
-                  explicitBounds:
-                    - 5000
-                    - 10000
-                    - 25000
-                    - 50000
-                    - 75000
-                    - 100000
-                    - 250000
-                    - 500000
-                    - 750000
-                    - 1e+06
-                    - 2.5e+06
-                    - 5e+06
-                    - 7.5e+06
-                    - 1e+07
+                  max: 1.1e+07
+                  min: 1.1e+07
+                  negative: {}
+                  positive:
+                    bucketCounts:
+                      - "1"
+                    offset: 2.4527241e+07
+                  scale: 20
                   sum: 1.1e+07
                   timeUnixNano: "1000000"
             name: transaction.duration.histogram
@@ -742,7 +627,7 @@ resourceMetrics:
             name: transaction.duration.summary
             unit: us
           - description: APM transaction aggregated metrics as histogram
-            histogram:
+            exponentialHistogram:
               aggregationTemporality: 1
               dataPoints:
                 - attributes:
@@ -778,38 +663,15 @@ resourceMetrics:
                     - key: transaction.type
                       value:
                         stringValue: request
-                  bucketCounts:
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "1"
                   count: "1"
-                  explicitBounds:
-                    - 5000
-                    - 10000
-                    - 25000
-                    - 50000
-                    - 75000
-                    - 100000
-                    - 250000
-                    - 500000
-                    - 750000
-                    - 1e+06
-                    - 2.5e+06
-                    - 5e+06
-                    - 7.5e+06
-                    - 1e+07
+                  max: 1.1e+07
+                  min: 1.1e+07
+                  negative: {}
+                  positive:
+                    bucketCounts:
+                      - "1"
+                    offset: 2.4527241e+07
+                  scale: 20
                   sum: 1.1e+07
                   timeUnixNano: "1000000"
                 - attributes:
@@ -845,38 +707,15 @@ resourceMetrics:
                     - key: transaction.type
                       value:
                         stringValue: request
-                  bucketCounts:
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "1"
                   count: "1"
-                  explicitBounds:
-                    - 5000
-                    - 10000
-                    - 25000
-                    - 50000
-                    - 75000
-                    - 100000
-                    - 250000
-                    - 500000
-                    - 750000
-                    - 1e+06
-                    - 2.5e+06
-                    - 5e+06
-                    - 7.5e+06
-                    - 1e+07
+                  max: 1.1e+07
+                  min: 1.1e+07
+                  negative: {}
+                  positive:
+                    bucketCounts:
+                      - "1"
+                    offset: 2.4527241e+07
+                  scale: 20
                   sum: 1.1e+07
                   timeUnixNano: "1000000"
             name: transaction.duration.histogram
@@ -970,7 +809,7 @@ resourceMetrics:
             name: transaction.duration.summary
             unit: us
           - description: APM transaction aggregated metrics as histogram
-            histogram:
+            exponentialHistogram:
               aggregationTemporality: 1
               dataPoints:
                 - attributes:
@@ -1006,38 +845,15 @@ resourceMetrics:
                     - key: transaction.type
                       value:
                         stringValue: request
-                  bucketCounts:
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "1"
                   count: "1"
-                  explicitBounds:
-                    - 5000
-                    - 10000
-                    - 25000
-                    - 50000
-                    - 75000
-                    - 100000
-                    - 250000
-                    - 500000
-                    - 750000
-                    - 1e+06
-                    - 2.5e+06
-                    - 5e+06
-                    - 7.5e+06
-                    - 1e+07
+                  max: 1.1e+07
+                  min: 1.1e+07
+                  negative: {}
+                  positive:
+                    bucketCounts:
+                      - "1"
+                    offset: 2.4527241e+07
+                  scale: 20
                   sum: 1.1e+07
                   timeUnixNano: "1000000"
                 - attributes:
@@ -1073,38 +889,15 @@ resourceMetrics:
                     - key: transaction.type
                       value:
                         stringValue: request
-                  bucketCounts:
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "1"
                   count: "1"
-                  explicitBounds:
-                    - 5000
-                    - 10000
-                    - 25000
-                    - 50000
-                    - 75000
-                    - 100000
-                    - 250000
-                    - 500000
-                    - 750000
-                    - 1e+06
-                    - 2.5e+06
-                    - 5e+06
-                    - 7.5e+06
-                    - 1e+07
+                  max: 1.1e+07
+                  min: 1.1e+07
+                  negative: {}
+                  positive:
+                    bucketCounts:
+                      - "1"
+                    offset: 2.4527241e+07
+                  scale: 20
                   sum: 1.1e+07
                   timeUnixNano: "1000000"
             name: transaction.duration.histogram


### PR DESCRIPTION
With the fixes for exponential histogram, it should perform on-par with histograms ([slack thread](https://elastic.slack.com/archives/C0680QCJKMM/p1743179432353619)).

Closes: https://github.com/elastic/opentelemetry-collector-components/issues/370