### PR TITLE
improve errorinfo for ratelimiter and auth errors

### DIFF
--- a/extension/apikeyauthextension/authenticator.go
+++ b/extension/apikeyauthextension/authenticator.go
@@ -246,7 +246,6 @@ func (a *authenticator) Authenticate(ctx context.Context, headers map[string][]s
 	if err != nil {
 		detailedErr := errorWithDetails(codes.Unauthenticated, err.Error(), map[string]string{
 			"component": "apikeyauthextension",
-			"api_key":   id,
 		})
 		return ctx, detailedErr
 	}

--- a/extension/apikeyauthextension/authenticator.go
+++ b/extension/apikeyauthextension/authenticator.go
@@ -324,6 +324,7 @@ func errorWithDetails(code codes.Code, msg string, metadata map[string]string) e
 	st := status.New(code, msg)
 	if detailedSt, err := st.WithDetails(&errdetails.ErrorInfo{
 		Reason:   msg,
+		Domain:   "ingest.elastic.co",
 		Metadata: metadata,
 	}); err == nil {
 		return detailedSt.Err()

--- a/extension/apikeyauthextension/authenticator.go
+++ b/extension/apikeyauthextension/authenticator.go
@@ -33,6 +33,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/extension/extensionauth"
 	"golang.org/x/crypto/pbkdf2"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -51,7 +52,7 @@ const (
 )
 
 var (
-	errAuthorizationHeaderWrongScheme = errors.New("ApiKey prefix not found")
+	errAuthorizationHeaderWrongScheme = errors.New("ApiKey prefix not found, expected ApiKey <value>")
 	errAuthorizationHeaderInvalid     = errors.New("invalid API Key")
 
 	_ client.AuthData      = (*authData)(nil)
@@ -147,7 +148,7 @@ func (a *authenticator) Shutdown(ctx context.Context) error {
 func (a *authenticator) parseAuthorizationHeader(headers map[string][]string) (string, string, error) {
 	orig, ok := getHeader(headers, authorizationHeader, lowerAuthorizationHeader)
 	if !ok {
-		return "", "", fmt.Errorf("missing header %q", authorizationHeader)
+		return "", "", fmt.Errorf("missing header %q, expected %q", authorizationHeader, "ApiKey <value>")
 	}
 
 	// The expected format of the Authorization header is:
@@ -243,7 +244,11 @@ func (a *authenticator) getCacheKey(ctx context.Context, id string, headers map[
 func (a *authenticator) Authenticate(ctx context.Context, headers map[string][]string) (context.Context, error) {
 	authHeaderValue, id, err := a.parseAuthorizationHeader(headers)
 	if err != nil {
-		return ctx, status.Error(codes.Unauthenticated, err.Error())
+		detailedErr := errorWithDetails(codes.Unauthenticated, err.Error(), map[string]string{
+			"component": "apikeyauthextension",
+			"api_key":   id,
+		})
+		return ctx, detailedErr
 	}
 
 	cacheKey, err := a.getCacheKey(ctx, id, headers)
@@ -263,9 +268,11 @@ func (a *authenticator) Authenticate(ctx context.Context, headers map[string][]s
 			// Client has specified an API Key with a colliding ID,
 			// but whose secret component does not match the one in
 			// the cache.
-			return ctx, status.Errorf(codes.Unauthenticated,
-				"API Key %q unauthorized", id,
-			)
+			detailedErr := errorWithDetails(codes.Unauthenticated, fmt.Sprintf("API Key %q unauthorized", id), map[string]string{
+				"component": "apikeyauthextension",
+				"api_key":   id,
+			})
+			return ctx, detailedErr
 		}
 		if cacheEntry.err != nil {
 			return ctx, status.Error(codes.Unauthenticated, cacheEntry.err.Error())
@@ -280,17 +287,18 @@ func (a *authenticator) Authenticate(ctx context.Context, headers map[string][]s
 				return ctx, status.Error(codes.Unauthenticated, err.Error())
 			}
 		}
-		return ctx, fmt.Errorf(
-			"error checking privileges for API Key %q: %v", id, err,
-		)
+		return ctx, status.Errorf(codes.Unauthenticated, "error checking privileges for API Key %q: %v", id, err)
 	}
 	if !hasPrivileges {
 		cacheEntry := &cacheEntry{
 			key: derivedKey,
-			err: fmt.Errorf("API Key %q unauthorized", id),
+			err: errorWithDetails(codes.PermissionDenied, fmt.Sprintf("API Key %q unauthorized", id), map[string]string{
+				"component": "apikeyauthextension",
+				"api_key":   id,
+			}),
 		}
 		a.cache.Add(cacheKey, cacheEntry)
-		return ctx, status.Error(codes.PermissionDenied, cacheEntry.err.Error())
+		return ctx, cacheEntry.err
 	}
 	cacheEntry := &cacheEntry{
 		key: derivedKey,
@@ -307,4 +315,18 @@ func newCtxWithAuthData(ctx context.Context, authData *authData) context.Context
 	clientInfo := client.FromContext(ctx)
 	clientInfo.Auth = authData
 	return client.NewContext(ctx, clientInfo)
+}
+
+// errorWithDetails provides a user friendly error with additional error details that
+// can be later used to provide more detailed error information to the user.
+// Fixed typo and optimized version
+func errorWithDetails(code codes.Code, msg string, metadata map[string]string) error {
+	st := status.New(code, msg)
+	if detailedSt, err := st.WithDetails(&errdetails.ErrorInfo{
+		Reason:   msg,
+		Metadata: metadata,
+	}); err == nil {
+		return detailedSt.Err()
+	}
+	return st.Err()
 }

--- a/extension/apikeyauthextension/authenticator.go
+++ b/extension/apikeyauthextension/authenticator.go
@@ -319,11 +319,9 @@ func newCtxWithAuthData(ctx context.Context, authData *authData) context.Context
 
 // errorWithDetails provides a user friendly error with additional error details that
 // can be later used to provide more detailed error information to the user.
-// Fixed typo and optimized version
 func errorWithDetails(code codes.Code, msg string, metadata map[string]string) error {
 	st := status.New(code, msg)
 	if detailedSt, err := st.WithDetails(&errdetails.ErrorInfo{
-		Reason:   msg,
 		Domain:   "ingest.elastic.co",
 		Metadata: metadata,
 	}); err == nil {

--- a/extension/apikeyauthextension/authenticator_test.go
+++ b/extension/apikeyauthextension/authenticator_test.go
@@ -209,7 +209,6 @@ func TestAuthenticator_ErrorWithDetails(t *testing.T) {
 			expectedMsg:  "ApiKey prefix not found, expected ApiKey <value>",
 			expectedMetadata: map[string]string{
 				"component": "apikeyauthextension",
-				"api_key":   "",
 			},
 		},
 		"api_key_collision": {

--- a/extension/apikeyauthextension/authenticator_test.go
+++ b/extension/apikeyauthextension/authenticator_test.go
@@ -269,6 +269,7 @@ func TestAuthenticator_ErrorWithDetails(t *testing.T) {
 			errorInfo, ok := details[0].(*errdetails.ErrorInfo)
 			require.True(t, ok, "expected errorinfo detail")
 			assert.Equal(t, testcase.expectedMsg, errorInfo.Reason)
+			assert.Equal(t, "ingest.elastic.co", errorInfo.Domain)
 			assert.Equal(t, testcase.expectedMetadata, errorInfo.Metadata)
 		})
 	}

--- a/extension/apikeyauthextension/authenticator_test.go
+++ b/extension/apikeyauthextension/authenticator_test.go
@@ -268,7 +268,6 @@ func TestAuthenticator_ErrorWithDetails(t *testing.T) {
 
 			errorInfo, ok := details[0].(*errdetails.ErrorInfo)
 			require.True(t, ok, "expected errorinfo detail")
-			assert.Equal(t, testcase.expectedMsg, errorInfo.Reason)
 			assert.Equal(t, "ingest.elastic.co", errorInfo.Domain)
 			assert.Equal(t, testcase.expectedMetadata, errorInfo.Metadata)
 		})

--- a/extension/apikeyauthextension/authenticator_test.go
+++ b/extension/apikeyauthextension/authenticator_test.go
@@ -33,6 +33,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/client"
 	"go.opentelemetry.io/collector/component/componenttest"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 const user = "test"
@@ -74,7 +77,7 @@ func TestAuthenticator(t *testing.T) {
 				},
 				Status: 400,
 			}),
-			expectedErr: `error checking privileges for API Key "id": status: 400, failed: [a_type], reason: a_reason`,
+			expectedErr: `rpc error: code = Unauthenticated desc = error checking privileges for API Key "id": status: 400, failed: [a_type], reason: a_reason`,
 		},
 		"auth_error": {
 			handler: newCannedErrorHandler(types.ElasticsearchError{
@@ -184,6 +187,91 @@ func TestAuthenticator_Caching(t *testing.T) {
 		"Authorization": {"ApiKey " + base64.StdEncoding.EncodeToString([]byte("id2:secret2"))},
 	})
 	assert.EqualError(t, err, `rpc error: code = Unauthenticated desc = API Key "id2" unauthorized`)
+}
+
+func TestAuthenticator_ErrorWithDetails(t *testing.T) {
+	for name, testcase := range map[string]struct {
+		setup            func(*testing.T) (*authenticator, map[string][]string)
+		expectedCode     codes.Code
+		expectedMsg      string
+		expectedMetadata map[string]string
+	}{
+		"invalid_header": {
+			setup: func(t *testing.T) (*authenticator, map[string][]string) {
+				srv := newMockElasticsearch(t, newCannedHasPrivilegesHandler(successfulResponse))
+				authenticator := newTestAuthenticator(t, srv, createDefaultConfig().(*Config))
+				headers := map[string][]string{
+					"Authorization": {"Bearer invalid"},
+				}
+				return authenticator, headers
+			},
+			expectedCode: codes.Unauthenticated,
+			expectedMsg:  "ApiKey prefix not found, expected ApiKey <value>",
+			expectedMetadata: map[string]string{
+				"component": "apikeyauthextension",
+				"api_key":   "",
+			},
+		},
+		"api_key_collision": {
+			setup: func(t *testing.T) (*authenticator, map[string][]string) {
+				srv := newMockElasticsearch(t, newCannedHasPrivilegesHandler(successfulResponse))
+				authenticator := newTestAuthenticator(t, srv, createDefaultConfig().(*Config))
+				_, err := authenticator.Authenticate(context.Background(), map[string][]string{
+					"Authorization": {"ApiKey " + base64.StdEncoding.EncodeToString([]byte("collision_id:secret1"))},
+				})
+				require.NoError(t, err)
+				// cause collision case
+				headers := map[string][]string{
+					"Authorization": {"ApiKey " + base64.StdEncoding.EncodeToString([]byte("collision_id:secret2"))},
+				}
+				return authenticator, headers
+			},
+			expectedCode: codes.Unauthenticated,
+			expectedMsg:  `API Key "collision_id" unauthorized`,
+			expectedMetadata: map[string]string{
+				"component": "apikeyauthextension",
+				"api_key":   "collision_id",
+			},
+		},
+		"missing_privileges": {
+			setup: func(t *testing.T) (*authenticator, map[string][]string) {
+				srv := newMockElasticsearch(t, newCannedHasPrivilegesHandler(hasprivileges.Response{
+					Username:        user,
+					HasAllRequested: false,
+				}))
+				authenticator := newTestAuthenticator(t, srv, createDefaultConfig().(*Config))
+				headers := map[string][]string{
+					"Authorization": {"ApiKey " + base64.StdEncoding.EncodeToString([]byte("no_privs_id:secret"))},
+				}
+				return authenticator, headers
+			},
+			expectedCode: codes.PermissionDenied,
+			expectedMsg:  `API Key "no_privs_id" unauthorized`,
+			expectedMetadata: map[string]string{
+				"component": "apikeyauthextension",
+				"api_key":   "no_privs_id",
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			authenticator, headers := testcase.setup(t)
+			_, err := authenticator.Authenticate(context.Background(), headers)
+			require.Error(t, err)
+
+			st, ok := status.FromError(err)
+			require.True(t, ok, "Expected gRPC status error")
+			assert.Equal(t, testcase.expectedCode, st.Code())
+			assert.Equal(t, testcase.expectedMsg, st.Message())
+
+			details := st.Details()
+			require.Len(t, details, 1, "expected 1 errorinfo detail")
+
+			errorInfo, ok := details[0].(*errdetails.ErrorInfo)
+			require.True(t, ok, "expected errorinfo detail")
+			assert.Equal(t, testcase.expectedMsg, errorInfo.Reason)
+			assert.Equal(t, testcase.expectedMetadata, errorInfo.Metadata)
+		})
+	}
 }
 
 func TestAuthenticator_CacheKeyHeaders(t *testing.T) {
@@ -327,7 +415,7 @@ func TestAuthenticator_AuthorizationHeader(t *testing.T) {
 		},
 		"missing_header": {
 			headers:     map[string][]string{},
-			expectedErr: `rpc error: code = Unauthenticated desc = missing header "Authorization"`,
+			expectedErr: `rpc error: code = Unauthenticated desc = missing header "Authorization", expected "ApiKey <value>"`,
 		},
 		"invalid_scheme": {
 			headers: map[string][]string{
@@ -335,7 +423,7 @@ func TestAuthenticator_AuthorizationHeader(t *testing.T) {
 					"Bearer " + base64.StdEncoding.EncodeToString([]byte("id:secret")),
 				},
 			},
-			expectedErr: `rpc error: code = Unauthenticated desc = ApiKey prefix not found`,
+			expectedErr: `rpc error: code = Unauthenticated desc = ApiKey prefix not found, expected ApiKey <value>`,
 		},
 		"invalid_base64": {
 			headers: map[string][]string{

--- a/extension/apikeyauthextension/go.mod
+++ b/extension/apikeyauthextension/go.mod
@@ -17,6 +17,7 @@ require (
 	go.opentelemetry.io/collector/extension/extensiontest v0.135.0
 	go.uber.org/goleak v1.3.0
 	golang.org/x/crypto v0.41.0
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20250707201910-8d1bb00bc6a7
 	google.golang.org/grpc v1.75.0
 )
 
@@ -72,7 +73,6 @@ require (
 	golang.org/x/net v0.43.0 // indirect
 	golang.org/x/sys v0.35.0 // indirect
 	golang.org/x/text v0.28.0 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20250707201910-8d1bb00bc6a7 // indirect
 	google.golang.org/protobuf v1.36.8 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/processor/ratelimitprocessor/go.mod
+++ b/processor/ratelimitprocessor/go.mod
@@ -30,6 +30,7 @@ require (
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/time v0.11.0
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20250707201910-8d1bb00bc6a7
 	google.golang.org/grpc v1.75.0
 )
 
@@ -131,7 +132,6 @@ require (
 	golang.org/x/text v0.26.0 // indirect
 	golang.org/x/tools v0.33.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250707201910-8d1bb00bc6a7 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20250707201910-8d1bb00bc6a7 // indirect
 	google.golang.org/protobuf v1.36.8 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/processor/ratelimitprocessor/gubernator.go
+++ b/processor/ratelimitprocessor/gubernator.go
@@ -30,9 +30,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/status"
 
 	"github.com/gubernator-io/gubernator/v2"
 	"go.opentelemetry.io/collector/component"
@@ -209,7 +207,7 @@ func (r *gubernatorRateLimiter) executeRateLimit(ctx context.Context,
 		// Same logic as local
 		switch r.cfg.ThrottleBehavior {
 		case ThrottleBehaviorError:
-			return status.Error(codes.ResourceExhausted, errTooManyRequests.Error())
+			return errorWithDetails(errTooManyRequests, cfg)
 		case ThrottleBehaviorDelay:
 			select {
 			case <-ctx.Done():

--- a/processor/ratelimitprocessor/processor_test.go
+++ b/processor/ratelimitprocessor/processor_test.go
@@ -493,7 +493,6 @@ func testError(t *testing.T, err error) {
 	require.Len(t, details, 1, "expected 1 errorinfo detail")
 	errorInfo, ok := details[0].(*errdetails.ErrorInfo)
 	require.True(t, ok, "expected errorinfo detail")
-	assert.Equal(t, "too many requests", errorInfo.Reason)
 	assert.Equal(t, "ingest.elastic.co", errorInfo.Domain)
 	assert.Equal(t, map[string]string{
 		"component":         "ratelimitprocessor",

--- a/processor/ratelimitprocessor/processor_test.go
+++ b/processor/ratelimitprocessor/processor_test.go
@@ -26,6 +26,9 @@ import (
 	"github.com/elastic/opentelemetry-collector-components/processor/ratelimitprocessor/internal/metadata"
 	"github.com/elastic/opentelemetry-collector-components/processor/ratelimitprocessor/internal/metadatatest"
 	"github.com/elastic/opentelemetry-collector-components/processor/ratelimitprocessor/internal/telemetry"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -171,7 +174,7 @@ func TestConsume_Logs(t *testing.T) {
 	consumed = false
 	err = processor.ConsumeLogs(clientContext, logs)
 	assert.False(t, consumed)
-	assert.EqualError(t, err, "rpc error: code = ResourceExhausted desc = too many requests")
+	testError(t, err)
 
 	testRatelimitLogMetadata(t, observedLogs.TakeAll())
 	testRateLimitTelemetry(t, tt)
@@ -224,7 +227,7 @@ func TestConsume_Metrics(t *testing.T) {
 	consumed = false
 	err = processor.ConsumeMetrics(clientContext, metrics)
 	assert.False(t, consumed)
-	assert.EqualError(t, err, "rpc error: code = ResourceExhausted desc = too many requests")
+	testError(t, err)
 
 	testRatelimitLogMetadata(t, observedLogs.TakeAll())
 	testRateLimitTelemetry(t, tt)
@@ -277,7 +280,7 @@ func TestConsume_Traces(t *testing.T) {
 	consumed = false
 	err = processor.ConsumeTraces(clientContext, traces)
 	assert.False(t, consumed)
-	assert.EqualError(t, err, "rpc error: code = ResourceExhausted desc = too many requests")
+	testError(t, err)
 
 	testRatelimitLogMetadata(t, observedLogs.TakeAll())
 	testRateLimitTelemetry(t, tt)
@@ -331,7 +334,7 @@ func TestConsume_Profiles(t *testing.T) {
 	consumed = false
 	err = processor.ConsumeProfiles(clientContext, profiles)
 	assert.False(t, consumed)
-	assert.EqualError(t, err, "rpc error: code = ResourceExhausted desc = too many requests")
+	testError(t, err)
 
 	testRatelimitLogMetadata(t, observedLogs.TakeAll())
 	testRateLimitTelemetry(t, tt)
@@ -478,4 +481,22 @@ func testRatelimitLogMetadata(t *testing.T, logEntries []observer.LoggedEntry) {
 
 	assert.Equal(t, "TestProjectID", fields["x-tenant-id"])
 	assert.Equal(t, int64(1), fields["hits"])
+}
+
+func testError(t *testing.T, err error) {
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok, "expected gRPC status error")
+	assert.Equal(t, codes.ResourceExhausted, st.Code())
+	assert.Equal(t, "rpc error: code = ResourceExhausted desc = too many requests", st.Err().Error())
+	details := st.Details()
+	require.Len(t, details, 1, "expected 1 errorinfo detail")
+	errorInfo, ok := details[0].(*errdetails.ErrorInfo)
+	require.True(t, ok, "expected errorinfo detail")
+	assert.Equal(t, "too many requests", errorInfo.Reason)
+	assert.Equal(t, map[string]string{
+		"component":         "ratelimitprocessor",
+		"limit":             "1",
+		"throttle_interval": "0s",
+	}, errorInfo.Metadata)
 }

--- a/processor/ratelimitprocessor/processor_test.go
+++ b/processor/ratelimitprocessor/processor_test.go
@@ -494,6 +494,7 @@ func testError(t *testing.T, err error) {
 	errorInfo, ok := details[0].(*errdetails.ErrorInfo)
 	require.True(t, ok, "expected errorinfo detail")
 	assert.Equal(t, "too many requests", errorInfo.Reason)
+	assert.Equal(t, "ingest.elastic.co", errorInfo.Domain)
 	assert.Equal(t, map[string]string{
 		"component":         "ratelimitprocessor",
 		"limit":             "1",

--- a/processor/ratelimitprocessor/ratelimiter.go
+++ b/processor/ratelimitprocessor/ratelimiter.go
@@ -102,6 +102,7 @@ func errorWithDetails(err error, cfg RateLimitSettings) error {
 	st := status.New(codes.ResourceExhausted, err.Error())
 	if detailedSt, stErr := st.WithDetails(&errdetails.ErrorInfo{
 		Reason: err.Error(),
+		Domain: "ingest.elastic.co",
 		Metadata: map[string]string{
 			"component":         "ratelimitprocessor",
 			"limit":             fmt.Sprintf("%d", cfg.Rate),

--- a/processor/ratelimitprocessor/ratelimiter.go
+++ b/processor/ratelimitprocessor/ratelimiter.go
@@ -20,9 +20,13 @@ package ratelimitprocessor // import "github.com/elastic/opentelemetry-collector
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 
 	"go.opentelemetry.io/otel/attribute"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"go.opentelemetry.io/collector/client"
 )
@@ -90,4 +94,21 @@ func getAttrsFromContext(ctx context.Context, metadataKeys []string) []attribute
 		}
 	}
 	return attrs
+}
+
+// errorWithDetails provides a user friendly error with additional error details that
+// can be later used to provide more detailed error information to the user.
+func errorWithDetails(err error, cfg RateLimitSettings) error {
+	st := status.New(codes.ResourceExhausted, err.Error())
+	if detailedSt, stErr := st.WithDetails(&errdetails.ErrorInfo{
+		Reason: err.Error(),
+		Metadata: map[string]string{
+			"component":         "ratelimitprocessor",
+			"limit":             fmt.Sprintf("%d", cfg.Rate),
+			"throttle_interval": cfg.ThrottleInterval.String(),
+		},
+	}); stErr == nil {
+		return detailedSt.Err()
+	}
+	return st.Err()
 }

--- a/processor/ratelimitprocessor/ratelimiter.go
+++ b/processor/ratelimitprocessor/ratelimiter.go
@@ -101,7 +101,6 @@ func getAttrsFromContext(ctx context.Context, metadataKeys []string) []attribute
 func errorWithDetails(err error, cfg RateLimitSettings) error {
 	st := status.New(codes.ResourceExhausted, err.Error())
 	if detailedSt, stErr := st.WithDetails(&errdetails.ErrorInfo{
-		Reason: err.Error(),
 		Domain: "ingest.elastic.co",
 		Metadata: map[string]string{
 			"component":         "ratelimitprocessor",


### PR DESCRIPTION
+ Improve the gRPC error info with additional details which can be leveraged in the upstream wrapper component to provide detailed error info to users. 