### PR TITLE
Add releaser script and tune docs

### DIFF
--- a/.github/workflows/scripts/bump_module_tags.sh
+++ b/.github/workflows/scripts/bump_module_tags.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# This script reads a YAML file defining a module-set, discovers the latest tag for each module
+# in a mono-repo like elastic/opentelemetry-collector-components (tags in the form
+#   <module-subpath>/vX.Y.Z), bumps the minor version, pushes the new tag, and creates a GitHub
+# release for it.
+#
+# Requirements:
+# - git (with push access to the target repo)
+# - gh (GitHub CLI; authenticated with permissions to create releases)
+# - yq (https://github.com/mikefarah/yq) for YAML parsing
+#
+# Usage:
+#   bash scripts/bump_module_tags.sh \
+#     --yaml path/to/modules.yaml \
+#     --repo-path /path/to/local/clone/of/elastic/opentelemetry-collector-components \
+#     [--module-set edot-base] \
+#     [--bump minor] \
+#     [--branch main] \
+#     [--dry-run]
+#
+# Notes:
+# - The script expects module entries like:
+#     github.com/elastic/opentelemetry-collector-components/receiver/elasticapmintakereceiver
+#   It will treat everything after the owner/repo (elastic/opentelemetry-collector-components)
+#   as the module subpath (receiver/elasticapmintakereceiver) and tag using the pattern:
+#     receiver/elasticapmintakereceiver/vX.Y.Z
+# - By default it bumps the minor version and resets patch to 0 (e.g., v0.9.0 -> v0.10.0).
+# - Tags are applied to the current HEAD of the provided --branch in --repo-path.
+
+print_usage() {
+  cat <<'USAGE'
+Usage: bump_module_tags.sh --yaml <path> --repo-path <path> [--module-set <name>] [--bump minor|patch|major] [--branch <branch>] [--dry-run]
+
+Options:
+  --yaml        Path to YAML file containing module-sets
+  --repo-path   Local path to the mono-repo clone (e.g., elastic/opentelemetry-collector-components)
+  --module-set  Name under module-sets to use (default: edot-base)
+  --bump        Which semver part to bump: minor (default), patch, major
+  --branch      Branch to tag from (checked out in --repo-path, default: main)
+  --dry-run     Print actions without performing git push / gh release
+USAGE
+}
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Error: required command '$1' not found in PATH" >&2
+    exit 1
+  fi
+}
+
+YAML_PATH=""
+REPO_PATH=""
+MODULE_SET="edot-base"
+BUMP_KIND="minor"
+BRANCH_NAME="main"
+DRY_RUN=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --yaml)
+      YAML_PATH="$2"; shift 2 ;;
+    --repo-path)
+      REPO_PATH="$2"; shift 2 ;;
+    --module-set)
+      MODULE_SET="$2"; shift 2 ;;
+    --bump)
+      BUMP_KIND="$2"; shift 2 ;;
+    --branch)
+      BRANCH_NAME="$2"; shift 2 ;;
+    --dry-run)
+      DRY_RUN=true; shift 1 ;;
+    -h|--help)
+      print_usage; exit 0 ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      print_usage
+      exit 1 ;;
+  esac
+done
+
+if [[ -z "$YAML_PATH" || -z "$REPO_PATH" ]]; then
+  echo "Error: --yaml and --repo-path are required" >&2
+  print_usage
+  exit 1
+fi
+
+require_cmd git
+require_cmd gh
+require_cmd yq
+
+if [[ ! -f "$YAML_PATH" ]]; then
+  echo "Error: YAML file not found at $YAML_PATH" >&2
+  exit 1
+fi
+
+if [[ ! -d "$REPO_PATH/.git" ]]; then
+  echo "Error: --repo-path does not appear to be a git repository: $REPO_PATH" >&2
+  exit 1
+fi
+
+if [[ "$BUMP_KIND" != "major" && "$BUMP_KIND" != "minor" && "$BUMP_KIND" != "patch" ]]; then
+  echo "Error: --bump must be one of: major, minor, patch" >&2
+  exit 1
+fi
+
+set -x
+
+# Ensure we are up-to-date and on the requested branch
+git -C "$REPO_PATH" fetch --tags origin
+git -C "$REPO_PATH" fetch origin "$BRANCH_NAME":"$BRANCH_NAME" || true
+git -C "$REPO_PATH" checkout "$BRANCH_NAME"
+git -C "$REPO_PATH" pull --ff-only origin "$BRANCH_NAME" || true
+
+set +x
+
+# Extract modules for the selected module-set
+echo "Reading modules from $YAML_PATH (module-set: $MODULE_SET)"
+mapfile -t MODULES < <(yq -r ".\"module-sets\".\"$MODULE_SET\".modules[]" "$YAML_PATH")
+
+if [[ ${#MODULES[@]} -eq 0 ]]; then
+  echo "Error: No modules found under module-sets.$MODULE_SET.modules in $YAML_PATH" >&2
+  exit 1
+fi
+
+# Bump function: given X.Y.Z and bump kind, output new X.Y.Z
+bump_version() {
+  local version="$1" kind="$2"
+  local major minor patch
+  IFS='.' read -r major minor patch <<<"$version"
+  case "$kind" in
+    major)
+      major=$((major+1)); minor=0; patch=0 ;;
+    minor)
+      minor=$((minor+1)); patch=0 ;;
+    patch)
+      patch=$((patch+1)) ;;
+  esac
+  echo "$major.$minor.$patch"
+}
+
+# Discover latest tag for a prefix and compute the next version
+discover_next_tag() {
+  local repo_path="$1" tag_prefix="$2" bump_kind="$3"
+  local latest_tag latest_version new_version
+
+  # List local tags for the prefix
+  mapfile -t tags < <(git -C "$repo_path" tag -l "$tag_prefix/v*")
+  if [[ ${#tags[@]} -eq 0 ]]; then
+    # Try fetching tags explicitly if none were present locally
+    git -C "$repo_path" fetch --tags origin >/dev/null 2>&1 || true
+    mapfile -t tags < <(git -C "$repo_path" tag -l "$tag_prefix/v*")
+  fi
+
+  if [[ ${#tags[@]} -eq 0 ]]; then
+    # Start from v0.1.0 for minor bump base v0.0.0 if nothing exists
+    case "$bump_kind" in
+      major) new_version="1.0.0" ;;
+      minor) new_version="0.1.0" ;;
+      patch) new_version="0.0.1" ;;
+    esac
+    echo "$tag_prefix/v$new_version"
+    return 0
+  fi
+
+  # Extract the version, sort semver-wise, and take the highest
+  latest_version=$(printf '%s\n' "${tags[@]}" \
+    | sed -E "s#^${tag_prefix}/v##" \
+    | sort -V \
+    | tail -n1)
+
+  new_version=$(bump_version "$latest_version" "$bump_kind")
+  echo "$tag_prefix/v$new_version"
+}
+
+create_tag_and_release() {
+  local repo_path="$1" owner_repo="$2" branch="$3" module_subpath="$4" bump_kind="$5" dry_run="$6"
+
+  local prefix new_tag sha title
+  prefix="$module_subpath"
+
+  new_tag=$(discover_next_tag "$repo_path" "$prefix" "$bump_kind")
+
+  # Tag at the current tip of the branch
+  sha=$(git -C "$repo_path" rev-parse "$branch")
+  title="$new_tag"
+
+  echo "Will create tag $new_tag at $owner_repo@$branch ($sha)"
+
+  if [[ "$dry_run" == true ]]; then
+    echo "[DRY-RUN] git tag -a '$new_tag' -m 'Release $new_tag' -- $(printf '%.7s' "$sha")"
+    echo "[DRY-RUN] git push origin '$new_tag'"
+    echo "[DRY-RUN] gh release create '$new_tag' -t '$title' -n 'Automated release for $module_subpath' -R '$owner_repo'"
+    return 0
+  fi
+
+  # Create annotated tag
+  GIT_COMMITTER_DATE="$(date -R)" GIT_AUTHOR_DATE="$(date -R)" \
+    git -C "$repo_path" tag -a "$new_tag" -m "Release $new_tag" "$sha"
+
+#  git -C "$repo_path" push origin "$new_tag"
+
+  # Create GitHub release
+#  gh release create "$new_tag" \
+#    --title "$title" \
+#    --notes "Automated release for $module_subpath" \
+#    -R "$owner_repo"
+}
+
+# Iterate modules
+for module in "${MODULES[@]}"; do
+  # Expect format github.com/<owner>/<repo>/<subpath...>
+  if [[ ! "$module" =~ ^github\.com/([^/]+)/([^/]+)/(.*)$ ]]; then
+    echo "Skipping unrecognized module path: $module" >&2
+    continue
+  fi
+  owner="${BASH_REMATCH[1]}"
+  repo="${BASH_REMATCH[2]}"
+  subpath="${BASH_REMATCH[3]}"
+  owner_repo="$owner/$repo"
+
+  echo "Processing module: $module"
+  echo "  Repo: $owner_repo"
+  echo "  Subpath: $subpath"
+
+  create_tag_and_release "$REPO_PATH" "$owner_repo" "$BRANCH_NAME" "$subpath" "$BUMP_KIND" "$DRY_RUN"
+done
+
+echo "Done."

--- a/.github/workflows/scripts/bump_module_tags.sh
+++ b/.github/workflows/scripts/bump_module_tags.sh
@@ -200,13 +200,16 @@ create_tag_and_release() {
   GIT_COMMITTER_DATE="$(date -R)" GIT_AUTHOR_DATE="$(date -R)" \
     git -C "$repo_path" tag -a "$new_tag" -m "Release $new_tag" "$sha"
 
-#  git -C "$repo_path" push origin "$new_tag"
+  read -r -n 1 -p "Going to push tag and create a new release. Continue? [y/N] " ans; echo
+  [[ $ans =~ ^[Yy]$ ]] || { echo "Aborted."; exit 1; }
+
+  git -C "$repo_path" push origin "$new_tag"
 
   # Create GitHub release
-#  gh release create "$new_tag" \
-#    --title "$title" \
-#    --notes "Automated release for $module_subpath" \
-#    -R "$owner_repo"
+  gh release create "$new_tag" \
+    --title "$title" \
+    --notes "Automated release for $module_subpath" \
+    -R "$owner_repo"
 }
 
 # Iterate modules

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,40 +1,15 @@
 # Releasing opentelemetry-collector-components
 
-1. Determine the version number that will be assigned to the release. It should
-   match the latest upstream release version (`OTEL_VERSION`).
+Try with dry-run first and verify if everything is working:
 
-2. Open a PR to the repository to use the newly released OpenTelemetry Collector Core version by doing the following:
-   - Ensure your local repository is up-to-date with upstream and create a new Git branch named `release/<release-series>` (e.g. `release/v0.85.x`)
-   - Manually update core and contrib collector module versions in
-     `../distributions/elastic-components/manifest.yaml`
-   - Manually update the version to be released in the [versions.yaml file](../versions.yaml)
-   - Run `make genelasticcol`
-   - Commit the changes
-   - Run `make update-otel OTEL_VERSION=vX.Y.Z OTEL_STABLE_VERSION=vA.B.C`
-     - If there is no new stable version released in the core collector, use the current stable module version in contrib as `OTEL_STABLE_VERSION`.
-   - If you were unable to run `make update-otel` before releasing core, fix any errors from breaking changes.
-   - Commit the changes
-   - Open the PR
-     🛑 **Do not move forward until this PR is merged.** 🛑
+```bash
+.github/workflows/scripts/bump_module_tags.sh \
+--yaml ./versions.yaml \
+  --repo-path . \
+  --module-set edot-base \
+  --bump minor \
+  --branch main \
+  --dry-run
+```
 
-3. Make sure you are on the `release/<release-series>` branch. Tag the module groups with the new release version by running:
-
-   ⚠️ If you set your remote using `https`, you need to include `REMOTE=https://github.com/elastic/opentelemetry-collector-components.git` in each command. ⚠️
-
-   - Run `make push-tags`.
-
-   If you encounter an error when running `make push-tags` like:
-
-   ```
-   Load key "~/.ssh/id_ed25519": incorrect passphrase supplied to decrypt private key error: unable to sign the tag
-   ```
-
-   It’s likely because Git is trying to sign a tag using an SSH key that requires a passphrase.
-
-   ✅ Solution: Run the following commands to decrypt your SSH key and make it available for Git tag signing:
-
-   ```bash
-   eval "$(ssh-agent -s)"
-   ssh-add <YOUR_SSH/GPG_KEY_PATH>
-   make push-tags
-   ```
+If output of the dry-run looks legit then repeat without the `--dry-run`.

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,14 +1,18 @@
 module-sets:
   edot-base:
-    version: v0.124.0
+    version: v0.124.0 # not used
     modules:
       - github.com/elastic/opentelemetry-collector-components/receiver/elasticapmintakereceiver
-      - github.com/elastic/opentelemetry-collector-components/receiver/loadgenreceiver
       - github.com/elastic/opentelemetry-collector-components/processor/elasticinframetricsprocessor
       - github.com/elastic/opentelemetry-collector-components/processor/elasticapmprocessor
+      - github.com/elastic/opentelemetry-collector-components/processor/elastictraceprocessor
       - github.com/elastic/opentelemetry-collector-components/processor/lsmintervalprocessor
       - github.com/elastic/opentelemetry-collector-components/processor/ratelimitprocessor
       - github.com/elastic/opentelemetry-collector-components/connector/elasticapmconnector
+      - github.com/elastic/opentelemetry-collector-components/connector/profilingmetricsconnector
+      - github.com/elastic/opentelemetry-collector-components/extension/beatsauthextension
+      - github.com/elastic/opentelemetry-collector-components/extension/apikeyauthextension
+      - github.com/elastic/opentelemetry-collector-components/extension/apmconfigextension
 
 excluded-modules:
   - github.com/elastic/opentelemetry-collector-components/internal/tools
@@ -18,9 +22,6 @@ excluded-modules:
   - github.com/elastic/opentelemetry-collector-components/receiver/integrationreceiver
   - github.com/elastic/opentelemetry-collector-components/extension/fileintegrationextension
   - github.com/elastic/opentelemetry-collector-components/extension/configintegrationextension
-  - github.com/elastic/opentelemetry-collector-components/extension/beatsauthextension
-  - github.com/elastic/opentelemetry-collector-components/extension/apikeyauthextension
-  - github.com/elastic/opentelemetry-collector-components/extension/apmconfigextension
   - github.com/elastic/opentelemetry-collector-components/processor/integrationprocessor
   - github.com/elastic/opentelemetry-collector-components/loadgen
   - github.com/elastic/opentelemetry-collector-components/_build


### PR DESCRIPTION
This PoC script is an attempt to automate the release process as discussed at https://github.com/elastic/opentelemetry-collector-components/issues/812:

Sample output:

```console
> .github/workflows/scripts/bump_module_tags.sh \
>  --yaml ./versions.yaml \
>  --repo-path . \
>  --module-set edot-base \
>  --bump minor \
>  --branch main \
>  --dry-run
+ git -C . fetch --tags origin
+ git -C . fetch origin main:main
fatal: refusing to fetch into branch 'refs/heads/main' checked out at '/Users/chrismark/go/src/github.com/elastic/opentelemetry-collector-components'
+ true
+ git -C . checkout main
M	versions.yaml
Already on 'main'
Your branch is up to date with 'origin/main'.
+ git -C . pull --ff-only origin main
From github.com:elastic/opentelemetry-collector-components
 * branch            main       -> FETCH_HEAD
Already up to date.
+ set +x
Reading modules from ./versions.yaml (module-set: edot-base)
Processing module: github.com/elastic/opentelemetry-collector-components/receiver/elasticapmintakereceiver
  Repo: elastic/opentelemetry-collector-components
  Subpath: receiver/elasticapmintakereceiver
Will create tag receiver/elasticapmintakereceiver/v0.5.0 at elastic/opentelemetry-collector-components@main (fc30e9e73e63f48aa81bc8d434e84823d2ea7b87)
[DRY-RUN] git tag -a 'receiver/elasticapmintakereceiver/v0.5.0' -m 'Release receiver/elasticapmintakereceiver/v0.5.0' -- fc30e9e
[DRY-RUN] git push origin 'receiver/elasticapmintakereceiver/v0.5.0'
[DRY-RUN] gh release create 'receiver/elasticapmintakereceiver/v0.5.0' -t 'receiver/elasticapmintakereceiver/v0.5.0' -n 'Automated release for receiver/elasticapmintakereceiver' -R 'elastic/opentelemetry-collector-components'
Processing module: github.com/elastic/opentelemetry-collector-components/processor/elasticinframetricsprocessor
  Repo: elastic/opentelemetry-collector-components
  Subpath: processor/elasticinframetricsprocessor
Will create tag processor/elasticinframetricsprocessor/v0.19.0 at elastic/opentelemetry-collector-components@main (fc30e9e73e63f48aa81bc8d434e84823d2ea7b87)
[DRY-RUN] git tag -a 'processor/elasticinframetricsprocessor/v0.19.0' -m 'Release processor/elasticinframetricsprocessor/v0.19.0' -- fc30e9e
[DRY-RUN] git push origin 'processor/elasticinframetricsprocessor/v0.19.0'
[DRY-RUN] gh release create 'processor/elasticinframetricsprocessor/v0.19.0' -t 'processor/elasticinframetricsprocessor/v0.19.0' -n 'Automated release for processor/elasticinframetricsprocessor' -R 'elastic/opentelemetry-collector-components'
Processing module: github.com/elastic/opentelemetry-collector-components/processor/elasticapmprocessor
  Repo: elastic/opentelemetry-collector-components
  Subpath: processor/elasticapmprocessor
Will create tag processor/elasticapmprocessor/v0.4.0 at elastic/opentelemetry-collector-components@main (fc30e9e73e63f48aa81bc8d434e84823d2ea7b87)
[DRY-RUN] git tag -a 'processor/elasticapmprocessor/v0.4.0' -m 'Release processor/elasticapmprocessor/v0.4.0' -- fc30e9e
[DRY-RUN] git push origin 'processor/elasticapmprocessor/v0.4.0'
[DRY-RUN] gh release create 'processor/elasticapmprocessor/v0.4.0' -t 'processor/elasticapmprocessor/v0.4.0' -n 'Automated release for processor/elasticapmprocessor' -R 'elastic/opentelemetry-collector-components'
Processing module: github.com/elastic/opentelemetry-collector-components/processor/elastictraceprocessor
  Repo: elastic/opentelemetry-collector-components
  Subpath: processor/elastictraceprocessor
Will create tag processor/elastictraceprocessor/v0.12.0 at elastic/opentelemetry-collector-components@main (fc30e9e73e63f48aa81bc8d434e84823d2ea7b87)
[DRY-RUN] git tag -a 'processor/elastictraceprocessor/v0.12.0' -m 'Release processor/elastictraceprocessor/v0.12.0' -- fc30e9e
[DRY-RUN] git push origin 'processor/elastictraceprocessor/v0.12.0'
[DRY-RUN] gh release create 'processor/elastictraceprocessor/v0.12.0' -t 'processor/elastictraceprocessor/v0.12.0' -n 'Automated release for processor/elastictraceprocessor' -R 'elastic/opentelemetry-collector-components'
Processing module: github.com/elastic/opentelemetry-collector-components/processor/lsmintervalprocessor
  Repo: elastic/opentelemetry-collector-components
  Subpath: processor/lsmintervalprocessor
Will create tag processor/lsmintervalprocessor/v0.10.0 at elastic/opentelemetry-collector-components@main (fc30e9e73e63f48aa81bc8d434e84823d2ea7b87)
[DRY-RUN] git tag -a 'processor/lsmintervalprocessor/v0.10.0' -m 'Release processor/lsmintervalprocessor/v0.10.0' -- fc30e9e
[DRY-RUN] git push origin 'processor/lsmintervalprocessor/v0.10.0'
[DRY-RUN] gh release create 'processor/lsmintervalprocessor/v0.10.0' -t 'processor/lsmintervalprocessor/v0.10.0' -n 'Automated release for processor/lsmintervalprocessor' -R 'elastic/opentelemetry-collector-components'
Processing module: github.com/elastic/opentelemetry-collector-components/processor/ratelimitprocessor
  Repo: elastic/opentelemetry-collector-components
  Subpath: processor/ratelimitprocessor
Will create tag processor/ratelimitprocessor/v0.10.0 at elastic/opentelemetry-collector-components@main (fc30e9e73e63f48aa81bc8d434e84823d2ea7b87)
[DRY-RUN] git tag -a 'processor/ratelimitprocessor/v0.10.0' -m 'Release processor/ratelimitprocessor/v0.10.0' -- fc30e9e
[DRY-RUN] git push origin 'processor/ratelimitprocessor/v0.10.0'
[DRY-RUN] gh release create 'processor/ratelimitprocessor/v0.10.0' -t 'processor/ratelimitprocessor/v0.10.0' -n 'Automated release for processor/ratelimitprocessor' -R 'elastic/opentelemetry-collector-components'
Processing module: github.com/elastic/opentelemetry-collector-components/connector/elasticapmconnector
  Repo: elastic/opentelemetry-collector-components
  Subpath: connector/elasticapmconnector
Will create tag connector/elasticapmconnector/v0.9.0 at elastic/opentelemetry-collector-components@main (fc30e9e73e63f48aa81bc8d434e84823d2ea7b87)
[DRY-RUN] git tag -a 'connector/elasticapmconnector/v0.9.0' -m 'Release connector/elasticapmconnector/v0.9.0' -- fc30e9e
[DRY-RUN] git push origin 'connector/elasticapmconnector/v0.9.0'
[DRY-RUN] gh release create 'connector/elasticapmconnector/v0.9.0' -t 'connector/elasticapmconnector/v0.9.0' -n 'Automated release for connector/elasticapmconnector' -R 'elastic/opentelemetry-collector-components'
Processing module: github.com/elastic/opentelemetry-collector-components/connector/profilingmetricsconnector
  Repo: elastic/opentelemetry-collector-components
  Subpath: connector/profilingmetricsconnector
Will create tag connector/profilingmetricsconnector/v0.2.0 at elastic/opentelemetry-collector-components@main (fc30e9e73e63f48aa81bc8d434e84823d2ea7b87)
[DRY-RUN] git tag -a 'connector/profilingmetricsconnector/v0.2.0' -m 'Release connector/profilingmetricsconnector/v0.2.0' -- fc30e9e
[DRY-RUN] git push origin 'connector/profilingmetricsconnector/v0.2.0'
[DRY-RUN] gh release create 'connector/profilingmetricsconnector/v0.2.0' -t 'connector/profilingmetricsconnector/v0.2.0' -n 'Automated release for connector/profilingmetricsconnector' -R 'elastic/opentelemetry-collector-components'
Processing module: github.com/elastic/opentelemetry-collector-components/extension/beatsauthextension
  Repo: elastic/opentelemetry-collector-components
  Subpath: extension/beatsauthextension
Will create tag extension/beatsauthextension/v0.6.0 at elastic/opentelemetry-collector-components@main (fc30e9e73e63f48aa81bc8d434e84823d2ea7b87)
[DRY-RUN] git tag -a 'extension/beatsauthextension/v0.6.0' -m 'Release extension/beatsauthextension/v0.6.0' -- fc30e9e
[DRY-RUN] git push origin 'extension/beatsauthextension/v0.6.0'
[DRY-RUN] gh release create 'extension/beatsauthextension/v0.6.0' -t 'extension/beatsauthextension/v0.6.0' -n 'Automated release for extension/beatsauthextension' -R 'elastic/opentelemetry-collector-components'
Processing module: github.com/elastic/opentelemetry-collector-components/extension/apikeyauthextension
  Repo: elastic/opentelemetry-collector-components
  Subpath: extension/apikeyauthextension
Will create tag extension/apikeyauthextension/v0.9.0 at elastic/opentelemetry-collector-components@main (fc30e9e73e63f48aa81bc8d434e84823d2ea7b87)
[DRY-RUN] git tag -a 'extension/apikeyauthextension/v0.9.0' -m 'Release extension/apikeyauthextension/v0.9.0' -- fc30e9e
[DRY-RUN] git push origin 'extension/apikeyauthextension/v0.9.0'
[DRY-RUN] gh release create 'extension/apikeyauthextension/v0.9.0' -t 'extension/apikeyauthextension/v0.9.0' -n 'Automated release for extension/apikeyauthextension' -R 'elastic/opentelemetry-collector-components'
Processing module: github.com/elastic/opentelemetry-collector-components/extension/apmconfigextension
  Repo: elastic/opentelemetry-collector-components
  Subpath: extension/apmconfigextension
Will create tag extension/apmconfigextension/v0.9.0 at elastic/opentelemetry-collector-components@main (fc30e9e73e63f48aa81bc8d434e84823d2ea7b87)
[DRY-RUN] git tag -a 'extension/apmconfigextension/v0.9.0' -m 'Release extension/apmconfigextension/v0.9.0' -- fc30e9e
[DRY-RUN] git push origin 'extension/apmconfigextension/v0.9.0'
[DRY-RUN] gh release create 'extension/apmconfigextension/v0.9.0' -t 'extension/apmconfigextension/v0.9.0' -n 'Automated release for extension/apmconfigextension' -R 'elastic/opentelemetry-collector-components'
Done.
```