### PR TITLE
profilingmetricsconnector: add (costum)? classification

### DIFF
--- a/connector/profilingmetricsconnector/config.go
+++ b/connector/profilingmetricsconnector/config.go
@@ -17,8 +17,25 @@
 
 package profilingmetricsconnector // import "github.com/elastic/opentelemetry-collector-components/connector/profilingmetricsconnector"
 
+// Aggregation applies Match as a regular expression on function strings
+// and generates a metric with Label if it matches.
+type Aggregation struct {
+	Match string `mapstructure:"match"`
+	Label string `mapstructure:"label"`
+}
+
 // Config represents the receiver config settings within the collector's config.yaml
 type Config struct {
 	// MetricsPrefix is the prefix to add to all generated metric names
 	MetricsPrefix string `mapstructure:"metrics_prefix"`
+
+	// Generate metrics based on frame type.
+	ByFrameType bool `mapstructure:"by_frametype"`
+
+	// Generate metrics based on functional classification.
+	// Currently only Java and Go are supported.
+	ByClassification bool `mapstructure:"by_classification"`
+
+	// CustomAggregations allows to generate costum metrics.
+	CustomAggregations []Aggregation `mapstructure:"aggregations"`
 }

--- a/connector/profilingmetricsconnector/config.go
+++ b/connector/profilingmetricsconnector/config.go
@@ -36,6 +36,6 @@ type Config struct {
 	// Currently only Java and Go are supported.
 	ByClassification bool `mapstructure:"by_classification"`
 
-	// CustomAggregations allows to generate costum metrics.
+	// CustomAggregations allows to generate custom metrics.
 	CustomAggregations []Aggregation `mapstructure:"aggregations"`
 }

