### PR TITLE
loadgen, otelbench: Fix panic on record count when struct is mutated

### DIFF
--- a/receiver/loadgenreceiver/logs.go
+++ b/receiver/loadgenreceiver/logs.go
@@ -125,16 +125,17 @@ func (ar *logsGenerator) Start(ctx context.Context, _ component.Host) error {
 				}
 				// For graceful shutdown, use ctx instead of startCtx to shield Consume* from context canceled
 				// In other words, Consume* will finish at its own pace, which may take indefinitely long.
+				recordCount := next.LogRecordCount()
 				if err := ar.consumer.ConsumeLogs(ctx, next); err != nil {
 					ar.logger.Error(err.Error())
 					ar.statsMu.Lock()
 					ar.stats.FailedRequests++
-					ar.stats.FailedLogRecords += next.LogRecordCount()
+					ar.stats.FailedLogRecords += recordCount
 					ar.statsMu.Unlock()
 				} else {
 					ar.statsMu.Lock()
 					ar.stats.Requests++
-					ar.stats.LogRecords += next.LogRecordCount()
+					ar.stats.LogRecords += recordCount
 					ar.statsMu.Unlock()
 				}
 			}

--- a/receiver/loadgenreceiver/metrics.go
+++ b/receiver/loadgenreceiver/metrics.go
@@ -132,16 +132,17 @@ func (ar *metricsGenerator) Start(ctx context.Context, _ component.Host) error {
 				}
 				// For graceful shutdown, use ctx instead of startCtx to shield Consume* from context canceled
 				// In other words, Consume* will finish at its own pace, which may take indefinitely long.
+				recordCount := next.DataPointCount()
 				if err := ar.consumer.ConsumeMetrics(ctx, next); err != nil {
 					ar.logger.Error(err.Error())
 					ar.statsMu.Lock()
 					ar.stats.FailedRequests++
-					ar.stats.FailedMetricDataPoints += next.DataPointCount()
+					ar.stats.FailedMetricDataPoints += recordCount
 					ar.statsMu.Unlock()
 				} else {
 					ar.statsMu.Lock()
 					ar.stats.Requests++
-					ar.stats.MetricDataPoints += next.DataPointCount()
+					ar.stats.MetricDataPoints += recordCount
 					ar.statsMu.Unlock()
 				}
 			}

--- a/receiver/loadgenreceiver/traces.go
+++ b/receiver/loadgenreceiver/traces.go
@@ -127,16 +127,17 @@ func (ar *tracesGenerator) Start(ctx context.Context, _ component.Host) error {
 				}
 				// For graceful shutdown, use ctx instead of startCtx to shield Consume* from context canceled
 				// In other words, Consume* will finish at its own pace, which may take indefinitely long.
+				recordCount := next.SpanCount()
 				if err := ar.consumer.ConsumeTraces(ctx, next); err != nil {
 					ar.logger.Error(err.Error())
 					ar.statsMu.Lock()
 					ar.stats.FailedRequests++
-					ar.stats.FailedSpans += next.SpanCount()
+					ar.stats.FailedSpans += recordCount
 					ar.statsMu.Unlock()
 				} else {
 					ar.statsMu.Lock()
 					ar.stats.Requests++
-					ar.stats.Spans += next.SpanCount()
+					ar.stats.Spans += recordCount
 					ar.statsMu.Unlock()
 				}
 			}


### PR DESCRIPTION
Fix panic

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xbcd43f]

goroutine 281 [running]:
go.opentelemetry.io/collector/pdata/plog.ResourceLogsSlice.At(...)
        go.opentelemetry.io/collector/pdata@v1.36.0/plog/generated_resourcelogsslice.go:57
go.opentelemetry.io/collector/pdata/plog.Logs.LogRecordCount({0xc003f4ef48?, 0xc001c263e4?})
        go.opentelemetry.io/collector/pdata@v1.36.0/plog/logs.go:48 +0x1f
github.com/elastic/opentelemetry-collector-components/receiver/loadgenreceiver.(*logsGenerator).Start.func1()
        github.com/elastic/opentelemetry-collector-components/receiver/loadgenreceiver@v0.0.0/logs.go:137 +0x1f3
created by github.com/elastic/opentelemetry-collector-components/receiver/loadgenreceiver.(*logsGenerator).Start in goroutine 1
        github.com/elastic/opentelemetry-collector-components/receiver/loadgenreceiver@v0.0.0/logs.go:106 +0x85
```

This is observed even `disable_pdata_reuse: true` when batchprocessor is used.
