### PR TITLE
update distribution to 0.27.0

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -1,6 +1,6 @@
 module-sets:
   edot-base:
-    version: v0.24.0
+    version: v0.27.0
     modules:
       - github.com/elastic/opentelemetry-collector-components/receiver/elasticapmintakereceiver
       - github.com/elastic/opentelemetry-collector-components/receiver/loadgenreceiver


### PR DESCRIPTION
Release all components and bump the version.
OTel collector dep previsouly bumped to `v0.142.0`.