### PR TITLE
[clientaddrmiddlewareextension] Fix HTTP request pattern propagation

### DIFF
--- a/extension/clientaddrmiddlewareextension/middleware.go
+++ b/extension/clientaddrmiddlewareextension/middleware.go
@@ -66,7 +66,8 @@ func (c *clientAddrMiddleware) GetHTTPHandler(base http.Handler) (http.Handler, 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		original := r
 		ctx := ctxWithClientAddr(r.Context(), r.Header)
-		base.ServeHTTP(w, r.WithContext(ctx))
+		r = r.WithContext(ctx)
+		base.ServeHTTP(w, r)
 		// Propagate the Pattern back to the original request for otelhttp instrumentation.
 		// See https://github.com/open-telemetry/opentelemetry-collector/issues/14508
 		if r.Pattern != "" {


### PR DESCRIPTION
Fix bug where `http.Request.Pattern` was not propagated correctly through the middleware chain

The pattern propagation logic introduced in #986 has a bug. When calling `r.WithContext(ctx)`, a new `*http.Request` is returned, but the result was passed directly to `base.ServeHTTP` without re-assigning it to `r`. This caused the `r.Pattern` check to reference the original request variable, which was never modified by downstream handlers.
