### PR TITLE
[ratelimiter] enhance error logging with additional attributes

### DIFF
--- a/processor/ratelimitprocessor/gubernator.go
+++ b/processor/ratelimitprocessor/gubernator.go
@@ -142,8 +142,7 @@ func (r *gubernatorRateLimiter) RateLimit(ctx context.Context, hits int) error {
 		},
 	})
 	if err != nil {
-		r.set.Logger.Error("error executing gubernator rate limit request", zap.Error(err))
-		return errRateLimitInternalError
+		return err
 	}
 
 	// Inside the gRPC response, we should have a single-item list of responses.
@@ -153,20 +152,13 @@ func (r *gubernatorRateLimiter) RateLimit(ctx context.Context, hits int) error {
 	}
 	resp := responses[0]
 	if resp.GetError() != "" {
-		r.set.Logger.Error("failed to get response from gubernator", zap.Error(errors.New(resp.GetError())))
-		return errRateLimitInternalError
+		return errors.New(resp.GetError())
 	}
 
 	if resp.GetStatus() == gubernator.Status_OVER_LIMIT {
 		// Same logic as local
 		switch r.cfg.ThrottleBehavior {
 		case ThrottleBehaviorError:
-			r.set.Logger.Error(
-				"request is over the limits defined by the rate limiter",
-				zap.Error(errTooManyRequests),
-				zap.String("processor_id", r.set.ID.String()),
-				zap.Strings("metadata_keys", r.cfg.MetadataKeys),
-			)
 			return status.Error(codes.ResourceExhausted, errTooManyRequests.Error())
 		case ThrottleBehaviorDelay:
 			delay := time.Duration(resp.GetResetTime()-createdAt) * time.Millisecond

--- a/processor/ratelimitprocessor/ratelimiter.go
+++ b/processor/ratelimitprocessor/ratelimiter.go
@@ -28,8 +28,7 @@ import (
 )
 
 var (
-	errTooManyRequests        = errors.New("too many requests")
-	errRateLimitInternalError = errors.New("rate limiter failed")
+	errTooManyRequests = errors.New("too many requests")
 )
 
 // RateLimiter provides an interface for rate limiting by some number


### PR DESCRIPTION
+ Improves the error log when requests are throttled with additional fields that are passed as `metadata_keys`. 
+ Moves the error logging to the common place so we can cover for both type of ratelimiters - `local and gubernator`. 