### PR TITLE
lsmintervalprocessor: fix telemetry builder shutdown and add internal telemetry tests

### DIFF
--- a/processor/lsmintervalprocessor/processor.go
+++ b/processor/lsmintervalprocessor/processor.go
@@ -262,6 +262,10 @@ func (p *Processor) Shutdown(ctx context.Context) error {
 		// All future operations are invalid after db is closed
 		p.db = nil
 	}
+	if p.telemetryBuilder != nil {
+		p.telemetryBuilder.Shutdown()
+		p.telemetryBuilder = nil
+	}
 	return nil
 }
 


### PR DESCRIPTION
A followup PR to https://github.com/elastic/opentelemetry-collector-components/pull/621 that adds forgotten unit tests to verify that the internal metrics are reported as they should. It additionally fixes `shutdown` call for the internal metrics telemetry builder.