### PR TITLE
Bump up lsminterval version for elastic apm connector

### DIFF
--- a/connector/elasticapmconnector/go.mod
+++ b/connector/elasticapmconnector/go.mod
@@ -4,7 +4,7 @@ go 1.23.8
 
 require (
 	github.com/elastic/opentelemetry-collector-components/internal/sharedcomponent v0.0.0-20250220025958-386ba0c4bced
-	github.com/elastic/opentelemetry-collector-components/processor/lsmintervalprocessor v0.4.0
+	github.com/elastic/opentelemetry-collector-components/processor/lsmintervalprocessor v0.8.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/connector/signaltometricsconnector v0.129.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.129.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.129.0


### PR DESCRIPTION
It seems when building with ocb (tried with v0.129.0), the [replace directive](https://github.com/elastic/opentelemetry-collector-components/blob/00f56bcca5c08e6317dc8f61ff44bfdb52862213/connector/elasticapmconnector/go.mod#L120) is ignored. Bumping up the version so the correct version is picked even in this case.