### PR TITLE
[receiver/elaticapmintake] Add mappings for transaction `session` attributes

### DIFF
--- a/receiver/elasticapmintakereceiver/internal/attributes.go
+++ b/receiver/elasticapmintakereceiver/internal/attributes.go
@@ -112,7 +112,8 @@ const (
 
 	ProcessThreadName = "process.thread.name"
 
-	SessionID = "session.id"
+	SessionID       = "session.id"
+	SessionSequence = "session.sequence"
 
 	TransactionCustom                                      = "transaction.custom"
 	TransactionUserExperienceCumulativeLayoutShift         = "transaction.experience.cls"

--- a/receiver/elasticapmintakereceiver/internal/mappers/intakeV2ToElasticSpecificFields.go
+++ b/receiver/elasticapmintakereceiver/internal/mappers/intakeV2ToElasticSpecificFields.go
@@ -349,6 +349,16 @@ func SetElasticSpecificFieldsForTransaction(event *modelpb.APMEvent, attributesM
 
 	setTransactionMarks(event.Transaction.Marks, attributesMap)
 	setMessage("transaction", event.Transaction.Message, attributesMap)
+
+	// add session attributes which hold optional transaction session information for RUM
+	if event.Session != nil {
+		if event.Session.Id != "" {
+			attributesMap.PutStr(attr.SessionID, event.Session.Id)
+		}
+		if event.Session.Sequence != 0 {
+			attributesMap.PutInt(attr.SessionSequence, int64(event.Session.Sequence))
+		}
+	}
 }
 
 func setProfilerStackTraceIDs(ids []string, attributesMap pcommon.Map) {
@@ -620,12 +630,6 @@ func SetElasticSpecificFieldsForLog(event *modelpb.APMEvent, attributesMap pcomm
 			if event.Process.Thread.Name != "" {
 				attributesMap.PutStr(attr.ProcessThreadName, event.Process.Thread.Name)
 			}
-		}
-	}
-
-	if event.Session != nil {
-		if event.Session.Id != "" {
-			attributesMap.PutStr(attr.SessionID, event.Session.Id)
 		}
 	}
 

--- a/receiver/elasticapmintakereceiver/testdata/transactions_expected.yaml
+++ b/receiver/elasticapmintakereceiver/testdata/transactions_expected.yaml
@@ -936,6 +936,12 @@ resourceSpans:
                     values:
                       - stringValue: user
                       - stringValue: auth
+              - key: session.id
+                value:
+                  stringValue: sunday
+              - key: session.sequence
+                value:
+                  intValue: "123"
             endTimeUnixNano: "1496170407157000000"
             name: amqp receive
             parentSpanId: abcdefabcdef0123


### PR DESCRIPTION
# Overview
- Add mapping for missing transaction `session.id` and `session.sequence` attributes


# Testing
- Updated unit test
-  Setup a local collector and validated indexed documents