### PR TITLE
Bump version to 0.24.0

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -1,6 +1,6 @@
 module-sets:
   edot-base:
-    version: v0.20.0
+    version: v0.24.0
     modules:
       - github.com/elastic/opentelemetry-collector-components/receiver/elasticapmintakereceiver
       - github.com/elastic/opentelemetry-collector-components/receiver/loadgenreceiver


### PR DESCRIPTION
This bumps the version to 0.24.0, to match the release that just happened.
It appears some components had been released without an update to `versions.yaml`, and the highest version there was is 0.23.0. So I had to bump from there.