### PR TITLE
[receiver/elasticapmintake] Update `http.request.body` translation from string to object

### DIFF
--- a/receiver/elasticapmintakereceiver/internal/mappers/intakeV2ToElasticSpecificFields.go
+++ b/receiver/elasticapmintakereceiver/internal/mappers/intakeV2ToElasticSpecificFields.go
@@ -101,7 +101,10 @@ func setHTTP(http *modelpb.HTTP, attributesMap pcommon.Map) {
 		}
 
 		if http.Request.Body != nil {
-			attributesMap.PutStr(attr.HTTPRequestBody, http.Request.Body.GetStringValue())
+			// add http body as an object since it is required by the APM index template
+			// see: https://github.com/elastic/elasticsearch/blob/714c077b11363f168e261ad43cff0b5b74556b7f/x-pack/plugin/apm-data/src/main/resources/component-templates/traces-apm%40mappings.yaml#L30
+			bodyValue := attributesMap.PutEmpty(attr.HTTPRequestBody)
+			insertValue(bodyValue, http.Request.Body)
 		}
 		if http.Request.Id != "" {
 			attributesMap.PutStr(attr.HTTPRequestID, http.Request.Id)

--- a/receiver/elasticapmintakereceiver/testdata/transactions_expected.yaml
+++ b/receiver/elasticapmintakereceiver/testdata/transactions_expected.yaml
@@ -446,7 +446,21 @@ resourceSpans:
                   stringValue: string_value:"v2"
               - key: http.request.body
                 value:
-                  stringValue: ""
+                  kvlistValue:
+                    values:
+                      - key: str
+                        value:
+                          stringValue: hello world
+                      - key: additional
+                        value:
+                          kvlistValue:
+                            values:
+                              - key: bar
+                                value:
+                                  doubleValue: 123
+                              - key: req
+                                value:
+                                  stringValue: additional information
               - key: http.request.referrer
                 value:
                   stringValue: http://localhost:8000/test/e2e/

--- a/receiver/elasticapmintakereceiver/testdata/transactions_spans_expected.yaml
+++ b/receiver/elasticapmintakereceiver/testdata/transactions_spans_expected.yaml
@@ -212,7 +212,21 @@ resourceSpans:
                   stringValue: string_value:"v2"
               - key: http.request.body
                 value:
-                  stringValue: ""
+                  kvlistValue:
+                    values:
+                      - key: str
+                        value:
+                          stringValue: hello world
+                      - key: additional
+                        value:
+                          kvlistValue:
+                            values:
+                              - key: bar
+                                value:
+                                  doubleValue: 123
+                              - key: req
+                                value:
+                                  stringValue: additional information
               - key: http.request.referrer
                 value:
                   stringValue: http://localhost:8000/test/e2e/

--- a/receiver/elasticapmintakereceiver/testdata/unknown-span-type_expected.yaml
+++ b/receiver/elasticapmintakereceiver/testdata/unknown-span-type_expected.yaml
@@ -206,7 +206,21 @@ resourceSpans:
                   stringValue: string_value:"v2"
               - key: http.request.body
                 value:
-                  stringValue: ""
+                  kvlistValue:
+                    values:
+                      - key: str
+                        value:
+                          stringValue: hello world
+                      - key: additional
+                        value:
+                          kvlistValue:
+                            values:
+                              - key: bar
+                                value:
+                                  doubleValue: 123
+                              - key: req
+                                value:
+                                  stringValue: additional information
               - key: http.request.referrer
                 value:
                   stringValue: http://localhost:8000/test/e2e/


### PR DESCRIPTION
## Overview
1.  Update `http.request.body` to be translated as an object instead of a string


## Testing
1. Covered by unit test