### PR TITLE
CODEOWNERS: Assign @elastic/elastic-agent-data-plane and @elastic/ecosystem

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,3 +7,7 @@ processor/elasticapmprocessor          @elastic/obs-ds-intake-services @elastic/
 processor/elastictraceprocessor        @elastic/obs-ds-intake-services @elastic/ingest-otel-data
 processor/lsmintervalprocessor         @elastic/obs-ds-intake-services
 connector/elasticapmconnector          @elastic/obs-ds-intake-services
+extension/beatsauthextension           @elastic/elastic-agent-data-plane
+extension/fileintegrationextension     @elastic/elastic-agent-data-plane
+processor/integrationprocessor         @elastic/elastic-agent-data-plane
+pkg/integrations                       @elastic/elastic-agent-data-plane

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,6 +8,6 @@ processor/elastictraceprocessor        @elastic/obs-ds-intake-services @elastic/
 processor/lsmintervalprocessor         @elastic/obs-ds-intake-services
 connector/elasticapmconnector          @elastic/obs-ds-intake-services
 extension/beatsauthextension           @elastic/elastic-agent-data-plane
-extension/fileintegrationextension     @elastic/elastic-agent-data-plane
-processor/integrationprocessor         @elastic/elastic-agent-data-plane
-pkg/integrations                       @elastic/elastic-agent-data-plane
+extension/fileintegrationextension     @elastic/ecosystem @elastic/ingest-otel-data
+processor/integrationprocessor         @elastic/ecosystem @elastic/ingest-otel-data
+pkg/integrations                       @elastic/ecosystem @elastic/ingest-otel-data


### PR DESCRIPTION
Integrations are an essential part for the @elastic/elastic-agent-data-plane team.

Follow up to https://github.com/elastic/opentelemetry-collector-components/pull/96