--- a/connector/profilingmetricsconnector/connector_test.go
+++ b/connector/profilingmetricsconnector/connector_test.go
@@ -45,7 +45,10 @@ func (m *mockMetricsConsumer) ConsumeMetrics(ctx context.Context, md pmetric.Met
 
 func TestConsumeProfiles_WithMetrics(t *testing.T) {
 	mockConsumer := new(mockMetricsConsumer)
-	cfg := &Config{MetricsPrefix: "test."}
+	cfg := &Config{
+		MetricsPrefix: "test.",
+		ByFrameType:   true,
+	}
 	conn := &profilesToMetricsConnector{
 		nextConsumer: mockConsumer,
 		config:       cfg,
@@ -77,7 +80,10 @@ func TestConsumeProfiles_WithMetrics(t *testing.T) {
 
 func TestConsumeProfiles_FrameTypeMetrics(t *testing.T) {
 	mockConsumer := new(mockMetricsConsumer)
-	cfg := &Config{MetricsPrefix: "test."}
+	cfg := &Config{
+		MetricsPrefix: "test.",
+		ByFrameType:   true,
+	}
 	conn := &profilesToMetricsConnector{
 		nextConsumer: mockConsumer,
 		config:       cfg,
@@ -154,7 +160,10 @@ func TestConsumeProfiles_FrameTypeMetrics(t *testing.T) {
 
 func TestConsumeProfiles_MultipleSamplesAndFrameTypes(t *testing.T) {
 	mockConsumer := new(mockMetricsConsumer)
-	cfg := &Config{MetricsPrefix: "test."}
+	cfg := &Config{
+		MetricsPrefix: "test.",
+		ByFrameType:   true,
+	}
 	conn := &profilesToMetricsConnector{
 		nextConsumer: mockConsumer,
 		config:       cfg,

--- a/connector/profilingmetricsconnector/connector_test.go
+++ b/connector/profilingmetricsconnector/connector_test.go
@@ -125,9 +125,21 @@ func TestConsumeProfiles_FrameTypeMetrics(t *testing.T) {
 			for j := 0; j < sm.Len(); j++ {
 				metrics := sm.At(j).Metrics()
 				for k := 0; k < metrics.Len(); k++ {
-					name := metrics.At(k).Name()
-					if name == "test.samples.frame_type.go" {
-						found = true
+					metric := metrics.At(k)
+					name := metric.Name()
+					if name == "test.samples.frame_type" {
+						// Verify it's a Gauge metric
+						if metric.Type() == pmetric.MetricTypeGauge {
+							gauge := metric.Gauge()
+							// Check if any data point has the expected frame.type attribute
+							for dp := 0; dp < gauge.DataPoints().Len(); dp++ {
+								dataPoint := gauge.DataPoints().At(dp)
+								if frameType, exists := dataPoint.Attributes().Get("frame.type"); exists && frameType.Str() == "go" {
+									found = true
+									break
+								}
+							}
+						}
 					}
 				}
 			}
@@ -198,12 +210,25 @@ func TestConsumeProfiles_MultipleSamplesAndFrameTypes(t *testing.T) {
 			for j := 0; j < sm.Len(); j++ {
 				metrics := sm.At(j).Metrics()
 				for k := 0; k < metrics.Len(); k++ {
-					name := metrics.At(k).Name()
-					if name == "test.samples.frame_type.go" {
-						foundGo = true
-					}
-					if name == "test.samples.frame_type.python" {
-						foundPy = true
+					metric := metrics.At(k)
+					name := metric.Name()
+					if name == "test.samples.frame_type" {
+						// Verify it's a Gauge metric
+						if metric.Type() == pmetric.MetricTypeGauge {
+							gauge := metric.Gauge()
+							// Check data points for both frame types
+							for dp := 0; dp < gauge.DataPoints().Len(); dp++ {
+								dataPoint := gauge.DataPoints().At(dp)
+								if frameType, exists := dataPoint.Attributes().Get("frame.type"); exists {
+									if frameType.Str() == "go" {
+										foundGo = true
+									}
+									if frameType.Str() == "python" {
+										foundPy = true
+									}
+								}
+							}
+						}
 					}
 				}
 			}

--- a/connector/profilingmetricsconnector/connector_test.go
+++ b/connector/profilingmetricsconnector/connector_test.go
@@ -27,6 +27,7 @@ import (
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/pprofile"
+	semconv "go.opentelemetry.io/otel/semconv/v1.34.0"
 )
 
 // mockMetricsConsumer is a mock implementation of consumer.Metrics.
@@ -108,7 +109,7 @@ func TestConsumeProfiles_FrameTypeMetrics(t *testing.T) {
 
 	// Add an attribute for frame type
 	attr := attrTable.AppendEmpty()
-	attr.SetKey("profile.frame.type")
+	attr.SetKey(string(semconv.ProfileFrameTypeKey))
 	attr.Value().SetStr("go")
 
 	// Add a location referencing the attribute
@@ -137,10 +138,10 @@ func TestConsumeProfiles_FrameTypeMetrics(t *testing.T) {
 						// Verify it's a Gauge metric
 						if metric.Type() == pmetric.MetricTypeGauge {
 							gauge := metric.Gauge()
-							// Check if any data point has the expected frame.type attribute
+							// Check if any data point has the expected frame_type attribute
 							for dp := 0; dp < gauge.DataPoints().Len(); dp++ {
 								dataPoint := gauge.DataPoints().At(dp)
-								if frameType, exists := dataPoint.Attributes().Get("frame.type"); exists && frameType.Str() == "go" {
+								if frameType, exists := dataPoint.Attributes().Get("frame_type"); exists && frameType.Str() == "go" {
 									found = true
 									break
 								}
@@ -185,10 +186,10 @@ func TestConsumeProfiles_MultipleSamplesAndFrameTypes(t *testing.T) {
 
 	// Add two attributes for frame types
 	attrGo := attrTable.AppendEmpty()
-	attrGo.SetKey("profile.frame.type")
+	attrGo.SetKey(string(semconv.ProfileFrameTypeKey))
 	attrGo.Value().SetStr("go")
 	attrPy := attrTable.AppendEmpty()
-	attrPy.SetKey("profile.frame.type")
+	attrPy.SetKey(string(semconv.ProfileFrameTypeKey))
 	attrPy.Value().SetStr("python")
 
 	// Add two locations, each referencing a different attribute
@@ -228,7 +229,7 @@ func TestConsumeProfiles_MultipleSamplesAndFrameTypes(t *testing.T) {
 							// Check data points for both frame types
 							for dp := 0; dp < gauge.DataPoints().Len(); dp++ {
 								dataPoint := gauge.DataPoints().At(dp)
-								if frameType, exists := dataPoint.Attributes().Get("frame.type"); exists {
+								if frameType, exists := dataPoint.Attributes().Get("frame_type"); exists {
 									if frameType.Str() == "go" {
 										foundGo = true
 									}

--- a/connector/profilingmetricsconnector/general_aggregation.go
+++ b/connector/profilingmetricsconnector/general_aggregation.go
@@ -1,0 +1,142 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package profilingmetricsconnector // import "github.com/elastic/opentelemetry-collector-components/connector/profilingmetricsconnector"
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var (
+	// Breakdown of the regex:
+	// `(?:\S+\s+)?`
+	//   - `(?:\S+\s+)`: Non-capturing group for the optional return type (e.g., "void ", "int ", "long ").
+	//     - `\S+`: Matches one or more non-whitespace characters (the return type).
+	//     - `\s+`: Matches one or more whitespace characters.
+	//   - `?`: Makes the entire return type group optional.
+	//
+	// `(`
+	//   - Start of the first capturing group, which will contain the full class path.
+	//
+	// `[a-zA-Z_][a-zA-Z0-9_.$<>+]+`
+	//   - Matches the first segment of the class name (e.g., "org", "sun", "MyClass").
+	//   - `[a-zA-Z_]`: Starts with a letter or underscore (standard Java identifier start).
+	//   - `[a-zA-Z0-9_.$<>+]+`: Followed by one or more letters, numbers, underscores,
+	//     dots (for package separators), dollar signs (for inner classes),
+	//     angle brackets (`<`, `>`) and plus signs (`+`) for synthetic class names
+	//     like those generated for lambdas (e.g., `$$Lambda+<hidden>`).
+	//
+	// `(?:\.[a-zA-Z_][a-zA-Z0-9_.$<>+]+)*`
+	//   - Non-capturing group for subsequent package/class segments (e.g., ".apache.lucene.search").
+	//   - `\.`: Matches a literal dot.
+	//   - `[a-zA-Z_][a-zA-Z0-9_.$<>+]+`: Matches another identifier-like segment.
+	//   - `*`: Allows zero or more of these segments.
+	//
+	// `)`
+	//   - End of the first capturing group (the full class path).
+	//
+	// `\.`
+	//   - Matches the literal dot that separates the class name from the method name.
+	//
+	// `([a-zA-Z_][a-zA-Z0-9_.$<>+]+)`
+	//   - Second capturing group, for the method name itself.
+	//   - `[a-zA-Z_][a-zA-Z0-9_.$<>+]+`: Matches a valid method name, which can also include
+	//     `$` for synthetic methods (e.g., `lambda$fillGapRunnable$13`).
+	//
+	// `\(`
+	//   - Matches the literal opening parenthesis that signifies the start of method arguments.
+	hotspotRegex = regexp.MustCompile(`(?:\S+\s+)?([a-zA-Z_][a-zA-Z0-9_.$<>+]+(?:\.[a-zA-Z_][a-zA-Z0-9_.$<>+]+)*)\.([a-zA-Z_][a-zA-Z0-9_.$<>+]+)\(`)
+
+	errHotspotNoMatch = errors.New("input does not match hotspot regex")
+)
+
+// hotspotInfo holds extracted Java package and class name information.
+type hotspotInfo struct {
+	pack  string
+	class string
+}
+
+func extractHotspotInfo(funcString string) (*hotspotInfo, error) {
+	matches := hotspotRegex.FindStringSubmatch(funcString)
+
+	if len(matches) < 2 {
+		return nil, fmt.Errorf("could not extract class information from string: '%s': %w",
+			funcString, errHotspotNoMatch)
+	}
+
+	// The first captured group is the fully qualified class name.
+	fullClassName := matches[1]
+
+	// Determine the last occurrence of a dot in the full class name.
+	// This dot separates the class name from its package path.
+	lastDotIndex := strings.LastIndex(fullClassName, ".")
+
+	var packageName string
+	var className string
+
+	if lastDotIndex == -1 {
+		// If no dot is found, it means the class is in the default package.
+		packageName = ""
+		className = fullClassName
+	} else {
+		packageName = fullClassName[:lastDotIndex]
+		className = fullClassName[lastDotIndex+1:]
+	}
+
+	return &hotspotInfo{
+		pack:  packageName,
+		class: className,
+	}, nil
+}
+
+// golangInfo holds extracted Go package information.
+type golangInfo struct {
+	pack string
+}
+
+func extractGolangInfo(funcString string) *golangInfo {
+	// Find the last slash. This separates the import path from the final package name segment.
+	lastSlashIdx := strings.LastIndex(funcString, "/")
+
+	if lastSlashIdx != -1 {
+		basePath := funcString[:lastSlashIdx]
+		lastSegment := funcString[lastSlashIdx+1:]
+
+		// Find the first dot in this last segment that separates the package name
+		// from the function/method name within that segment.
+		firstDotInSegmentIdx := strings.Index(lastSegment, ".")
+		if firstDotInSegmentIdx != -1 {
+			return &golangInfo{pack: basePath + "/" + lastSegment[:firstDotInSegmentIdx]}
+		}
+
+		return &golangInfo{
+			pack: funcString,
+		}
+	} else {
+		// If no slash exists, the function string is likely just "package.FunctionName"
+		// or "package.(*Type).MethodName".
+		firstDotIdx := strings.Index(funcString, ".")
+		if firstDotIdx != -1 {
+			return &golangInfo{pack: funcString[:firstDotIdx]}
+		}
+
+		return &golangInfo{pack: funcString}
+	}
+}

--- a/connector/profilingmetricsconnector/general_aggregation_test.go
+++ b/connector/profilingmetricsconnector/general_aggregation_test.go
@@ -113,8 +113,6 @@ func TestExtractHotspotInfo(t *testing.T) {
 				class: "MyClass",
 			},
 		},
-		{input: "void .invalidMethod()", err: errHotspotNoMatch},
-		{input: "justAMethod()", err: errHotspotNoMatch},
 	}
 
 	for _, tc := range tests {

--- a/connector/profilingmetricsconnector/general_aggregation_test.go
+++ b/connector/profilingmetricsconnector/general_aggregation_test.go
@@ -1,0 +1,202 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package profilingmetricsconnector // import "github.com/elastic/opentelemetry-collector-components/connector/profilingmetricsconnector"
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractHotspotInfo(t *testing.T) {
+	tests := []struct {
+		input  string
+		output *hotspotInfo
+		err    error
+	}{
+		{
+			input: "void sun.security.provider.DigestBase.engineUpdate(byte[], int, int)",
+			output: &hotspotInfo{
+				pack:  "sun.security.provider",
+				class: "DigestBase",
+			},
+		},
+		{
+			input: "int org.apache.lucene.search.Weight$DefaultBulkScorer.score(org.apache.lucene.search.LeafCollector, org.apache.lucene.util.Bits, int, int)",
+			output: &hotspotInfo{
+				pack:  "org.apache.lucene.search",
+				class: "Weight$DefaultBulkScorer",
+			},
+		},
+		{
+			input: "void org.apache.lucene.search.IndexSearcher.search(org.apache.lucene.search.IndexSearcher$LeafReaderContextPartition[], org.apache.lucene.search.Weight, org.apache.lucene.search.Collector)",
+			output: &hotspotInfo{
+				pack:  "org.apache.lucene.search",
+				class: "IndexSearcher",
+			},
+		},
+		{
+			input: "void org.elasticsearch.blobcache.shared.SharedBlobCacheService$CacheFileRegion.lambda$fillGapRunnable$13(org.elasticsearch.blobcache.common.SparseFileTracker$Gap, org.elasticsearch.blobcache.shared.SharedBlobCacheService$RangeMissingHandler, org.elasticsearch.blobcache.shared.SharedBlobCacheService$SourceInputStreamFactory, org.elasticsearch.action.ActionListener)",
+			output: &hotspotInfo{
+				pack:  "org.elasticsearch.blobcache.shared",
+				class: "SharedBlobCacheService$CacheFileRegion",
+			},
+		},
+		{
+			input: "int software.amazon.awssdk.core.internal.metrics.BytesReadTrackingInputStream.read(byte[], int, int)",
+			output: &hotspotInfo{
+				pack:  "software.amazon.awssdk.core.internal.metrics",
+				class: "BytesReadTrackingInputStream",
+			},
+		},
+		{
+			input: "void org.apache.lucene.search.DocIdStream.forEach(org.apache.lucene.search.CheckedIntConsumer)",
+			output: &hotspotInfo{
+				pack:  "org.apache.lucene.search",
+				class: "DocIdStream",
+			},
+		},
+		{
+			input: "void org.apache.lucene.search.LeafCollector$$Lambda+<hidden>.accept(int)",
+			output: &hotspotInfo{
+				pack:  "org.apache.lucene.search",
+				class: "LeafCollector$$Lambda+<hidden>",
+			},
+		},
+		{
+			input: "void org.apache.lucene.index.SortedSetDocValuesWriter.addOneValue(org.apache.lucene.util.BytesRef)",
+			output: &hotspotInfo{
+				pack:  "org.apache.lucene.index",
+				class: "SortedSetDocValuesWriter",
+			},
+		},
+		{
+			input: "int com.sun.crypto.provider.GaloisCounterMode$GCMEngine.implGCMCrypt(java.nio.ByteBuffer, java.nio.ByteBuffer)",
+			output: &hotspotInfo{
+				pack:  "com.sun.crypto.provider",
+				class: "GaloisCounterMode$GCMEngine",
+			},
+		},
+		{
+			input: "long org.elasticsearch.cluster.routing.allocation.allocator.BalancedShardsAllocator$Balancer.getShardDiskUsageInBytes(org.elasticsearch.cluster.routing.ShardRouting, org.elasticsearch.cluster.metadata.IndexMetadata, org.elasticsearch.cluster.ClusterInfo)",
+			output: &hotspotInfo{
+				pack:  "org.elasticsearch.cluster.routing.allocation.allocator",
+				class: "BalancedShardsAllocator$Balancer",
+			},
+		},
+		{input: "void MyClass.myMethod()", output: &hotspotInfo{class: "MyClass"}},
+		{input: "void OuterClass$InnerClass.innerMethod()", output: &hotspotInfo{class: "OuterClass$InnerClass"}},
+		{input: "void some.package.MyClass.myMethod()",
+			output: &hotspotInfo{
+				pack:  "some.package",
+				class: "MyClass",
+			},
+		},
+		{input: "MyClass.constructor()",
+			output: &hotspotInfo{
+				class: "MyClass",
+			},
+		},
+		{input: "void .invalidMethod()", err: errHotspotNoMatch},
+		{input: "justAMethod()", err: errHotspotNoMatch},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			output, err := extractHotspotInfo(tc.input)
+			require.ErrorIs(t, err, tc.err)
+			assert.Equal(t, tc.output, output)
+		})
+	}
+}
+
+func TestExtractGolangInfo(t *testing.T) {
+	tests := []struct {
+		input  string
+		output *golangInfo
+	}{
+		{input: "runtime.gcBgMarkWorker.func2",
+			output: &golangInfo{
+				pack: "runtime",
+			},
+		},
+		{input: "runtime.gcDrain",
+			output: &golangInfo{
+				pack: "runtime",
+			},
+		},
+		{input: "runtime.(*mspan).typePointersOfUnchecked",
+			output: &golangInfo{
+				pack: "runtime",
+			},
+		},
+		{input: "github.com/elastic/elastic-agent-libs/mapstr.M.GetValue",
+			output: &golangInfo{
+				pack: "github.com/elastic/elastic-agent-libs/mapstr",
+			},
+		},
+		{input: "github.com/elastic/beats/v7/metricbeat/helper/prometheus.(*prometheus).ProcessMetrics",
+			output: &golangInfo{
+				pack: "github.com/elastic/beats/v7/metricbeat/helper/prometheus",
+			},
+		},
+		{input: "internal/runtime/maps.(*Map).getWithoutKeySmallFastStr",
+			output: &golangInfo{
+				pack: "internal/runtime/maps",
+			},
+		},
+		{input: "sigs.k8s.io/json/internal/golang/encoding/json.(*decodeState).object",
+			output: &golangInfo{
+				pack: "sigs.k8s.io/json/internal/golang/encoding/json",
+			},
+		},
+		{input: "crypto/internal/fips140/rsa.verifyPKCS1v15",
+			output: &golangInfo{
+				pack: "crypto/internal/fips140/rsa",
+			},
+		},
+		{input: "k8s.io/apimachinery/pkg/runtime/serializer/json.(*Serializer).Decode",
+			output: &golangInfo{
+				pack: "k8s.io/apimachinery/pkg/runtime/serializer/json",
+			},
+		},
+		{input: "github.com/google/uuid.NewRandom",
+			output: &golangInfo{
+				pack: "github.com/google/uuid",
+			},
+		},
+		{input: "github.com/cilium/cilium/pkg/hubble/monitor.(*consumer).NotifyPerfEvent",
+			output: &golangInfo{
+				pack: "github.com/cilium/cilium/pkg/hubble/monitor",
+			},
+		},
+		{input: "syscall.RawSyscall6",
+			output: &golangInfo{
+				pack: "syscall",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			output := extractGolangInfo(tc.input)
+			assert.Equal(t, tc.output, output)
+		})
+	}
+}


### PR DESCRIPTION
Allow more detailed aggregation and classification of metrics from profiling information.

Treemap visualization of the top 25 entries generated by classification:
<img width="1680" height="1588" alt="2025-07-29_14-22" src="https://github.com/user-attachments/assets/bd900b27-1589-4364-a175-1d21b0a8b0df" />
