### PR TITLE
[loadgen/otelbench] Add example of docker image usage to readme

### DIFF
--- a/loadgen/cmd/otelbench/README.md
+++ b/loadgen/cmd/otelbench/README.md
@@ -144,7 +144,7 @@ To send to an ESS apm-server
 To send to an OTel collector with a special otlphttp path
 
 ```shell
-./otelbench -config=./config.yaml -endpoint-otlp=localhost:4317 -endpoint-otlphttp=https://localhost:4318/prefix -api-key some_api_key
+./otelbench -config=./config.yaml -endpoint-otlp=http://localhost:4317 -endpoint-otlphttp=https://localhost:4318/prefix -api-key some_api_key
 ```
 
 It is possible to run with a customized config to avoid passing in command line options every time
@@ -156,6 +156,14 @@ It is possible to run with a customized config to avoid passing in command line 
 Optional remote OTel collector metrics will be reported as bench stats when additional telemetry flags are provided.
 Gauge metrics will be aggregated to average, while Counter and Histogram will be aggregated to sum.
 For the full list of reported metrics see https://opentelemetry.io/docs/collector/internal-telemetry/#basic-level-metrics.
+
+## Example usage with Docker image
+
+```shell
+docker run -it docker.elastic.co/observability-ci/otelbench:v0.2.1 -endpoint-otlp=http://172.17.0.1:4317 -insecure
+```
+
+Remember that `localhost` does not work because otelbench runs in a container. Use `172.17.0.1` for Linux and `host.docker.internal` for macOS.
 
 ```shell
 ./otelbench -config=./config.yaml -endpoint-otlp=localhost:4317 -endpoint-otlphttp=https://localhost:4318/prefix -api-key some_api_key -telemetry-elasticsearch-url=localhost:9200 -telemetry-elasticsearch-api-key telemetry_api_key -telemetry-elasticsearch-index "metrics*" -telemetry-filter-cluster-name cluster_name


### PR DESCRIPTION
Update readme to add an example of otelbench docker image usage
