### PR TITLE
apikeyauthextension: propagate status code in errs

### DIFF
--- a/extension/apikeyauthextension/authenticator_test.go
+++ b/extension/apikeyauthextension/authenticator_test.go
@@ -74,7 +74,7 @@ func TestAuthenticator(t *testing.T) {
 				},
 				Status: 400,
 			}),
-			expectedErr: `rpc error: code = Internal desc = error checking privileges for API Key "id": status: 400, failed: [a_type], reason: a_reason`,
+			expectedErr: `error checking privileges for API Key "id": status: 400, failed: [a_type], reason: a_reason`,
 		},
 		"missing_privileges": {
 			handler:     newCannedHasPrivilegesHandler(hasprivileges.Response{HasAllRequested: false}),
@@ -170,7 +170,7 @@ func TestAuthenticator_Caching(t *testing.T) {
 	_, err = authenticator.Authenticate(context.Background(), map[string][]string{
 		"Authorization": {"ApiKey " + base64.StdEncoding.EncodeToString([]byte("id2:secret2"))},
 	})
-	assert.EqualError(t, err, `rpc error: code = InvalidArgument desc = API Key "id2" unauthorized`)
+	assert.EqualError(t, err, `rpc error: code = Unauthenticated desc = API Key "id2" unauthorized`)
 }
 
 func TestAuthenticator_CacheKeyHeaders(t *testing.T) {
@@ -183,7 +183,7 @@ func TestAuthenticator_CacheKeyHeaders(t *testing.T) {
 	_, err := authenticator.Authenticate(context.Background(), map[string][]string{
 		"Authorization": {"ApiKey " + base64.StdEncoding.EncodeToString([]byte("id1:secret1"))},
 	})
-	require.EqualError(t, err, `rpc error: code = Internal desc = error computing cache key: missing header "X-Tenant-Id"`)
+	require.EqualError(t, err, `error computing cache key: missing header "X-Tenant-Id"`)
 
 	ctx, err := authenticator.Authenticate(context.Background(), map[string][]string{
 		"X-Tenant-Id":   {"tenant1"},

--- a/extension/apikeyauthextension/authenticator_test.go
+++ b/extension/apikeyauthextension/authenticator_test.go
@@ -74,11 +74,11 @@ func TestAuthenticator(t *testing.T) {
 				},
 				Status: 400,
 			}),
-			expectedErr: `status: 400, failed: [a_type], reason: a_reason`,
+			expectedErr: `rpc error: code = Internal desc = error checking privileges for API Key "id": status: 400, failed: [a_type], reason: a_reason`,
 		},
 		"missing_privileges": {
 			handler:     newCannedHasPrivilegesHandler(hasprivileges.Response{HasAllRequested: false}),
-			expectedErr: `API Key "id" unauthorized`,
+			expectedErr: `rpc error: code = PermissionDenied desc = API Key "id" unauthorized`,
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -170,7 +170,7 @@ func TestAuthenticator_Caching(t *testing.T) {
 	_, err = authenticator.Authenticate(context.Background(), map[string][]string{
 		"Authorization": {"ApiKey " + base64.StdEncoding.EncodeToString([]byte("id2:secret2"))},
 	})
-	assert.EqualError(t, err, `API Key "id2" unauthorized`)
+	assert.EqualError(t, err, `rpc error: code = InvalidArgument desc = API Key "id2" unauthorized`)
 }
 
 func TestAuthenticator_CacheKeyHeaders(t *testing.T) {
@@ -183,7 +183,7 @@ func TestAuthenticator_CacheKeyHeaders(t *testing.T) {
 	_, err := authenticator.Authenticate(context.Background(), map[string][]string{
 		"Authorization": {"ApiKey " + base64.StdEncoding.EncodeToString([]byte("id1:secret1"))},
 	})
-	require.EqualError(t, err, `error computing cache key: missing header "X-Tenant-Id"`)
+	require.EqualError(t, err, `rpc error: code = Internal desc = error computing cache key: missing header "X-Tenant-Id"`)
 
 	ctx, err := authenticator.Authenticate(context.Background(), map[string][]string{
 		"X-Tenant-Id":   {"tenant1"},
@@ -259,7 +259,7 @@ func TestAuthenticator_AuthorizationHeader(t *testing.T) {
 		},
 		"missing_header": {
 			headers:     map[string][]string{},
-			expectedErr: `missing header "Authorization"`,
+			expectedErr: `rpc error: code = Unauthenticated desc = missing header "Authorization"`,
 		},
 		"invalid_scheme": {
 			headers: map[string][]string{
@@ -267,13 +267,13 @@ func TestAuthenticator_AuthorizationHeader(t *testing.T) {
 					"Bearer " + base64.StdEncoding.EncodeToString([]byte("id:secret")),
 				},
 			},
-			expectedErr: `ApiKey prefix not found`,
+			expectedErr: `rpc error: code = Unauthenticated desc = ApiKey prefix not found`,
 		},
 		"invalid_base64": {
 			headers: map[string][]string{
 				"Authorization": {"ApiKey not_base64"},
 			},
-			expectedErr: "illegal base64 data at input byte 3",
+			expectedErr: "rpc error: code = Unauthenticated desc = illegal base64 data at input byte 3",
 		},
 		"invalid_encoded_apikey": {
 			headers: map[string][]string{
@@ -281,7 +281,7 @@ func TestAuthenticator_AuthorizationHeader(t *testing.T) {
 					"ApiKey " + base64.StdEncoding.EncodeToString([]byte("junk")),
 				},
 			},
-			expectedErr: "invalid API Key",
+			expectedErr: "rpc error: code = Unauthenticated desc = invalid API Key",
 		},
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/extension/apikeyauthextension/go.mod
+++ b/extension/apikeyauthextension/go.mod
@@ -17,6 +17,7 @@ require (
 	go.opentelemetry.io/collector/extension/extensiontest v0.129.0
 	go.uber.org/goleak v1.3.0
 	golang.org/x/crypto v0.39.0
+	google.golang.org/grpc v1.73.0
 )
 
 require (
@@ -67,7 +68,6 @@ require (
 	golang.org/x/sys v0.33.0 // indirect
 	golang.org/x/text v0.26.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250324211829-b45e905df463 // indirect
-	google.golang.org/grpc v1.73.0 // indirect
 	google.golang.org/protobuf v1.36.6 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect


### PR DESCRIPTION
Updates the extension to return a `status.Error` type (which wraps the `status.Status` type) instead of a plain `error` type. This allows propagating the status code and message from the extension to the collector.

This is similar to what the upstream OTLP receiver does:

https://github.com/open-telemetry/opentelemetry-collector/blob/v0.129.0/receiver/otlpreceiver/otlphttp.go#L183-L192