### PR TITLE
[elasticapmprocessor] Handle labels set by the elasticapmintake receiver

### DIFF
--- a/processor/elasticapmprocessor/testdata/ecs/elastic_span_db/input.yaml
+++ b/processor/elasticapmprocessor/testdata/ecs/elastic_span_db/input.yaml
@@ -10,6 +10,12 @@ resourceSpans:
         - key: agent.version
           value:
             stringValue: 1.0.0
+        - key: labels.my_value
+          value:
+            stringValue: foo
+        - key: numeric_labels.foo
+          value:
+            doubleValue: 42.0
     scopeSpans:
       - scope: {}
         spans:

--- a/processor/elasticapmprocessor/testdata/ecs/elastic_span_db/output.yaml
+++ b/processor/elasticapmprocessor/testdata/ecs/elastic_span_db/output.yaml
@@ -10,6 +10,12 @@ resourceSpans:
         - key: labels.unsupported_key
           value:
             stringValue: foo
+        - key: labels.my_value
+          value:
+            stringValue: foo
+        - key: numeric_labels.foo
+          value:
+            doubleValue: 42.0
         - key: data_stream.type
           value:
             stringValue: traces


### PR DESCRIPTION
https://github.com/elastic/opentelemetry-collector-components/pull/779 added support for `labels` and `numeric_labels` from classic apm agents by moving those into attributes in the elasticapmintake receiver.

Problem ist that in the `elasticapmprocessor` we automatically prefixed those additionally with `labels.*` resulting in double prefixing:

<img width="1159" height="227" alt="Screenshot 2025-10-13 at 17 26 16" src="https://github.com/user-attachments/assets/3402c22e-38bd-40a5-aea5-2ca6d3547102" />

The idea here is this: in the processor, we check if a field is already prefix - if so, we just keep it as is.

An alternative would be to not prefixing those fields in the receiver and handling those with other attributes together.

I'd prefer keeping the receiver as is and handling it here. No strong opinion, but to me it seems better to already store labels with `labels.` prefix in attributes in the receiver. 

cc @isaacaflores2 
