### PR TITLE
[Otelbench] Set datapath for signals

### DIFF
--- a/loadgen/cmd/otelbench/.chloggen/setdatapath_signals.yaml
+++ b/loadgen/cmd/otelbench/.chloggen/setdatapath_signals.yaml
@@ -10,7 +10,7 @@ note: Adds <signal>-data-path config option n order to provide custom data input
 component: otelbench
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [719]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/loadgen/cmd/otelbench/.chloggen/setdatapath_signals.yaml
+++ b/loadgen/cmd/otelbench/.chloggen/setdatapath_signals.yaml
@@ -1,0 +1,18 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Adds <signal>-data-path config option n order to provide custom data input for your tests
+
+# It is mandatory to specify the component. Do not change this.
+component: otelbench
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/loadgen/cmd/otelbench/README.md
+++ b/loadgen/cmd/otelbench/README.md
@@ -33,8 +33,12 @@ Usage of ./otelbench:
         skip validating the remote server TLS certificates (default to value in config yaml)
   -logs
         benchmark logs (default true)
+  -logs-data-path string
+        path to logs data file (e.g. logs.json). If empty, embedded data will be used.
   -metrics
         benchmark metrics (default true)
+  -metrics-data-path string
+        path to metrics data file (e.g. metrics.json). If empty, embedded data will be used.
   -secret-token string
         secret token for target server
   -telemetry-elasticsearch-api-key string
@@ -123,6 +127,8 @@ Usage of ./otelbench:
         verbose: print additional output
   -traces
         benchmark traces (default true)
