### PR TITLE
[connector/elasticapm] Add span.name enrichment to traces since the attribute is no longer added by the `processor/elasticapm`

### DIFF
--- a/connector/elasticapmconnector/testdata/traces/span_metrics/input.yaml
+++ b/connector/elasticapmconnector/testdata/traces/span_metrics/input.yaml
@@ -47,9 +47,6 @@ resourceSpans:
               - key: span.duration.us
                 value:
                   intValue: 500000
-              - key: span.name
-                value:
-                  stringValue: th-value-8
               - key: span.representative_count
                 value:
                   doubleValue: 1.0 # Should be 2, elastictrace doesn't handle ot=th at time of writing

--- a/connector/elasticapmconnector/testdata/traces/span_metrics_custom_attrs/input.yaml
+++ b/connector/elasticapmconnector/testdata/traces/span_metrics_custom_attrs/input.yaml
@@ -47,9 +47,6 @@ resourceSpans:
               - key: span.duration.us
                 value:
                   intValue: 500000
-              - key: span.name
-                value:
-                  stringValue: th-value-8
               - key: span.representative_count
                 value:
                   doubleValue: 1.0 # Should be 2, elastictrace doesn't handle ot=th at time of writing

--- a/connector/elasticapmconnector/testdata/traces/span_metrics_no_overflow/input.yaml
+++ b/connector/elasticapmconnector/testdata/traces/span_metrics_no_overflow/input.yaml
@@ -47,9 +47,6 @@ resourceSpans:
               - key: span.duration.us
                 value:
                   intValue: 500000
-              - key: span.name
-                value:
-                  stringValue: th-value-8
               - key: span.representative_count
                 value:
                   doubleValue: 1.0 # Should be 2, elastictrace doesn't handle ot=th at time of writing

--- a/connector/elasticapmconnector/testdata/traces/span_metrics_overflow/input.yaml
+++ b/connector/elasticapmconnector/testdata/traces/span_metrics_overflow/input.yaml
@@ -44,9 +44,6 @@ resourceSpans:
               - key: span.duration.us
                 value:
                   intValue: 500000
-              - key: span.name
-                value:
-                  stringValue: th-value-8
               - key: span.representative_count
                 value:
                   doubleValue: 1.0 # Should be 2, elastictrace doesn't handle ot=th at time of writing


### PR DESCRIPTION
# Overview
Recent changes to the `processor/elasticapm` removed the `span.name` attribute from spans since the `span.name` is added by the `exporter/elasticsearch`.  Relevant `processor/elasticapm` PRs:
1. https://github.com/elastic/opentelemetry-collector-components/pull/968
2. htps://github.com/elastic/opentelemetry-lib/pull/254

This PR adds the `span.name` using the top-level span name since it is a required field for span destination metrics

## Alternate solution
I considered reverting some of the changes in  htps://github.com/elastic/opentelemetry-lib/pull/254 to re-add the `span.name` enrichment but I think the reason the field was removed in the first place is still valid.

# Testing 
1. Update unit test input files to remove `span.name` and assert the output aggregated metrics are the same