### PR TITLE
[receiver/elasticapmintake] Remove span kind enrichment when a `span.kind` is not provided

### DIFF
--- a/receiver/elasticapmintakereceiver/testdata/spans_expected.yaml
+++ b/receiver/elasticapmintakereceiver/testdata/spans_expected.yaml
@@ -22,9 +22,6 @@ resourceSpans:
         - key: host.arch
           value:
             stringValue: x64
-        - key: host.hostname
-          value:
-            stringValue: prod1.example.com
         - key: cloud.provider
           value:
             stringValue: cloud_provider
@@ -127,6 +124,9 @@ resourceSpans:
         - key: host.os.platform
           value:
             stringValue: darwin
+        - key: host.hostname
+          value:
+            stringValue: prod1.example.com
         - key: user.domain
           value:
             stringValue: ldap://abc
@@ -214,9 +214,6 @@ resourceSpans:
         - key: host.arch
           value:
             stringValue: x64
-        - key: host.hostname
-          value:
-            stringValue: prod1.example.com
         - key: cloud.provider
           value:
             stringValue: cloud_provider
@@ -328,6 +325,9 @@ resourceSpans:
         - key: host.os.platform
           value:
             stringValue: darwin
+        - key: host.hostname
+          value:
+            stringValue: prod1.example.com
         - key: user.domain
           value:
             stringValue: ldap://abc
@@ -401,9 +401,6 @@ resourceSpans:
         - key: host.arch
           value:
             stringValue: x64
-        - key: host.hostname
-          value:
-            stringValue: prod1.example.com
         - key: cloud.provider
           value:
             stringValue: cloud_provider
@@ -506,6 +503,9 @@ resourceSpans:
         - key: host.os.platform
           value:
             stringValue: darwin
+        - key: host.hostname
+          value:
+            stringValue: prod1.example.com
         - key: user.domain
           value:
             stringValue: ldap://abc
@@ -585,9 +585,6 @@ resourceSpans:
         - key: host.arch
           value:
             stringValue: x64
-        - key: host.hostname
-          value:
-            stringValue: prod1.example.com
         - key: cloud.provider
           value:
             stringValue: cloud_provider
@@ -690,6 +687,9 @@ resourceSpans:
         - key: host.os.platform
           value:
             stringValue: darwin
+        - key: host.hostname
+          value:
+            stringValue: prod1.example.com
         - key: user.domain
           value:
             stringValue: ldap://abc
@@ -760,9 +760,6 @@ resourceSpans:
         - key: host.arch
           value:
             stringValue: x64
-        - key: host.hostname
-          value:
-            stringValue: prod1.example.com
         - key: cloud.provider
           value:
             stringValue: cloud_provider
@@ -868,6 +865,9 @@ resourceSpans:
         - key: host.os.platform
           value:
             stringValue: darwin
+        - key: host.hostname
+          value:
+            stringValue: prod1.example.com
         - key: user.domain
           value:
             stringValue: ldap://abc
@@ -1061,7 +1061,6 @@ resourceSpans:
                               value:
                                 boolValue: false
             endTimeUnixNano: "1532976822284781912"
-            kind: 3
             name: SELECT FROM product_types
             parentSpanId: abcdef0123456789
             spanId: 1234567890aaaade
@@ -1089,9 +1088,6 @@ resourceSpans:
         - key: host.arch
           value:
             stringValue: x64
-        - key: host.hostname
-          value:
-            stringValue: prod1.example.com
         - key: cloud.provider
           value:
             stringValue: cloud_provider
@@ -1197,6 +1193,9 @@ resourceSpans:
         - key: host.os.platform
           value:
             stringValue: darwin
+        - key: host.hostname
+          value:
+            stringValue: prod1.example.com
         - key: user.domain
           value:
             stringValue: ldap://abc
@@ -1387,7 +1386,6 @@ resourceSpans:
                               value:
                                 boolValue: false
             endTimeUnixNano: "1532976822284781912"
-            kind: 3
             name: SELECT FROM product_types
             parentSpanId: abcdef0123456789
             spanId: fdc4567890aaaade
@@ -1414,9 +1412,6 @@ resourceSpans:
         - key: host.arch
           value:
             stringValue: x64
-        - key: host.hostname
-          value:
-            stringValue: prod1.example.com
         - key: cloud.provider
           value:
             stringValue: cloud_provider
@@ -1522,6 +1517,9 @@ resourceSpans:
         - key: host.os.platform
           value:
             stringValue: darwin
