### PR TITLE
Fix metric name as per convention and remove signal attr

### DIFF
--- a/connector/dynamicroutingconnector/documentation.md
+++ b/connector/dynamicroutingconnector/documentation.md
@@ -6,7 +6,7 @@
 
 The following telemetry is emitted by this component.
 
-### otelcol_dynamicrouting.routed
+### otelcol.dynamicrouting.routed
 
 Number of telemetry batches routed by the connector. [Development]
 
@@ -20,4 +20,3 @@ Number of telemetry batches routed by the connector. [Development]
 | ---- | ----------- | ------ |
 | cardinality_bucket | Cardinality bucket identifier derived from routing_pipelines. | Any Str |
 | partition_key | Composite partition key built from routing_keys.partition_by values. | Any Str |
-| signal | Telemetry signal routed by the connector. | Any Str |

--- a/connector/dynamicroutingconnector/internal/metadata/generated_telemetry.go
+++ b/connector/dynamicroutingconnector/internal/metadata/generated_telemetry.go
@@ -76,7 +76,7 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 	builder.meter = Meter(settings)
 	var err, errs error
 	builder.DynamicroutingRouted, err = builder.meter.Int64Counter(
-		"otelcol_dynamicrouting.routed",
+		"otelcol.dynamicrouting.routed",
 		metric.WithDescription("Number of telemetry batches routed by the connector. [Development]"),
 		metric.WithUnit("1"),
 	)

--- a/connector/dynamicroutingconnector/internal/metadatatest/generated_telemetrytest.go
+++ b/connector/dynamicroutingconnector/internal/metadatatest/generated_telemetrytest.go
@@ -40,7 +40,7 @@ func NewSettings(tt *componenttest.Telemetry) connector.Settings {
 
 func AssertEqualDynamicroutingRouted(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
-		Name:        "otelcol_dynamicrouting.routed",
+		Name:        "otelcol.dynamicrouting.routed",
 		Description: "Number of telemetry batches routed by the connector. [Development]",
 		Unit:        "1",
 		Data: metricdata.Sum[int64]{
@@ -49,7 +49,7 @@ func AssertEqualDynamicroutingRouted(t *testing.T, tt *componenttest.Telemetry, 
 			DataPoints:  dps,
 		},
 	}
-	got, err := tt.GetMetric("otelcol_dynamicrouting.routed")
+	got, err := tt.GetMetric("otelcol.dynamicrouting.routed")
 	require.NoError(t, err)
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }

--- a/connector/dynamicroutingconnector/logs.go
+++ b/connector/dynamicroutingconnector/logs.go
@@ -26,7 +26,6 @@ import (
 	"go.opentelemetry.io/collector/connector"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/pdata/plog"
-	"go.opentelemetry.io/collector/pipeline"
 	"go.uber.org/zap"
 )
 
@@ -47,7 +46,7 @@ func newLogsConnector(
 		return nil, errors.New("expected connector to be a router and consumer")
 	}
 
-	router, err := newRouter(cfg, set.TelemetrySettings, lr.Consumer, pipeline.SignalLogs)
+	router, err := newRouter(cfg, set.TelemetrySettings, lr.Consumer)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create router: %w", err)
 	}

--- a/connector/dynamicroutingconnector/metadata.yaml
+++ b/connector/dynamicroutingconnector/metadata.yaml
@@ -18,13 +18,11 @@ attributes:
   partition_key:
     description: Composite partition key built from routing_keys.partition_by values.
     type: string
-  signal:
-    description: Telemetry signal routed by the connector.
-    type: string
 
 telemetry:
   metrics:
     dynamicrouting.routed:
+      prefix: otelcol.
       enabled: true
       description: Number of telemetry batches routed by the connector.
       unit: "1"
@@ -34,7 +32,7 @@ telemetry:
         value_type: int
         aggregation_temporality: delta
         monotonic: true
-      attributes: [cardinality_bucket, partition_key, signal]
+      attributes: [cardinality_bucket, partition_key]
 
 tests:
   config:

