### PR TITLE
[extension/apikeyauth] Fix cached error losing original gRPC status code

### DIFF
--- a/extension/apikeyauthextension/authenticator.go
+++ b/extension/apikeyauthextension/authenticator.go
@@ -317,7 +317,7 @@ func (a *authenticator) Authenticate(ctx context.Context, headers map[string][]s
 			return ctx, detailedErr
 		}
 		if cacheEntry.err != nil {
-			return ctx, status.Error(codes.Unauthenticated, cacheEntry.err.Error())
+			return ctx, cacheEntry.err
 		}
 		return newCtxWithAuthData(ctx, cacheEntry.data), nil
 	}


### PR DESCRIPTION
## Summary

- Fix bug where cached authentication errors lost their original gRPC status code and were incorrectly returned as `Unauthenticated`
- Add test to verify cached errors preserve their original status code

## What

When an API key failed privilege checks, the error was correctly created with `codes.PermissionDenied` and cached. However, when the cached error was retrieved on subsequent requests, the code wrapped it in a new `status.Error(codes.Unauthenticated, ...)`, discarding the original status code.