### PR TITLE
loadgen: add support for running benchmark for n iterations

### DIFF
--- a/loadgen/cmd/otelbench/.chloggen/main.yaml
+++ b/loadgen/cmd/otelbench/.chloggen/main.yaml
@@ -1,0 +1,18 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Run benchmarks for multiple iterations to get more accurate results
+
+# It is mandatory to specify the component. Do not change this.
+component: otelbench
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [644]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Use -test.count flag to run benchmarks n times

--- a/loadgen/cmd/otelbench/main.go
+++ b/loadgen/cmd/otelbench/main.go
@@ -205,12 +205,6 @@ func main() {
 			for _, exporter := range getExporters() {
 				benchName := fullBenchmarkName(signal, exporter, concurrency)
 				for i := 0; i < count; i++ {
-					// Format display name with iteration number if running multiple times
-					displayName := benchName
-					if count > 1 {
-						displayName = fmt.Sprintf("%s-%d", benchName, i+1)
-					}
-
 					t := time.Now().UTC()
 					result := runBench(ctx, signal, exporter, concurrency, func(b *testing.B) {
 						if fetcher == nil {
@@ -228,7 +222,7 @@ func main() {
 						}
 					})
 					// write benchmark result to stdout, as stderr may be cluttered with collector logs
-					fmt.Printf("%-*s\t%s\n", maxLen, displayName, result.String())
+					fmt.Printf("%-*s\t%s\n", maxLen, benchName, result.String())
 					// break early if context was canceled
 					select {
 					case <-ctx.Done():


### PR DESCRIPTION
+ Part of https://github.com/elastic/hosted-otel-collector/issues/921
+ Uses the existing `--test.count` flag available via the testing.Benchmarks runner to run benchmark for n iterations to get more stable results. 