### PR TITLE
ratelimitprocessor: use up-down counter for concurrent requests

### DIFF
--- a/processor/ratelimitprocessor/documentation.md
+++ b/processor/ratelimitprocessor/documentation.md
@@ -10,9 +10,9 @@ The following telemetry is emitted by this component.
 
 Number of in-flight requests at any given time [Development]
 
-| Unit | Metric Type | Value Type | Stability |
-| ---- | ----------- | ---------- | --------- |
-| {requests} | Gauge | Int | Development |
+| Unit | Metric Type | Value Type | Monotonic | Stability |
+| ---- | ----------- | ---------- | --------- | --------- |
+| {requests} | Sum | Int | false | Development |
 
 ### otelcol_ratelimit.dynamic.escalations
 

--- a/processor/ratelimitprocessor/factory.go
+++ b/processor/ratelimitprocessor/factory.go
@@ -82,7 +82,6 @@ func createLogsProcessor(
 	if err != nil {
 		return nil, err
 	}
-	var inflight int64
 	return NewLogsRateLimiterProcessor(
 		rateLimiter,
 		set.TelemetrySettings.Logger,
@@ -92,7 +91,6 @@ func createLogsProcessor(
 		func(ctx context.Context, ld plog.Logs) error {
 			return nextConsumer.ConsumeLogs(ctx, ld)
 		},
-		&inflight,
 		config.MetadataKeys,
 	)
 }
@@ -112,7 +110,6 @@ func createMetricsProcessor(
 	if err != nil {
 		return nil, err
 	}
-	var inflight int64
 	return NewMetricsRateLimiterProcessor(
 		rateLimiter,
 		set.TelemetrySettings.Logger,
@@ -122,7 +119,6 @@ func createMetricsProcessor(
 		func(ctx context.Context, md pmetric.Metrics) error {
 			return nextConsumer.ConsumeMetrics(ctx, md)
 		},
-		&inflight,
 		config.MetadataKeys,
 	)
 }
@@ -142,7 +138,6 @@ func createTracesProcessor(
 	if err != nil {
 		return nil, err
 	}
-	var inflight int64
 	return NewTracesRateLimiterProcessor(
 		rateLimiter,
 		set.TelemetrySettings.Logger,
@@ -152,7 +147,6 @@ func createTracesProcessor(
 		func(ctx context.Context, td ptrace.Traces) error {
 			return nextConsumer.ConsumeTraces(ctx, td)
 		},
-		&inflight,
 		config.MetadataKeys,
 	)
 }
@@ -172,7 +166,6 @@ func createProfilesProcessor(
 	if err != nil {
 		return nil, err
 	}
-	var inflight int64
 	return NewProfilesRateLimiterProcessor(
 		rateLimiter,
 		set.TelemetrySettings.Logger,
@@ -182,7 +175,6 @@ func createProfilesProcessor(
 		func(ctx context.Context, td pprofile.Profiles) error {
 			return nextConsumer.ConsumeProfiles(ctx, td)
 		},
-		&inflight,
 		config.MetadataKeys,
 	)
 }

--- a/processor/ratelimitprocessor/internal/metadata/generated_telemetry.go
+++ b/processor/ratelimitprocessor/internal/metadata/generated_telemetry.go
@@ -43,7 +43,7 @@ type TelemetryBuilder struct {
 	meter                       metric.Meter
 	mu                          sync.Mutex
 	registrations               []metric.Registration
-	RatelimitConcurrentRequests metric.Int64Gauge
+	RatelimitConcurrentRequests metric.Int64UpDownCounter
 	RatelimitDynamicEscalations metric.Int64Counter
 	RatelimitRequestDuration    metric.Float64Histogram
 	RatelimitRequestSize        metric.Int64Histogram
@@ -80,7 +80,7 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 	}
 	builder.meter = Meter(settings)
 	var err, errs error
-	builder.RatelimitConcurrentRequests, err = builder.meter.Int64Gauge(
+	builder.RatelimitConcurrentRequests, err = builder.meter.Int64UpDownCounter(
 		"otelcol_ratelimit.concurrent_requests",
 		metric.WithDescription("Number of in-flight requests at any given time [Development]"),
 		metric.WithUnit("{requests}"),

--- a/processor/ratelimitprocessor/internal/metadatatest/generated_telemetrytest.go
+++ b/processor/ratelimitprocessor/internal/metadatatest/generated_telemetrytest.go
@@ -43,8 +43,10 @@ func AssertEqualRatelimitConcurrentRequests(t *testing.T, tt *componenttest.Tele
 		Name:        "otelcol_ratelimit.concurrent_requests",
 		Description: "Number of in-flight requests at any given time [Development]",
 		Unit:        "{requests}",
-		Data: metricdata.Gauge[int64]{
-			DataPoints: dps,
+		Data: metricdata.Sum[int64]{
+			Temporality: metricdata.CumulativeTemporality,
+			IsMonotonic: false,
+			DataPoints:  dps,
 		},
 	}
 	got, err := tt.GetMetric("otelcol_ratelimit.concurrent_requests")

--- a/processor/ratelimitprocessor/internal/metadatatest/generated_telemetrytest_test.go
+++ b/processor/ratelimitprocessor/internal/metadatatest/generated_telemetrytest_test.go
@@ -36,7 +36,7 @@ func TestSetupTelemetry(t *testing.T) {
 	tb, err := metadata.NewTelemetryBuilder(testTel.NewTelemetrySettings())
 	require.NoError(t, err)
 	defer tb.Shutdown()
-	tb.RatelimitConcurrentRequests.Record(context.Background(), 1)
+	tb.RatelimitConcurrentRequests.Add(context.Background(), 1)
 	tb.RatelimitDynamicEscalations.Add(context.Background(), 1)
 	tb.RatelimitRequestDuration.Record(context.Background(), 1)
 	tb.RatelimitRequestSize.Record(context.Background(), 1)

--- a/processor/ratelimitprocessor/metadata.yaml
+++ b/processor/ratelimitprocessor/metadata.yaml
@@ -19,9 +19,9 @@ telemetry:
       unit: "{requests}"
       stability:
         level: development
-      gauge:
+      sum:
         value_type: int
-        monotonic: true
+        monotonic: false
     ratelimit.dynamic.escalations:
       enabled: true
       description: Total number of dynamic rate escalations (dynamic > static)

--- a/processor/ratelimitprocessor/processor_test.go
+++ b/processor/ratelimitprocessor/processor_test.go
@@ -48,7 +48,6 @@ import (
 )
 
 var (
-	inflight      int64
 	clientContext = client.NewContext(context.Background(), client.Info{
 		Metadata: client.NewMetadata(map[string][]string{
 			"x-tenant-id": {"TestProjectID"},
@@ -153,7 +152,6 @@ func TestConsume_Logs(t *testing.T) {
 		rl:               rateLimiter,
 		telemetryBuilder: telemetryBuilder,
 		logger:           zap.New(observedZapCore),
-		inflight:         &inflight,
 		metadataKeys:     []string{"x-tenant-id"},
 		strategy:         StrategyRateLimitBytes,
 	}
@@ -230,7 +228,6 @@ func TestConsume_Metrics(t *testing.T) {
 		rl:               rateLimiter,
 		telemetryBuilder: telemetryBuilder,
 		logger:           zap.New(observedZapCore),
-		inflight:         &inflight,
 		metadataKeys:     []string{"x-tenant-id"},
 		strategy:         StrategyRateLimitBytes,
 	}
@@ -307,7 +304,6 @@ func TestConsume_Traces(t *testing.T) {
 		rl:               rateLimiter,
 		telemetryBuilder: telemetryBuilder,
 		logger:           zap.New(observedZapCore),
-		inflight:         &inflight,
 		metadataKeys:     []string{"x-tenant-id"},
 		strategy:         StrategyRateLimitBytes,
 	}
@@ -385,7 +381,6 @@ func TestConsume_Profiles(t *testing.T) {
 		rl:               rateLimiter,
 		telemetryBuilder: telemetryBuilder,
 		logger:           zap.New(observedZapCore),
-		inflight:         &inflight,
 		metadataKeys:     []string{"x-tenant-id"},
 		strategy:         StrategyRateLimitBytes,
 	}
@@ -470,7 +465,6 @@ func TestConcurrentRequestsTelemetry(t *testing.T) {
 	rl := rateLimiterProcessor{
 		rl:               rateLimiter,
 		telemetryBuilder: telemetryBuilder,
-		inflight:         &inflight,
 		metadataKeys:     []string{"x-tenant-id"},
 	}
 	processor := &MetricsRateLimiterProcessor{
@@ -501,11 +495,9 @@ func TestConcurrentRequestsTelemetry(t *testing.T) {
 
 	m, err := tt.GetMetric("otelcol_ratelimit.concurrent_requests")
 	require.NoError(t, err, "expected to observe otelcol_ratelimit.concurrent_requests")
-	for _, dp := range m.Data.(metricdata.Gauge[int64]).DataPoints {
-		if assert.Equal(t, int64(2), dp.Value, "expected to observe otelcol_ratelimit.concurrent_requests == 2") {
-			break
-		}
-	}
+	dps := m.Data.(metricdata.Sum[int64]).DataPoints
+	require.Len(t, dps, 1)
+	assert.Equal(t, int64(numWorkers), dps[0].Value)
 
 	// Release both goroutines
 	close(blockCh)


### PR DESCRIPTION
Fixes https://github.com/elastic/opentelemetry-collector-components/issues/922