+  -traces-data-path string
+        path to traces data file (e.g. traces.json). If empty, embedded data will be used.
 ```
 
 ## Example usage

--- a/loadgen/cmd/otelbench/README.md
+++ b/loadgen/cmd/otelbench/README.md
@@ -34,13 +34,10 @@ Usage of ./otelbench:
         path to logs data file (e.g. logs.json). If empty, embedded data will be used.
   -metrics
         benchmark metrics (default true)
-<<<<<<< HEAD
   -metrics-data-path string
         path to metrics data file (e.g. metrics.json). If empty, embedded data will be used.
-=======
   -mixed
         benchmark mixed signals, i.e. logs, metrics and traces at the same time (default true)
->>>>>>> f89497e9dfdaefd492535839e657b249bb8842b9
   -secret-token string
         secret token for target server
   -shuffle

--- a/loadgen/cmd/otelbench/config.yaml
+++ b/loadgen/cmd/otelbench/config.yaml
@@ -1,28 +1,33 @@
 receivers:
   loadgen:
-  nop: # required as nop is used to disable pipelines that are not relevant to the bench, e.g. disabling metrics pipeline in logs bench
+  nop:
 
 exporters:
   otlp:
-    endpoint: "http://localhost:8200"
-    tls:
-      # As otlpexporter ignores the protocol in `endpoint`,
-      # `tls::insecure` needs to be explicitly set to true if target server does not use TLS
-      insecure: false
-      insecure_skip_verify: false
+    endpoint: "https://gizas-benchmarktest-cfd867.ingest.us-central1.gcp.qa.elastic.cloud:443"
+    headers:
+      # The value of the authorization header does not matter, but it should
+      # follow the format the elasticcloudauth expects it to be: base64 encoded,
+      # and there should be one : splitting ID from the encoded value.
+      Authorization: "ApiKey aElDUnpKZ0J5S1FsRnp6UHZoX2o6N0F3WjVkVUN4VXhzMkFjeWQxNm94Zw=="
     sending_queue:
       enabled: false
+    tls:
+      insecure_skip_verify: true
     timeout: 60s
   otlphttp:
-    endpoint: "http://localhost:8200"
-    tls:
-      # As long as the endpoint contains the correct protocol, `tls::insecure` does not matter.
-      insecure: false
-      insecure_skip_verify: false
+    endpoint: "https://gizas-benchmarktest-cfd867.ingest.us-central1.gcp.qa.elastic.cloud:443"
+    headers:
+      # The value of the authorization header does not matter, but it should
+      # follow the format the elasticcloudauth expects it to be: base64 encoded,
+      # and there should be one : splitting ID from the encoded value.
+      Authorization: "ApiKey aElDUnpKZ0J5S1FsRnp6UHZoX2o6N0F3WjVkVUN4VXhzMkFjeWQxNm94Zw=="
     sending_queue:
       enabled: false
+    tls:
+      insecure_skip_verify: true
     timeout: 60s
-  nop: # required as nop is used to disable pipelines that are not relevant to the bench, e.g. disabling metrics pipeline in logs bench
+  nop:
 
 processors:
   transform/rewrite:  # Rewrite telemetry to increase cardinality

--- a/loadgen/cmd/otelbench/config.yaml
+++ b/loadgen/cmd/otelbench/config.yaml
@@ -1,33 +1,28 @@
 receivers:
   loadgen:
-  nop:
+  nop: # required as nop is used to disable pipelines that are not relevant to the bench, e.g. disabling metrics pipeline in logs bench
 
 exporters:
   otlp:
-    endpoint: "https://gizas-benchmarktest-cfd867.ingest.us-central1.gcp.qa.elastic.cloud:443"
-    headers:
-      # The value of the authorization header does not matter, but it should
-      # follow the format the elasticcloudauth expects it to be: base64 encoded,
-      # and there should be one : splitting ID from the encoded value.
-      Authorization: "ApiKey aElDUnpKZ0J5S1FsRnp6UHZoX2o6N0F3WjVkVUN4VXhzMkFjeWQxNm94Zw=="
+    endpoint: "http://localhost:8200"
+    tls:
+      # As otlpexporter ignores the protocol in `endpoint`,
+      # `tls::insecure` needs to be explicitly set to true if target server does not use TLS
+      insecure: false
+      insecure_skip_verify: false
     sending_queue:
       enabled: false
-    tls:
-      insecure_skip_verify: true
     timeout: 60s
   otlphttp:
-    endpoint: "https://gizas-benchmarktest-cfd867.ingest.us-central1.gcp.qa.elastic.cloud:443"
-    headers:
-      # The value of the authorization header does not matter, but it should
-      # follow the format the elasticcloudauth expects it to be: base64 encoded,
-      # and there should be one : splitting ID from the encoded value.
-      Authorization: "ApiKey aElDUnpKZ0J5S1FsRnp6UHZoX2o6N0F3WjVkVUN4VXhzMkFjeWQxNm94Zw=="
+    endpoint: "http://localhost:8200"
+    tls:
+      # As long as the endpoint contains the correct protocol, `tls::insecure` does not matter.
+      insecure: false
+      insecure_skip_verify: false
     sending_queue:
       enabled: false
-    tls:
-      insecure_skip_verify: true
     timeout: 60s
-  nop:
+  nop: # required as nop is used to disable pipelines that are not relevant to the bench, e.g. disabling metrics pipeline in logs bench
 
 processors:
   transform/rewrite:  # Rewrite telemetry to increase cardinality

--- a/loadgen/cmd/otelbench/flags.go
+++ b/loadgen/cmd/otelbench/flags.go
@@ -346,20 +346,15 @@ func SetConcurrency(concurrency int) (configFiles []string) {
 // Configuration options for `traces_data_path`, `metrics_data_path`, and `logs_data_path` will update
 // the existing 'jsonl_file' option for each signal.
 func SetDataPaths(tracesPath, metricsPath, logsPath string) []string {
-	if tracesPath == "" && metricsPath == "" && logsPath == "" {
-		return nil
-	}
-
-	var sb strings.Builder
-	sb.WriteString("receivers:\n  loadgen:\n")
+	var sets []string
 	if tracesPath != "" {
-		sb.WriteString(fmt.Sprintf("    traces:\n      jsonl_file: %q\n", tracesPath))
+		sets = append(sets, fmt.Sprintf("receivers.loadgen.traces.jsonl_file=%q", tracesPath))
 	}
 	if metricsPath != "" {
-		sb.WriteString(fmt.Sprintf("    metrics:\n      jsonl_file: %q\n", metricsPath))
+		sets = append(sets, fmt.Sprintf("receivers.loadgen.metrics.jsonl_file=%q", metricsPath))
 	}
 	if logsPath != "" {
-		sb.WriteString(fmt.Sprintf("    logs:\n      jsonl_file: %q\n", logsPath))
+		sets = append(sets, fmt.Sprintf("receivers.loadgen.logs.jsonl_file=%q", logsPath))
 	}
-	return []string{fmt.Sprintf("yaml:%s", sb.String())}
+	return setsToConfigs(sets)
 }

--- a/loadgen/cmd/otelbench/main.go
+++ b/loadgen/cmd/otelbench/main.go
@@ -249,6 +249,7 @@ func configs(exporter, signal string, iterations, concurrency int) (configFiles 
 	configFiles = append(configFiles, ExporterConfigs(exporter)...)
 	configFiles = append(configFiles, SetIterations(iterations)...)
 	configFiles = append(configFiles, SetConcurrency(concurrency)...)
+	configFiles = append(configFiles, SetDataPaths(Config.TracesDataPath, Config.MetricsDataPath, Config.LogsDataPath)...)
 	for _, s := range []string{"logs", "metrics", "traces"} {
 		// Disable pipelines not relevant to the benchmark by overriding receiver and exporter to nop
 		if signal != s {

--- a/loadgen/cmd/otelbench/main.go
+++ b/loadgen/cmd/otelbench/main.go
@@ -159,9 +159,6 @@ func main() {
 	}
 	flag.Parse()
 
-	// DEBUG: Print the parsed data path flags to confirm they are being read.
-	fmt.Fprintf(os.Stderr, "DEBUG: Parsed logs-data-path: %q, metrics-data-path: %q, traces-data-path: %q\n", Config.LogsDataPath, Config.MetricsDataPath, Config.TracesDataPath)
-
 	// default to embedded collector config
 	if Config.CollectorConfigPath == "" {
 		url, srv, err := serveEmbeddedConf()

--- a/loadgen/cmd/otelbench/main.go
+++ b/loadgen/cmd/otelbench/main.go
@@ -159,6 +159,9 @@ func main() {
 	}
 	flag.Parse()
 
+	// DEBUG: Print the parsed data path flags to confirm they are being read.
+	fmt.Fprintf(os.Stderr, "DEBUG: Parsed logs-data-path: %q, metrics-data-path: %q, traces-data-path: %q\n", Config.LogsDataPath, Config.MetricsDataPath, Config.TracesDataPath)
+
 	// default to embedded collector config
 	if Config.CollectorConfigPath == "" {
 		url, srv, err := serveEmbeddedConf()

--- a/loadgen/cmd/otelbench/main.go
+++ b/loadgen/cmd/otelbench/main.go
@@ -27,7 +27,9 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -59,8 +61,26 @@ func getExporters() (exporters []string) {
 	return
 }
 
-func fullBenchmarkName(signal, exporter string, concurrency int) string {
-	return fmt.Sprintf("BenchmarkOTelbench/%s-%s-%d", signal, exporter, concurrency)
+// getDataPathForSignal returns the data path for a given signal type.
+func getDataPathForSignal(signal string) string {
+	switch signal {
+	case "logs":
+		return Config.LogsDataPath
+	case "metrics":
+		return Config.MetricsDataPath
+	case "traces":
+		return Config.TracesDataPath
+	}
+	return ""
+}
+
+func fullBenchmarkName(signal, exporter string, concurrency int, dataPath string) string {
+	name := fmt.Sprintf("BenchmarkOTelbench/%s-%s", signal, exporter)
+	if dataPath != "" {
+		filename := filepath.Base(dataPath)
+		name = fmt.Sprintf("%s-%s", name, strings.TrimSuffix(filename, filepath.Ext(filename)))
+	}
+	return fmt.Sprintf("%s-%d", name, concurrency)
 }
 
 func runBench(ctx context.Context, signal, exporter string, concurrency int, reporter func(b *testing.B)) testing.BenchmarkResult {
@@ -186,7 +206,8 @@ func main() {
 	for _, concurrency := range Config.ConcurrencyList {
 		for _, signal := range getSignals() {
 			for _, exporter := range getExporters() {
-				maxLen = max(maxLen, len(fullBenchmarkName(signal, exporter, concurrency)))
+				dataPath := getDataPathForSignal(signal)
+				maxLen = max(maxLen, len(fullBenchmarkName(signal, exporter, concurrency, dataPath)))
 			}
 		}
 	}
@@ -212,7 +233,8 @@ func main() {
 	for _, concurrency := range Config.ConcurrencyList {
 		for _, signal := range signals {
 			for _, exporter := range exporters {
-				benchName := fullBenchmarkName(signal, exporter, concurrency)
+				dataPath := getDataPathForSignal(signal)
+				benchName := fullBenchmarkName(signal, exporter, concurrency, dataPath)
 				for i := 0; i < count; i++ {
 					t := time.Now().UTC()
 					result := runBench(ctx, signal, exporter, concurrency, func(b *testing.B) {


### PR DESCRIPTION
This adds the ability to provide `<signal>-data-path` parameter to your tests in order to provide custom input for your tests
The PR includes also the update of the name of the test in case the data-path is provided

```bash
./loadgen -config="./config_traces.yaml" -concurrency=60 -test.benchtime=1m -test.count=3 -traces-data-path="./testdata/tracesTestFile.jsonl"

BenchmarkOTelbench/traces-otlp-tracesTestFile-60    	    7710	   9093050 ns/op	         0 failed_logs/s	         0 failed_metric_points/s	         0 failed_requests/s	         0 failed_spans/s	         0 logs/s	         0 metric_points/s	       110.0 requests/s	       549.9 spans/s

```

The above is handy when you want to provide custom load for the benchmark test we want to run

Verified that the the custom data path is applied in e2e tests:

<img width="1865" height="618" alt="Screenshot 2025-08-22 at 3 24 07 PM" src="https://github.com/user-attachments/assets/50b772cf-23d2-4ee3-b187-a08ca13217e2" />