--- a/connector/dynamicroutingconnector/metrics.go
+++ b/connector/dynamicroutingconnector/metrics.go
@@ -26,7 +26,6 @@ import (
 	"go.opentelemetry.io/collector/connector"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/pdata/pmetric"
-	"go.opentelemetry.io/collector/pipeline"
 	"go.uber.org/zap"
 )
 
@@ -47,7 +46,7 @@ func newMetricsConnector(
 		return nil, errors.New("expected connector to be a router and consumer")
 	}
 
-	router, err := newRouter(cfg, set.TelemetrySettings, mr.Consumer, pipeline.SignalMetrics)
+	router, err := newRouter(cfg, set.TelemetrySettings, mr.Consumer)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create router: %w", err)
 	}

--- a/connector/dynamicroutingconnector/router.go
+++ b/connector/dynamicroutingconnector/router.go
@@ -56,7 +56,6 @@ type router[C any] struct {
 	consumers          []ct[C]
 
 	logger           *zap.Logger
-	signal           pipeline.Signal
 	telemetryBuilder *metadata.TelemetryBuilder
 
 	mu      sync.Mutex
@@ -78,7 +77,6 @@ func newRouter[C any](
 	cfg *Config,
 	settings component.TelemetrySettings,
 	provider consumerProvider[C],
-	signal pipeline.Signal,
 ) (*router[C], error) {
 	sortedMetadataKeys := slices.Clone(cfg.RoutingKeys.MeasureBy)
 	slices.Sort(sortedMetadataKeys)
@@ -119,7 +117,6 @@ func newRouter[C any](
 		defaultConsumer:    defaultConsumer,
 		consumers:          consumers,
 		logger:             settings.Logger,
-		signal:             signal,
 		telemetryBuilder:   telemetryBuilder,
 		stop:               make(chan struct{}),
 		decision:           make(map[string]ct[C]),
@@ -352,7 +349,6 @@ func (r *router[C]) recordRoutedMetric(ctx context.Context, pk string, bucket st
 		metric.WithAttributes(
 			attribute.String("cardinality_bucket", bucket),
 			attribute.String("partition_key", pk),
-			attribute.String("signal", fmt.Sprint(r.signal)),
 		),
 	)
 }

--- a/connector/dynamicroutingconnector/router_metrics_test.go
+++ b/connector/dynamicroutingconnector/router_metrics_test.go
@@ -131,7 +131,6 @@ func TestDynamicroutingRoutedTelemetry(t *testing.T) {
 				func(...pipeline.ID) (consumer.Metrics, error) {
 					return consumertest.NewNop(), nil
 				},
-				pipeline.SignalMetrics,
 			)
 			require.NoError(t, err)
 			t.Cleanup(func() {
@@ -152,7 +151,6 @@ func TestDynamicroutingRoutedTelemetry(t *testing.T) {
 					Attributes: attribute.NewSet(
 						attribute.String("cardinality_bucket", tt.wantBucket),
 						attribute.String("partition_key", pk),
-						attribute.String("signal", pipeline.SignalMetrics.String()),
 					),
 				})
 			}

--- a/connector/dynamicroutingconnector/traces.go
+++ b/connector/dynamicroutingconnector/traces.go
@@ -26,7 +26,6 @@ import (
 	"go.opentelemetry.io/collector/connector"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	"go.opentelemetry.io/collector/pipeline"
 	"go.uber.org/zap"
 )
 
@@ -47,7 +46,7 @@ func newTracesConnector(
 		return nil, errors.New("expected connector to be a router and consumer")
 	}
 
-	router, err := newRouter(cfg, set.TelemetrySettings, tr.Consumer, pipeline.SignalTraces)
+	router, err := newRouter(cfg, set.TelemetrySettings, tr.Consumer)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create router: %w", err)
 	}


### PR DESCRIPTION
Fixes the metric name to follow the convention to use period (`.`) and remove `signal` attribute as `otelcol.signal` attribute is added by default to all metrics.

Related to: https://github.com/elastic/hosted-otel-collector/issues/1349