+        - key: host.hostname
+          value:
+            stringValue: prod1.example.com
         - key: user.domain
           value:
             stringValue: ldap://abc
@@ -1715,7 +1713,6 @@ resourceSpans:
                               value:
                                 boolValue: false
             endTimeUnixNano: "1532976822284781912"
-            kind: 3
             name: SELECT FROM product_types
             parentSpanId: abcdef0123456789
             startTimeUnixNano: "1532976822281000000"
@@ -1744,9 +1741,6 @@ resourceSpans:
         - key: host.arch
           value:
             stringValue: x64
-        - key: host.hostname
-          value:
-            stringValue: prod1.example.com
         - key: cloud.provider
           value:
             stringValue: cloud_provider
@@ -1849,6 +1843,9 @@ resourceSpans:
         - key: host.os.platform
           value:
             stringValue: darwin
+        - key: host.hostname
+          value:
+            stringValue: prod1.example.com
         - key: user.domain
           value:
             stringValue: ldap://abc
@@ -1945,9 +1942,6 @@ resourceSpans:
         - key: host.arch
           value:
             stringValue: x64
-        - key: host.hostname
-          value:
-            stringValue: prod1.example.com
         - key: cloud.provider
           value:
             stringValue: cloud_provider
@@ -2050,6 +2044,9 @@ resourceSpans:
         - key: host.os.platform
           value:
             stringValue: darwin
+        - key: host.hostname
+          value:
+            stringValue: prod1.example.com
         - key: user.domain
           value:
             stringValue: ldap://abc
@@ -2166,9 +2163,6 @@ resourceSpans:
         - key: host.arch
           value:
             stringValue: x64
-        - key: host.hostname
-          value:
-            stringValue: prod1.example.com
         - key: cloud.provider
           value:
             stringValue: cloud_provider
@@ -2271,6 +2265,9 @@ resourceSpans:
         - key: host.os.platform
           value:
             stringValue: darwin
+        - key: host.hostname
+          value:
+            stringValue: prod1.example.com
         - key: user.domain
           value:
             stringValue: ldap://abc

--- a/receiver/elasticapmintakereceiver/testdata/transactions_expected.yaml
+++ b/receiver/elasticapmintakereceiver/testdata/transactions_expected.yaml
@@ -25,9 +25,6 @@ resourceSpans:
         - key: host.arch
           value:
             stringValue: x64
-        - key: host.hostname
-          value:
-            stringValue: prod1.example.com
         - key: cloud.provider
           value:
             stringValue: cloud_provider
@@ -130,6 +127,9 @@ resourceSpans:
         - key: host.os.platform
           value:
             stringValue: darwin
+        - key: host.hostname
+          value:
+            stringValue: prod1.example.com
         - key: labels.tag1
           value:
             stringValue: one
@@ -211,9 +211,6 @@ resourceSpans:
         - key: host.arch
           value:
             stringValue: x64
-        - key: host.hostname
-          value:
-            stringValue: prod1.example.com
         - key: user_agent.original
           value:
             stringValue: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36, Mozilla Chrome Edge
@@ -322,6 +319,9 @@ resourceSpans:
         - key: host.os.platform
           value:
             stringValue: darwin
+        - key: host.hostname
+          value:
+            stringValue: prod1.example.com
         - key: user.domain
           value:
             stringValue: ldap://abc
@@ -536,7 +536,6 @@ resourceSpans:
                         value:
                           stringValue: not a valid regex and that is fine
             endTimeUnixNano: "1496170407186592981"
-            kind: 2
             name: GET /api/types
             spanId: 4340a8e0df1906ec
             startTimeUnixNano: "1496170407154000000"
@@ -569,9 +568,6 @@ resourceSpans:
         - key: host.arch
           value:
             stringValue: x64
-        - key: host.hostname
-          value:
-            stringValue: prod1.example.com
         - key: cloud.provider
           value:
             stringValue: cloud_provider
@@ -677,6 +673,9 @@ resourceSpans:
         - key: host.os.platform
           value:
             stringValue: darwin
+        - key: host.hostname
+          value:
+            stringValue: prod1.example.com
         - key: labels.tag1
           value:
             stringValue: one
@@ -763,7 +762,6 @@ resourceSpans:
                                 value:
                                   doubleValue: 10
             endTimeUnixNano: "1532976822294980558"
-            kind: 2
             spanId: cdef4340a8e0df19
             startTimeUnixNano: "1532976822281000000"
             status: {}
