### PR TITLE
ratelimitprocessor: class: Remove burst validation

### DIFF
--- a/processor/ratelimitprocessor/config.go
+++ b/processor/ratelimitprocessor/config.go
@@ -126,9 +126,6 @@ func (c *Class) Validate() error {
 	if c.Burst < 0 {
 		errs = append(errs, errors.New("burst must be non-negative"))
 	}
-	if c.Burst > 0 && c.Burst < c.Rate {
-		errs = append(errs, errors.New("burst must be greater than or equal to rate when specified"))
-	}
 	return errors.Join(errs...)
 }
 


### PR DESCRIPTION
Removes the incorrect burst validation. Rate may not be per second, while Burst is always per second.