### PR TITLE
apikeyauth: support cache key from client metadata

### DIFF
--- a/extension/apikeyauthextension/authenticator.go
+++ b/extension/apikeyauthextension/authenticator.go
@@ -210,7 +210,11 @@ func (a *authenticator) hasPrivileges(ctx context.Context, authHeaderValue strin
 }
 
 // getCacheKey computes a cache key for the given API Key ID and headers.
-func (a *authenticator) getCacheKey(id string, headers map[string][]string) (string, error) {
+func (a *authenticator) getCacheKey(ctx context.Context, id string, headers map[string][]string) (string, error) {
+	var clientMetadata client.Metadata
+	if len(a.config.Cache.KeyMetadata) != 0 {
+		clientMetadata = client.FromContext(ctx).Metadata
+	}
 	key := id
 	for _, header := range a.config.Cache.KeyHeaders {
 		value, ok := getHeader(headers, header, strings.ToLower(header))
@@ -218,6 +222,13 @@ func (a *authenticator) getCacheKey(id string, headers map[string][]string) (str
 			return "", fmt.Errorf("error computing cache key: missing header %q", header)
 		}
 		key += " " + value
+	}
+	for _, metadataKey := range a.config.Cache.KeyMetadata {
+		values := clientMetadata.Get(metadataKey)
+		if len(values) == 0 {
+			return "", fmt.Errorf("error computing cache key: missing client metadata %q", metadataKey)
+		}
+		key += " " + values[0]
 	}
 	return key, nil
 }
@@ -234,7 +245,7 @@ func (a *authenticator) Authenticate(ctx context.Context, headers map[string][]s
 		return ctx, status.Error(codes.Unauthenticated, err.Error())
 	}
 
-	cacheKey, err := a.getCacheKey(id, headers)
+	cacheKey, err := a.getCacheKey(ctx, id, headers)
 	if err != nil {
 		return ctx, err
 	}

--- a/extension/apikeyauthextension/authenticator_test.go
+++ b/extension/apikeyauthextension/authenticator_test.go
@@ -206,6 +206,47 @@ func TestAuthenticator_CacheKeyHeaders(t *testing.T) {
 	assert.Equal(t, "id1", clientInfo.Auth.GetAttribute("api_key"))
 }
 
+func TestAuthenticator_CacheKeyMetadata(t *testing.T) {
+	srv := newMockElasticsearch(t, newCannedHasPrivilegesHandler(successfulResponse))
+	config := createDefaultConfig().(*Config)
+	config.Cache.KeyMetadata = []string{"X-Tenant-Id"}
+	authenticator := newTestAuthenticator(t, srv, config)
+
+	// Missing X-Tenant-Id header should result in an error.
+	_, err := authenticator.Authenticate(context.Background(), map[string][]string{
+		"Authorization": {"ApiKey " + base64.StdEncoding.EncodeToString([]byte("id1:secret1"))},
+	})
+	require.EqualError(t, err, `error computing cache key: missing client metadata "X-Tenant-Id"`)
+
+	withMetadata := client.NewContext(context.Background(), client.Info{
+		Metadata: client.NewMetadata(map[string][]string{
+			"X-Tenant-Id": {"tenant1"},
+		}),
+	})
+	ctx, err := authenticator.Authenticate(withMetadata, map[string][]string{
+		"Authorization": {"ApiKey " + base64.StdEncoding.EncodeToString([]byte("id1:secret1"))},
+	})
+	require.NoError(t, err)
+	clientInfo := client.FromContext(ctx)
+	assert.Equal(t, user, clientInfo.Auth.GetAttribute("username"))
+	assert.Equal(t, "id1", clientInfo.Auth.GetAttribute("api_key"))
+
+	// Different x-tenant-id header value should result in a cache miss,
+	// despite the API Key ID being the same.
+	withMetadata2 := client.NewContext(context.Background(), client.Info{
+		Metadata: client.NewMetadata(map[string][]string{
+			"X-Tenant-Id": {"tenant2"},
+		}),
+	})
+	ctx, err = authenticator.Authenticate(withMetadata2, map[string][]string{
+		"Authorization": {"ApiKey " + base64.StdEncoding.EncodeToString([]byte("id1:secret2"))},
+	})
+	require.NoError(t, err)
+	clientInfo = client.FromContext(ctx)
+	assert.Equal(t, user, clientInfo.Auth.GetAttribute("username"))
+	assert.Equal(t, "id1", clientInfo.Auth.GetAttribute("api_key"))
+}
+
 func TestAuthenticator_CacheTTL(t *testing.T) {
 	var calls int
 	srv := newMockElasticsearch(t, func(w http.ResponseWriter, r *http.Request) {

--- a/extension/apikeyauthextension/config.go
+++ b/extension/apikeyauthextension/config.go
@@ -57,6 +57,12 @@ type CacheConfig struct {
 	// are missing from the request, an error will be returned.
 	KeyHeaders []string `mapstructure:"key_headers,omitempty"`
 
+	// KeyMetadata holds an optional set of client metadata keys to
+	// include in the cache key, for partitioning the API Key space.
+	// If any keys are missing from the client metadata, an error
+	// will be returned.
+	KeyMetadata []string `mapstructure:"key_metadata,omitempty"`
+
 	// PBKDF2Iterations defines the iteration count for PBKDF2
 	// for key derivation in cached API Keys.
 	PBKDF2Iterations int `mapstructure:"pbkdf2_iterations,omitempty"`


### PR DESCRIPTION
Add support for configuring the extension to use client metadata for the cache key. This is useful if you have middleware that derives client metadata from headers.