### PR TITLE
chore: remove outdated comment

### DIFF
--- a/distributions/elastic-components/manifest.yaml
+++ b/distributions/elastic-components/manifest.yaml
@@ -63,7 +63,6 @@ exporters:
   - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.130.0
   - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.130.0
 
-# workaround known issue https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.110.0
 providers:
   - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.36.0
   - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.36.0


### PR DESCRIPTION
The [issue](https://github.com/open-telemetry/opentelemetry-collector/issues/11129) that forced us to explicitly list providers has been resolved for a while. I think it's still worth listing the providers explicitly, so only deleted the comment.