### PR TITLE
profilingmetricsconnector: Add link to user documentation.

### DIFF
--- a/connector/profilingmetricsconnector/README.md
+++ b/connector/profilingmetricsconnector/README.md
@@ -7,3 +7,6 @@ The Profiling metrics connector is an opinionated OTel connector that generates 
 The following settings can be optionally configured:
 
 - `metrics_prefix`: Define a prefix that is used for all generated metric names.
+
+
+[Quickstart guide](https://www.elastic.co/docs/reference/edot-collector/config/configure-profiles-collection) to use this connector as part of [EDOT](https://www.elastic.co/docs/reference/opentelemetry).


### PR DESCRIPTION
Added a quickstart guide link for using the connector.