@@ -794,9 +792,6 @@ resourceSpans:
         - key: host.arch
           value:
             stringValue: x64
-        - key: host.hostname
-          value:
-            stringValue: prod1.example.com
         - key: cloud.provider
           value:
             stringValue: cloud_provider
@@ -899,6 +894,9 @@ resourceSpans:
         - key: host.os.platform
           value:
             stringValue: darwin
+        - key: host.hostname
+          value:
+            stringValue: prod1.example.com
         - key: labels.tag1
           value:
             stringValue: one
@@ -1000,9 +998,6 @@ resourceSpans:
         - key: host.arch
           value:
             stringValue: x64
-        - key: host.hostname
-          value:
-            stringValue: prod1.example.com
         - key: cloud.provider
           value:
             stringValue: cloud_provider
@@ -1144,6 +1139,9 @@ resourceSpans:
         - key: host.os.platform
           value:
             stringValue: darwin
+        - key: host.hostname
+          value:
+            stringValue: prod1.example.com
         - key: labels.tag1
           value:
             stringValue: one

--- a/receiver/elasticapmintakereceiver/testdata/transactions_spans_expected.yaml
+++ b/receiver/elasticapmintakereceiver/testdata/transactions_spans_expected.yaml
@@ -22,9 +22,6 @@ resourceSpans:
         - key: host.arch
           value:
             stringValue: x64
-        - key: host.hostname
-          value:
-            stringValue: prod1.example.com
         - key: user_agent.original
           value:
             stringValue: Mozilla Chrome Edge
@@ -94,6 +91,9 @@ resourceSpans:
         - key: host.os.platform
           value:
             stringValue: darwin
+        - key: host.hostname
+          value:
+            stringValue: prod1.example.com
         - key: labels.organization_uuid
           value:
             stringValue: 9f0e9d64-c185-4d21-a6f4-4673ed561ec8
@@ -316,7 +316,6 @@ resourceSpans:
                                 value:
                                   doubleValue: 10
             endTimeUnixNano: "1496170407186592981"
-            kind: 2
             name: GET /api/types
             spanId: 945254c567a5417e
             startTimeUnixNano: "1496170407154000000"
@@ -346,9 +345,6 @@ resourceSpans:
         - key: host.arch
           value:
             stringValue: x64
-        - key: host.hostname
-          value:
-            stringValue: prod1.example.com
         - key: container.id
           value:
             stringValue: container-id
@@ -412,6 +408,9 @@ resourceSpans:
         - key: host.os.platform
           value:
             stringValue: darwin
+        - key: host.hostname
+          value:
+            stringValue: prod1.example.com
         - key: labels.span_tag
           value:
             stringValue: something
@@ -541,7 +540,6 @@ resourceSpans:
                               value:
                                 boolValue: false
             endTimeUnixNano: "1496170407157781912"
-            kind: 3
             name: SELECT FROM product_types
             parentSpanId: 945254c567a5417e
             spanId: 0aaaaaaaaaaaaaaa
@@ -572,9 +570,6 @@ resourceSpans:
         - key: host.arch
           value:
             stringValue: x64
-        - key: host.hostname
-          value:
-            stringValue: prod1.example.com
         - key: container.id
           value:
             stringValue: container-id
@@ -638,6 +633,9 @@ resourceSpans:
         - key: host.os.platform
           value:
             stringValue: darwin
+        - key: host.hostname
+          value:
+            stringValue: prod1.example.com
     scopeSpans:
       - scope: {}
         spans:
@@ -702,9 +700,6 @@ resourceSpans:
         - key: host.arch
           value:
             stringValue: x64
-        - key: host.hostname
-          value:
-            stringValue: prod1.example.com
         - key: container.id
           value:
             stringValue: container-id
@@ -768,6 +763,9 @@ resourceSpans:
         - key: host.os.platform
           value:
             stringValue: darwin
+        - key: host.hostname
+          value:
+            stringValue: prod1.example.com
     scopeSpans:
       - scope: {}
         spans:
@@ -835,9 +833,6 @@ resourceSpans:
         - key: host.arch
           value:
             stringValue: x64
-        - key: host.hostname
-          value:
-            stringValue: prod1.example.com
         - key: container.id
           value:
             stringValue: container-id
@@ -901,6 +896,9 @@ resourceSpans:
         - key: host.os.platform
           value:
             stringValue: darwin
+        - key: host.hostname
+          value:
+            stringValue: prod1.example.com
     scopeSpans:
       - scope: {}
         spans:
