### PR TITLE
(ratelimitprocessor): treat gubernator failures as retryable errors

### DIFF
--- a/processor/ratelimitprocessor/ratelimiter.go
+++ b/processor/ratelimitprocessor/ratelimiter.go
@@ -19,7 +19,6 @@ package ratelimitprocessor // import "github.com/elastic/opentelemetry-collector
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -33,7 +32,7 @@ import (
 )
 
 var (
-	errTooManyRequests = errors.New("too many requests")
+	errTooManyRequests = status.Error(codes.ResourceExhausted, "too many requests")
 )
 
 // RateLimiter provides an interface for rate limiting by some number
@@ -99,7 +98,7 @@ func getAttrsFromContext(ctx context.Context, metadataKeys []string) []attribute
 // errorWithDetails provides a user friendly error with additional error details that
 // can be later used to provide more detailed error information to the user.
 func errorWithDetails(err error, cfg RateLimitSettings) error {
-	st := status.New(codes.ResourceExhausted, err.Error())
+	st := status.Convert(err)
 	if detailedSt, stErr := st.WithDetails(&errdetails.ErrorInfo{
 		Domain: "ingest.elastic.co",
 		Metadata: map[string]string{


### PR DESCRIPTION
+ Treat internal gubernator related ratelimiter errors as Transient errors and return status code with codes.Unavailable and retryDelay info so clients can retry after specified interval. 

This is a retryable error for OTLPexporter - https://github.com/open-telemetry/opentelemetry-collector/blob/1847c2eda72c5554b99400845306e38c582ed8c3/exporter/otlpexporter/otlp.go#L194