### PR TITLE
[apikeyauthextension] Add forward_headers configuration option

### DIFF
--- a/extension/apikeyauthextension/config.go
+++ b/extension/apikeyauthextension/config.go
@@ -37,6 +37,10 @@ type Config struct {
 	// Cache holds configuration related to caching
 	// API Key verification results.
 	Cache CacheConfig `mapstructure:"cache"`
+
+	// ForwardHeaders specifies which headers from the incoming request should
+	// be forwarded to Elasticsearch when checking privileges.
+	ForwardHeaders []string `mapstructure:"forward_headers,omitempty"`
 }
 
 type ApplicationPrivilegesConfig struct {

--- a/extension/apikeyauthextension/config_test.go
+++ b/extension/apikeyauthextension/config_test.go
@@ -105,6 +105,14 @@ func TestLoadConfig(t *testing.T) {
 			id:                 component.NewIDWithName(metadata.Type, "dynamic_resources_empty_metadata"),
 			expectedErrMessage: `application_privileges::0::dynamic_resources::0: metadata must be non-empty`,
 		},
+		{
+			id: component.NewIDWithName(metadata.Type, "forward_headers"),
+			expected: func() *Config {
+				config := createDefaultConfig().(*Config)
+				config.ForwardHeaders = []string{"X-Elastic-App-Auth"}
+				return config
+			}(),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.id.String(), func(t *testing.T) {
@@ -128,5 +136,4 @@ func TestLoadConfig(t *testing.T) {
 			assert.Equal(t, tt.expected, cfg)
 		})
 	}
-
 }

--- a/extension/apikeyauthextension/testdata/config.yaml
+++ b/extension/apikeyauthextension/testdata/config.yaml
@@ -4,6 +4,8 @@ apikeyauth/application_privileges:
     - application: my_app
       privileges: [read, write]
       resources: ['*']
+apikeyauth/forward_headers:
+  forward_headers: ["X-Elastic-App-Auth"]
 apikeyauth/invalid_cache_capacity:
   cache:
     capacity: 0


### PR DESCRIPTION
This PR adds a new `forward_headers` configuration option to the `apikeyauthextension`. This allows users to specify a list of headers from the incoming request that should be forwarded to Elasticsearch when performing the privilege check.

This is particularly useful for passing through headers like `X-Elastic-App-Auth` that may be required by traffic filters or intermediate proxies when communicating with Elasticsearch.