### PR TITLE
[elasticapmintakereceiver] Fix: do not set transaction.id on spans as span.id

### DIFF
--- a/receiver/elasticapmintakereceiver/testdata/invalid_ids_expected.yaml
+++ b/receiver/elasticapmintakereceiver/testdata/invalid_ids_expected.yaml
@@ -241,7 +241,6 @@ resourceSpans:
                   stringValue: query.custom
             endTimeUnixNano: "1532976822422581000"
             name: GET /api/types
-            spanId: 01af25874dec69dd
             startTimeUnixNano: "1532976822281000000"
             status:
               code: 1

--- a/receiver/elasticapmintakereceiver/testdata/metricsets_expected.yaml
+++ b/receiver/elasticapmintakereceiver/testdata/metricsets_expected.yaml
@@ -217,51 +217,6 @@ resourceMetrics:
                       value:
                         intValue: "1496170421367000"
                   timeUnixNano: "1496170421367000000"
-            name: system.process.cgroup.cpu.cfs.quota.us
-          - gauge:
-              dataPoints:
-                - asDouble: 2048
-                  attributes:
-                    - key: event.outcome
-                      value:
-                        stringValue: unknown
-                    - key: processor.event
-                      value:
-                        stringValue: metric
-                    - key: timestamp.us
-                      value:
-                        intValue: "1496170421367000"
-                  timeUnixNano: "1496170421367000000"
-            name: system.process.cgroup.cpu.stats.periods
-          - gauge:
-              dataPoints:
-                - asDouble: 2048
-                  attributes:
-                    - key: event.outcome
-                      value:
-                        stringValue: unknown
-                    - key: processor.event
-                      value:
-                        stringValue: metric
-                    - key: timestamp.us
-                      value:
-                        intValue: "1496170421367000"
-                  timeUnixNano: "1496170421367000000"
-            name: system.process.cgroup.cpu.stats.throttled.periods
-          - gauge:
-              dataPoints:
-                - asDouble: 2048
-                  attributes:
-                    - key: event.outcome
-                      value:
-                        stringValue: unknown
-                    - key: processor.event
-                      value:
-                        stringValue: metric
-                    - key: timestamp.us
-                      value:
-                        intValue: "1496170421367000"
-                  timeUnixNano: "1496170421367000000"
             name: system.process.cgroup.cpu.stats.throttled.ns
           - gauge:
               dataPoints:
@@ -323,6 +278,51 @@ resourceMetrics:
                         intValue: "1496170421367000"
                   timeUnixNano: "1496170421367000000"
             name: system.process.cgroup.cpu.id
+          - gauge:
+              dataPoints:
+                - asDouble: 2048
+                  attributes:
+                    - key: event.outcome
+                      value:
+                        stringValue: unknown
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                    - key: timestamp.us
+                      value:
+                        intValue: "1496170421367000"
+                  timeUnixNano: "1496170421367000000"
+            name: system.process.cgroup.cpu.cfs.quota.us
+          - gauge:
+              dataPoints:
+                - asDouble: 2048
+                  attributes:
+                    - key: event.outcome
+                      value:
+                        stringValue: unknown
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                    - key: timestamp.us
+                      value:
+                        intValue: "1496170421367000"
+                  timeUnixNano: "1496170421367000000"
+            name: system.process.cgroup.cpu.stats.periods
+          - gauge:
+              dataPoints:
+                - asDouble: 2048
+                  attributes:
+                    - key: event.outcome
+                      value:
+                        stringValue: unknown
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                    - key: timestamp.us
+                      value:
+                        intValue: "1496170421367000"
+                  timeUnixNano: "1496170421367000000"
+            name: system.process.cgroup.cpu.stats.throttled.periods
         scope: {}
   - resource:
       attributes:

--- a/receiver/elasticapmintakereceiver/testdata/spans_expected.yaml
+++ b/receiver/elasticapmintakereceiver/testdata/spans_expected.yaml
@@ -116,7 +116,7 @@ resourceSpans:
             endTimeUnixNano: "1532976822422581000"
             name: GET /api/types
             parentSpanId: abcdef0123456789
-            spanId: 01af25874dec69dd
+            spanId: abcdef0123456700
             startTimeUnixNano: "1532976822281000000"
             status:
               code: 1
@@ -238,7 +238,7 @@ resourceSpans:
             endTimeUnixNano: "1532976822313592981"
             name: GET /api/types
             parentSpanId: "0000000011111111"
-            spanId: ab45781d265894fe
+            spanId: 1234abcdef567895
             startTimeUnixNano: "1532976822281000000"
             status: {}
             traceId: abcdef0123456789abcdef9876543210
@@ -359,7 +359,7 @@ resourceSpans:
             endTimeUnixNano: "1532976822284564298"
             name: GET /api/types
             parentSpanId: abcdefabcdef7890
