### PR TITLE
apikeyauthextension: Elasticsearch check error codes explicitly

### DIFF
--- a/extension/apikeyauthextension/authenticator.go
+++ b/extension/apikeyauthextension/authenticator.go
@@ -266,7 +266,7 @@ func (a *authenticator) Authenticate(ctx context.Context, headers map[string][]s
 	if err != nil {
 		if elasticsearchErr, ok := err.(*types.ElasticsearchError); ok {
 			if elasticsearchErr.Status == http.StatusUnauthorized || elasticsearchErr.Status == http.StatusForbidden {
-				return ctx, status.Error(codes.PermissionDenied, err.Error())
+				return ctx, status.Error(codes.Unauthenticated, err.Error())
 			}
 		}
 		return ctx, fmt.Errorf(

--- a/extension/apikeyauthextension/authenticator_test.go
+++ b/extension/apikeyauthextension/authenticator_test.go
@@ -87,7 +87,7 @@ func TestAuthenticator(t *testing.T) {
 				},
 				Status: 401,
 			}),
-			expectedErr: `rpc error: code = PermissionDenied desc = status: 401, failed: [auth_reason], reason: auth_reason`,
+			expectedErr: `rpc error: code = Unauthenticated desc = status: 401, failed: [auth_reason], reason: auth_reason`,
 		},
 		"missing_privileges": {
 			handler:     newCannedHasPrivilegesHandler(hasprivileges.Response{HasAllRequested: false}),


### PR DESCRIPTION
For well-known Elasticsearch error codes returned from `HasPrivileges` API we should propagate the client error back through the extension.