### PR TITLE
[receiver/loadgen] Add disable_pdata_reuse config

### DIFF
--- a/receiver/loadgenreceiver/config.go
+++ b/receiver/loadgenreceiver/config.go
@@ -40,6 +40,10 @@ type Config struct {
 	// As requests are synchronous, when concurrency is N, there will be N in-flight requests.
 	// This is similar to the `agent_replicas` config in apmsoak.
 	Concurrency int `mapstructure:"concurrency"`
+
+	// DisablePdataReuse disables the optimization that reuses pdata structures to reduce allocations.
+	// It is useful in cases where the optimization causes problems with certain downstream components, e.g. batchprocessor.
+	DisablePdataReuse bool `mapstructure:"disable_pdata_reuse"`
 }
 
 type MetricsConfig struct {

--- a/receiver/loadgenreceiver/logs.go
+++ b/receiver/loadgenreceiver/logs.go
@@ -112,7 +112,7 @@ func (ar *logsGenerator) Start(ctx context.Context, _ component.Host) error {
 					return
 				default:
 				}
-				if next.IsReadOnly() {
+				if ar.cfg.DisablePdataReuse || next.IsReadOnly() {
 					// As the optimization to reuse pdata is not compatible with fanoutconsumer,
 					// i.e. in pipelines where there are more than 1 consumer,
 					// as fanoutconsumer will mark the pdata struct as read only and cannot be reused.

--- a/receiver/loadgenreceiver/metrics.go
+++ b/receiver/loadgenreceiver/metrics.go
@@ -119,7 +119,7 @@ func (ar *metricsGenerator) Start(ctx context.Context, _ component.Host) error {
 					return
 				default:
 				}
-				if next.IsReadOnly() {
+				if ar.cfg.DisablePdataReuse || next.IsReadOnly() {
 					// As the optimization to reuse pdata is not compatible with fanoutconsumer,
 					// i.e. in pipelines where there are more than 1 consumer,
 					// as fanoutconsumer will mark the pdata struct as read only and cannot be reused.

--- a/receiver/loadgenreceiver/traces.go
+++ b/receiver/loadgenreceiver/traces.go
@@ -114,7 +114,7 @@ func (ar *tracesGenerator) Start(ctx context.Context, _ component.Host) error {
 					return
 				default:
 				}
-				if next.IsReadOnly() {
+				if ar.cfg.DisablePdataReuse || next.IsReadOnly() {
 					// As the optimization to reuse pdata is not compatible with fanoutconsumer,
 					// i.e. in pipelines where there are more than 1 consumer,
 					// as fanoutconsumer will mark the pdata struct as read only and cannot be reused.


### PR DESCRIPTION
Add a config that fixes panic when batchprocessor is used
```
panic: runtime error: index out of range [0] with length 0

goroutine 68 [running]:
go.opentelemetry.io/collector/pdata/plog.ResourceLogsSlice.At(...)
	go.opentelemetry.io/collector/pdata@v1.36.1/plog/generated_resourcelogsslice.go:57
github.com/elastic/opentelemetry-collector-components/receiver/loadgenreceiver.(*logsGenerator).nextLogs(0xc000a901b0, {0xc000010018?, 0xc000e88000?})
	github.com/elastic/opentelemetry-collector-components/receiver/loadgenreceiver@v0.0.0-20250723123524-274e72bdd7de/logs.go:171 +0x185
github.com/elastic/opentelemetry-collector-components/receiver/loadgenreceiver.(*logsGenerator).Start.func1()
	github.com/elastic/opentelemetry-collector-components/receiver/loadgenreceiver@v0.0.0-20250723123524-274e72bdd7de/logs.go:122 +0x145
created by github.com/elastic/opentelemetry-collector-components/receiver/loadgenreceiver.(*logsGenerator).Start in goroutine 1
	github.com/elastic/opentelemetry-collector-components/receiver/loadgenreceiver@v0.0.0-20250723123524-274e72bdd7de/logs.go:106 +0x85
```
