### PR TITLE
loadgen/otelsoak: remove stale comment

### DIFF
--- a/loadgen/cmd/otelsoak/config.example.yaml
+++ b/loadgen/cmd/otelsoak/config.example.yaml
@@ -39,9 +39,6 @@ processors:
     burst: 5000
     throttle_behavior: delay
 
-# TODO(carsonip): simulate > 1 agents for higher load
-# https://github.com/elastic/opentelemetry-collector-components/issues/305
-
 service:
   pipelines:
     logs:


### PR DESCRIPTION
Remove a stale comment in the `otelsoak` example configuration as it may lead to confusion.

The mentioned limitation has been removed by https://github.com/elastic/opentelemetry-collector-components/pull/313
