### PR TITLE
Fix dynamic rate limit escalation metrics

### DIFF
--- a/processor/ratelimitprocessor/gubernator_test.go
+++ b/processor/ratelimitprocessor/gubernator_test.go
@@ -914,7 +914,7 @@ func TestGubernatorRateLimiter_TelemetryCounters(t *testing.T) {
 				Attributes: attribute.NewSet(
 					attribute.String("class", "alpha"),
 					attribute.String("source_kind", "class"),
-					attribute.String("reason", "success"),
+					attribute.String("reason", "escalation"),
 				),
 			},
 		}, metricdatatest.IgnoreTimestamp())


### PR DESCRIPTION
Since the component now supports decreasing the rate limit, adapt the `RatelimitDynamicEscalations` metric accordingly.