### PR TITLE
bump versions for edot base

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -1,6 +1,6 @@
 module-sets:
   edot-base:
-    version: v0.33.0
+    version: v0.34.0
     modules:
       - github.com/elastic/opentelemetry-collector-components/receiver/elasticapmintakereceiver
       - github.com/elastic/opentelemetry-collector-components/receiver/loadgenreceiver


### PR DESCRIPTION
After https://github.com/elastic/opentelemetry-collector-components/releases/tag/v0.34.0 and manually running the `make push-tags` command.

Related to https://github.com/elastic/opentelemetry-collector-components/pull/1028