### PR TITLE
[elasticapmprocessor] - do not disable AgentName and AgentVersion in ECS mode

### DIFF
--- a/processor/elasticapmprocessor/processor.go
+++ b/processor/elasticapmprocessor/processor.go
@@ -66,8 +66,6 @@ func (p *TraceProcessor) ConsumeTraces(ctx context.Context, td ptrace.Traces) er
 			resource := resourceSpan.Resource()
 			ecs.TranslateResourceMetadata(resource)
 			routing.EncodeDataStream(resource, "traces")
-			p.enricher.Config.Resource.AgentName.Enabled = false
-			p.enricher.Config.Resource.AgentVersion.Enabled = false
 			p.enricher.Config.Resource.DeploymentEnvironment.Enabled = false
 		}
 	}
@@ -140,8 +138,6 @@ func (p *MetricProcessor) ConsumeMetrics(ctx context.Context, md pmetric.Metrics
 			resource := resourceMetric.Resource()
 			ecs.TranslateResourceMetadata(resource)
 			routing.EncodeDataStream(resource, "metrics")
-			p.enricher.Config.Resource.AgentName.Enabled = false
-			p.enricher.Config.Resource.AgentVersion.Enabled = false
 			p.enricher.Config.Resource.DeploymentEnvironment.Enabled = false
 		}
 	}
@@ -157,7 +153,6 @@ func (p *LogProcessor) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 			resource := resourceLog.Resource()
 			ecs.TranslateResourceMetadata(resource)
 			routing.EncodeDataStream(resource, "logs")
-			p.enricher.Config.Resource.AgentName.Enabled = false
 			p.enricher.Config.Resource.AgentVersion.Enabled = false
 			p.enricher.Config.Resource.DeploymentEnvironment.Enabled = false
 		}


### PR DESCRIPTION
https://github.com/elastic/opentelemetry-lib/pull/229 is a prerequisite for this - until that the corresponding test fails.

When OTLP receiver (for OTel SDKs) is used and set to `ecs` mode, then agent.name and version were not calculated due to these lines. `agent.name` is required in Kibana -without that the APM UI throws an exception 

https://github.com/elastic/opentelemetry-lib/pull/229 has more details on the complete plan - and also linking internal issue. 
