### PR TITLE
ratelimitprocessor: Wrap error with code for 429

### DIFF
--- a/processor/ratelimitprocessor/gubernator.go
+++ b/processor/ratelimitprocessor/gubernator.go
@@ -29,7 +29,9 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
 
 	"github.com/gubernator-io/gubernator/v2"
 	"go.opentelemetry.io/collector/component"
@@ -165,7 +167,7 @@ func (r *gubernatorRateLimiter) RateLimit(ctx context.Context, hits int) error {
 				zap.String("processor_id", r.set.ID.String()),
 				zap.Strings("metadata_keys", r.cfg.MetadataKeys),
 			)
-			return errTooManyRequests
+			return status.Error(codes.ResourceExhausted, errTooManyRequests.Error())
 		case ThrottleBehaviorDelay:
 			delay := time.Duration(resp.GetResetTime()-createdAt) * time.Millisecond
 			timer := time.NewTimer(delay)

--- a/processor/ratelimitprocessor/gubernator_test.go
+++ b/processor/ratelimitprocessor/gubernator_test.go
@@ -100,7 +100,7 @@ func TestGubernatorRateLimiter_RateLimit(t *testing.T) {
 			err = rateLimiter.RateLimit(context.Background(), 1)
 			switch behavior {
 			case ThrottleBehaviorError:
-				assert.EqualError(t, err, "too many requests")
+				assert.EqualError(t, err, "rpc error: code = ResourceExhausted desc = too many requests")
 			case ThrottleBehaviorDelay:
 				assert.NoError(t, err)
 			}

--- a/processor/ratelimitprocessor/local_test.go
+++ b/processor/ratelimitprocessor/local_test.go
@@ -80,7 +80,7 @@ func TestLocalRateLimiter_RateLimit(t *testing.T) {
 			err = rateLimiter.RateLimit(context.Background(), 1) // should fail
 			switch behavior {
 			case ThrottleBehaviorError:
-				assert.EqualError(t, err, "too many requests")
+				assert.EqualError(t, err, "rpc error: code = ResourceExhausted desc = too many requests")
 				// retry every 20ms to ensure that RateLimit will recover from error when bucket refills after 1 second
 				assert.Eventually(t, func() bool {
 					return rateLimiter.RateLimit(context.Background(), 1) == nil

--- a/processor/ratelimitprocessor/processor_test.go
+++ b/processor/ratelimitprocessor/processor_test.go
@@ -164,7 +164,7 @@ func TestConsume_Logs(t *testing.T) {
 	consumed = false
 	err = processor.ConsumeLogs(clientContext, logs)
 	assert.False(t, consumed)
-	assert.EqualError(t, err, "too many requests")
+	assert.EqualError(t, err, "rpc error: code = ResourceExhausted desc = too many requests")
 
 	testRateLimitTelemetry(t, tt)
 }
@@ -211,7 +211,7 @@ func TestConsume_Metrics(t *testing.T) {
 	consumed = false
 	err = processor.ConsumeMetrics(clientContext, metrics)
 	assert.False(t, consumed)
-	assert.EqualError(t, err, "too many requests")
+	assert.EqualError(t, err, "rpc error: code = ResourceExhausted desc = too many requests")
 
 	testRateLimitTelemetry(t, tt)
 }
@@ -258,7 +258,7 @@ func TestConsume_Traces(t *testing.T) {
 	consumed = false
 	err = processor.ConsumeTraces(clientContext, traces)
 	assert.False(t, consumed)
-	assert.EqualError(t, err, "too many requests")
+	assert.EqualError(t, err, "rpc error: code = ResourceExhausted desc = too many requests")
 
 	testRateLimitTelemetry(t, tt)
 }
@@ -306,7 +306,7 @@ func TestConsume_Profiles(t *testing.T) {
 	consumed = false
 	err = processor.ConsumeProfiles(clientContext, profiles)
 	assert.False(t, consumed)
-	assert.EqualError(t, err, "too many requests")
+	assert.EqualError(t, err, "rpc error: code = ResourceExhausted desc = too many requests")
 
 	testRateLimitTelemetry(t, tt)
 }


### PR DESCRIPTION
Wraps the error returned by the rate limiter with the grpc code library to ensure that the code is propagated to the client. For non 5xx errors, the code is set to `codes.ResourceExhausted`, which is the appropriate code for rate limiting errors.

Part of elastic/hosted-otel-collector#991