### PR TITLE
[elasticapm processor] Cover ServicePeerName introduced in SemConv v1.39.0

### DIFF
--- a/processor/elasticapmprocessor/internal/enrichments/span.go
+++ b/processor/elasticapmprocessor/internal/enrichments/span.go
@@ -129,7 +129,7 @@ func (s *spanEnrichmentContext) Enrich(
 	// Extract information from span attributes.
 	span.Attributes().Range(func(k string, v pcommon.Value) bool {
 		switch k {
-		case string(semconv25.PeerServiceKey):
+		case string(semconv25.PeerServiceKey), string(semconv39.ServicePeerNameKey):
 			s.peerService = v.Str()
 		case string(semconv25.ServerAddressKey):
 			s.serverAddress = v.Str()

--- a/processor/elasticapmprocessor/internal/enrichments/span_test.go
+++ b/processor/elasticapmprocessor/internal/enrichments/span_test.go
@@ -1220,6 +1220,28 @@ func TestElasticSpanEnrich(t *testing.T) {
 			},
 		},
 		{
+			name: "service_peer_name_semconv_v1_39",
+			input: func() ptrace.Span {
+				span := getElasticSpan()
+				span.SetName("testspan")
+				span.Attributes().PutStr(string(semconv39.ServicePeerNameKey), "testsvc")
+				return span
+			}(),
+			config: config.Enabled().Span,
+			enrichedAttrs: map[string]any{
+				elasticattr.TimestampUs:                    startTs.AsTime().UnixMicro(),
+				elasticattr.ProcessorEvent:                 "span",
+				elasticattr.SpanRepresentativeCount:        float64(1),
+				elasticattr.SpanType:                       "unknown",
+				elasticattr.SpanDurationUs:                 expectedDuration.Microseconds(),
+				elasticattr.EventOutcome:                   outcomeSuccess,
+				elasticattr.SuccessCount:                   int64(1),
+				elasticattr.ServiceTargetName:              "testsvc",
+				elasticattr.ServiceTargetType:              "",
+				elasticattr.SpanDestinationServiceResource: "testsvc",
+			},
+		},
+		{
 			name: "http_span_basic",
 			input: func() ptrace.Span {
 				span := getElasticSpan()


### PR DESCRIPTION
The change was listed [here](https://github.com/open-telemetry/semantic-conventions/releases/tag/v1.39.0):

> peer: The peer.service attribute has been deprecated in favor of service.peer.name. (https://github.com/open-telemetry/semantic-conventions/issues/2945)
The peer.service attribute has been renamed to service.peer.name to align with the service.{name|namespace} resource attributes.

As usual, we keep the old version in place. 