@@ -967,9 +965,6 @@ resourceSpans:
         - key: host.arch
           value:
             stringValue: x64
-        - key: host.hostname
-          value:
-            stringValue: prod1.example.com
         - key: container.id
           value:
             stringValue: container-id
@@ -1033,6 +1028,9 @@ resourceSpans:
         - key: host.os.platform
           value:
             stringValue: darwin
+        - key: host.hostname
+          value:
+            stringValue: prod1.example.com
     scopeSpans:
       - scope: {}
         spans:
@@ -1099,9 +1097,6 @@ resourceSpans:
         - key: host.arch
           value:
             stringValue: x64
-        - key: host.hostname
-          value:
-            stringValue: prod1.example.com
         - key: container.id
           value:
             stringValue: container-id
@@ -1165,6 +1160,9 @@ resourceSpans:
         - key: host.os.platform
           value:
             stringValue: darwin
+        - key: host.hostname
+          value:
+            stringValue: prod1.example.com
     scopeSpans:
       - scope: {}
         spans:
@@ -1231,9 +1229,6 @@ resourceSpans:
         - key: host.arch
           value:
             stringValue: x64
-        - key: host.hostname
-          value:
-            stringValue: prod1.example.com
         - key: container.id
           value:
             stringValue: container-id
@@ -1297,6 +1292,9 @@ resourceSpans:
         - key: host.os.platform
           value:
             stringValue: darwin
+        - key: host.hostname
+          value:
+            stringValue: prod1.example.com
     scopeSpans:
       - scope: {}
         spans:
@@ -1363,9 +1361,6 @@ resourceSpans:
         - key: host.arch
           value:
             stringValue: x64
-        - key: host.hostname
-          value:
-            stringValue: prod1.example.com
         - key: container.id
           value:
             stringValue: container-id
@@ -1429,6 +1424,9 @@ resourceSpans:
         - key: host.os.platform
           value:
             stringValue: darwin
+        - key: host.hostname
+          value:
+            stringValue: prod1.example.com
         - key: destination.ip
           value:
             stringValue: ::1

--- a/receiver/elasticapmintakereceiver/testdata/unknown-span-type_expected.yaml
+++ b/receiver/elasticapmintakereceiver/testdata/unknown-span-type_expected.yaml
@@ -307,7 +307,6 @@ resourceSpans:
                                 value:
                                   doubleValue: 10
             endTimeUnixNano: "1496170407186592981"
-            kind: 2
             name: GET /api/types
             spanId: 945254c567a5417e
             startTimeUnixNano: "1496170407154000000"
@@ -523,7 +522,6 @@ resourceSpans:
                               value:
                                 boolValue: false
             endTimeUnixNano: "1496170407157781912"
-            kind: 3
             name: SELECT FROM product_types
             parentSpanId: 945254c567a5417e
             spanId: 0aaaaaaaaaaaaaaa


### PR DESCRIPTION
# Overview
- This PR removes span kind enrichment from the intake receiver since it is not required. The receiver should only map span.kind and not perform any form of enrichment. With this change when a span.kind is not provided the receiver will set the span.kind to the default value of  `ptrace.SpanKindUnspecified` (which I consider a valid apm to otel mapping). 
- The legacy apm-data flow does not index a `span.kind` attribute when the client has not specified a value in the apm-event. This differs from the otel data flow since the intake receiver will derive span.kind if it was not provided.
- Per the [agent spec](https://github.com/elastic/apm/blob/1ce43143469feb2c8d16e81484c843f562e67be7/specs/agents/tracing-api-otel.md#span-kind) span.kind has a default value of INTERNAL only when the agent is in otel bridge mode. The field is not required by apm-data and it only has a default value set when the otel object is [set](https://github.com/elastic/apm-data/blob/main/input/elasticapm/internal/modeldecoder/v2/decoder.go#L1482-L1486).

## es exporter
The exporter has historically not indexed the span kind value. This [PR](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44139) recently added the mapping to the exporter ecs mode span encoder. This further shows that `span.kind` is not strictly required and can be missing for a span if it is not specified. 

## Alternate Option
- This can be considered a breaking change, even though span.kind is not strictly required. Another option can be to add enrichment to the opentelemetry-lib/elasticapmprocessor which is controlled by a config. Then a collector can be configured to disable this enrichment if needed. 


# Testing
- Updated unit teset
- Setup local collector to verify a `span.kind` attribute value is not indexed when it is not provided by the client. 