-            spanId: ab23456a89012345
+            spanId: 0123456a89012345
             startTimeUnixNano: "1532976822281000000"
             status: {}
             traceId: abcdef0123456789abcdef9876543210
@@ -1060,7 +1060,6 @@ resourceSpans:
             endTimeUnixNano: "1532975583585205000"
             name: Request
             parentSpanId: abcdef0123456789
-            spanId: 01af25874dec69dd
             startTimeUnixNano: "1532975583584217000"
             status:
               code: 1
@@ -1193,7 +1192,6 @@ resourceSpans:
             endTimeUnixNano: "1532976822422581000"
             name: Rabbitmq receive
             parentSpanId: abcdef0123456789
-            spanId: 01af25874dec69dd
             startTimeUnixNano: "1532976822281000000"
             status: {}
             traceId: fdedef0123456789abcdef9876543210
@@ -1314,7 +1312,7 @@ resourceSpans:
             endTimeUnixNano: "1625572686060463200"
             name: SELECT FROM p_details
             parentSpanId: abcdef0123456789
-            spanId: 01af25874dec69dd
+            spanId: abcdef0123456700
             startTimeUnixNano: "1625572685682272000"
             status:
               code: 1

--- a/receiver/elasticapmintakereceiver/testdata/transactions_spans_expected.yaml
+++ b/receiver/elasticapmintakereceiver/testdata/transactions_spans_expected.yaml
@@ -239,7 +239,7 @@ resourceSpans:
             kind: 3
             name: SELECT FROM product_types
             parentSpanId: 945254c567a5417e
-            spanId: 945254c567a5417e
+            spanId: 0aaaaaaaaaaaaaaa
             startTimeUnixNano: "1496170407154000000"
             status:
               code: 1
@@ -343,7 +343,7 @@ resourceSpans:
             endTimeUnixNano: "1496170407186592981"
             name: GET /api/types
             parentSpanId: 945254c567a5417e
-            spanId: 945254c567a5417e
+            spanId: 1aaaaaaaaaaaaaaa
             startTimeUnixNano: "1496170407154000000"
             status: {}
             traceId: 945254c567a5417eaaaaaaaaaaaaaaaa
@@ -446,7 +446,7 @@ resourceSpans:
             endTimeUnixNano: "1496170407157564298"
             name: GET /api/types
             parentSpanId: 945254c567a5417e
-            spanId: 945254c567a5417e
+            spanId: 2aaaaaaaaaaaaaaa
             startTimeUnixNano: "1496170407154000000"
             status: {}
             traceId: 945254c567a5417eaaaaaaaaaaaaaaaa
@@ -549,7 +549,7 @@ resourceSpans:
             endTimeUnixNano: "1496170407167980298"
             name: GET /api/types
             parentSpanId: 945254c567a5417e
-            spanId: 945254c567a5417e
+            spanId: 3aaaaaaaaaaaaaaa
             startTimeUnixNano: "1496170407154000000"
             status: {}
             traceId: 945254c567a5417eaaaaaaaaaaaaaaaa
@@ -985,7 +985,7 @@ resourceSpans:
             endTimeUnixNano: "1496170422284781912"
             name: SELECT FROM product_types
             parentSpanId: 85925e55b43f4342
-            spanId: 85925e55b43f4342
+            spanId: 15aaaaaaaaaaaaaa
             startTimeUnixNano: "1496170422281000000"
             status: {}
             traceId: 85925e55b43f4342aaaaaaaaaaaaaaaa

--- a/receiver/elasticapmintakereceiver/testdata/unknown-span-type_expected.yaml
+++ b/receiver/elasticapmintakereceiver/testdata/unknown-span-type_expected.yaml
@@ -236,7 +236,7 @@ resourceSpans:
             kind: 3
             name: SELECT FROM product_types
             parentSpanId: 945254c567a5417e
-            spanId: 945254c567a5417e
+            spanId: 0aaaaaaaaaaaaaaa
             startTimeUnixNano: "1496170407154000000"
             status:
               code: 1


### PR DESCRIPTION
This likely happened when we added error/LogRecord support.


### Manifestation of this bug:

The waterfall chart did not work - spans were not shown, only the root transaction. And then looking at the documents, each span in a given trace fog a given transaction had the same `span.id` on all the spans and on the transaction. So basically `span.id`s were incorrect.

### Background

In the elastic apm data model, on each span we have a `transaction.id` field, which is the id of the root transaction in the given trace. However, this isn't needed anymore.

At the same time, an error and a transaction also has a `transaction.id` (errors may or may not have it)

So if the given event is an error or a transaction, and we turn those into pdata, then we need to use this `transaction.id` as the span id. But if the given event is a span, we can just ignore it, since we don't need it and the span id in that case is stored in `span.id`.


### Testing 

This was actually already covered by golden tests, but the expected values were wrong. I adapted those. So this scenario is covered, and was covered before, but with wrong expected values. 