### PR TITLE
perf(beatsencodingextension): optimize end-to-end unmarshal hot paths

### DIFF
--- a/extension/beatsencodingextension/config.go
+++ b/extension/beatsencodingextension/config.go
@@ -18,6 +18,7 @@
 package beatsencodingextension // import "github.com/elastic/opentelemetry-collector-components/extension/beatsencodingextension"
 
 import (
+	"errors"
 	"fmt"
 )
 
@@ -85,11 +86,11 @@ func (c *Config) Validate() error {
 	}
 
 	if c.DataStream.Dataset == "" {
-		return fmt.Errorf("data_stream.dataset is required")
+		return errors.New("data_stream.dataset is required")
 	}
 
 	if c.DataStream.Namespace == "" {
-		return fmt.Errorf("data_stream.namespace is required")
+		return errors.New("data_stream.namespace is required")
 	}
 
 	return nil

--- a/extension/beatsencodingextension/extension.go
+++ b/extension/beatsencodingextension/extension.go
@@ -243,6 +243,9 @@ func (e *beatsEncodingExtension) unmarshalText(buf []byte) (plog.Logs, error) {
 		}
 	}
 
+	if logs.LogRecordCount() == 0 {
+		return plog.NewLogs(), nil
+	}
 	return logs, nil
 }
 
@@ -338,7 +341,7 @@ func (e *beatsEncodingExtension) newLineDecoder(reader io.Reader, options ...enc
 		}
 
 		if logs.LogRecordCount() == 0 {
-			return logs, io.EOF
+			return plog.NewLogs(), io.EOF
 		}
 		return logs, nil
 	}
@@ -460,7 +463,7 @@ func (e *beatsEncodingExtension) newStreamingJSONDecoder(reader io.Reader, opts 
 		}
 
 		if logs.LogRecordCount() == 0 {
-			return logs, io.EOF
+			return plog.NewLogs(), io.EOF
 		}
 		return logs, nil
 	}

--- a/extension/beatsencodingextension/extension.go
+++ b/extension/beatsencodingextension/extension.go
@@ -45,19 +45,163 @@ var (
 )
 
 type beatsEncodingExtension struct {
-	config *Config
-	logger *zap.Logger
+	config      *Config
+	logger      *zap.Logger
+	fieldWriter func(pcommon.Map)
 }
 
 func newBeatsEncodingExtension(config *Config, logger *zap.Logger) (*beatsEncodingExtension, error) {
-	return &beatsEncodingExtension{config: config, logger: logger}, nil
+	return &beatsEncodingExtension{
+		config:      config,
+		logger:      logger,
+		fieldWriter: compileMapWriter(logger, config.Fields),
+	}, nil
 }
 
-func (e *beatsEncodingExtension) Start(context.Context, component.Host) error {
+// compileMapWriter converts static config fields into a reusable map writer.
+// This shifts type-switch and recursion work to startup so per-record writes
+// in appendLogRecord stay cheaper on hot paths.
+func compileMapWriter(logger *zap.Logger, fields map[string]any) func(pcommon.Map) {
+	if len(fields) == 0 {
+		return nil
+	}
+
+	writers := make([]func(pcommon.Map), 0, len(fields))
+	for k, v := range fields {
+		switch val := v.(type) {
+		case string:
+			key := k
+			value := val
+			writers = append(writers, func(m pcommon.Map) {
+				m.PutStr(key, value)
+			})
+		case bool:
+			key := k
+			value := val
+			writers = append(writers, func(m pcommon.Map) {
+				m.PutBool(key, value)
+			})
+		case int:
+			key := k
+			value := int64(val)
+			writers = append(writers, func(m pcommon.Map) {
+				m.PutInt(key, value)
+			})
+		case int64:
+			key := k
+			value := val
+			writers = append(writers, func(m pcommon.Map) {
+				m.PutInt(key, value)
+			})
+		case float64:
+			key := k
+			value := val
+			writers = append(writers, func(m pcommon.Map) {
+				m.PutDouble(key, value)
+			})
+		case map[string]any:
+			key := k
+			nestedLen := len(val)
+			nestedWriter := compileMapWriter(logger, val)
+			writers = append(writers, func(m pcommon.Map) {
+				nested := m.PutEmptyMap(key)
+				nested.EnsureCapacity(nestedLen)
+				if nestedWriter != nil {
+					nestedWriter(nested)
+				}
+			})
+		case []any:
+			key := k
+			sliceWriter := compileSliceWriter(logger, key, val)
+			writers = append(writers, func(m pcommon.Map) {
+				sl := m.PutEmptySlice(key)
+				if sliceWriter != nil {
+					sliceWriter(sl)
+				}
+			})
+		default:
+			key := k
+			value := val
+			writers = append(writers, func(pcommon.Map) {
+				logger.Warn("unsupported field type, skipping", zap.String("key", key), zap.Any("value", value))
+			})
+		}
+	}
+
+	return func(m pcommon.Map) {
+		for _, writer := range writers {
+			writer(m)
+		}
+	}
+}
+
+// compileSliceWriter converts static slice values into reusable appenders.
+// This avoids repeating per-element type checks for every log record and keeps
+// field enrichment overhead lower in steady-state decoding.
+func compileSliceWriter(logger *zap.Logger, key string, values []any) func(pcommon.Slice) {
+	if len(values) == 0 {
+		return nil
+	}
+
+	appenders := make([]func(pcommon.Slice), 0, len(values))
+	for _, item := range values {
+		switch elem := item.(type) {
+		case string:
+			value := elem
+			appenders = append(appenders, func(sl pcommon.Slice) {
+				sl.AppendEmpty().SetStr(value)
+			})
+		case bool:
+			value := elem
+			appenders = append(appenders, func(sl pcommon.Slice) {
+				sl.AppendEmpty().SetBool(value)
+			})
+		case int:
+			value := int64(elem)
+			appenders = append(appenders, func(sl pcommon.Slice) {
+				sl.AppendEmpty().SetInt(value)
+			})
+		case int64:
+			value := elem
+			appenders = append(appenders, func(sl pcommon.Slice) {
+				sl.AppendEmpty().SetInt(value)
+			})
+		case float64:
+			value := elem
+			appenders = append(appenders, func(sl pcommon.Slice) {
+				sl.AppendEmpty().SetDouble(value)
+			})
+		case map[string]any:
+			nestedLen := len(elem)
+			nestedWriter := compileMapWriter(logger, elem)
+			appenders = append(appenders, func(sl pcommon.Slice) {
+				nested := sl.AppendEmpty().SetEmptyMap()
+				nested.EnsureCapacity(nestedLen)
+				if nestedWriter != nil {
+					nestedWriter(nested)
+				}
+			})
+		default:
+			value := elem
+			appenders = append(appenders, func(pcommon.Slice) {
+				logger.Warn("unsupported field type in slice, skipping", zap.String("key", key), zap.Any("value", value))
+			})
+		}
+	}
+
+	return func(sl pcommon.Slice) {
+		sl.EnsureCapacity(len(appenders))
+		for _, appender := range appenders {
+			appender(sl)
+		}
+	}
+}
+
+func (*beatsEncodingExtension) Start(context.Context, component.Host) error {
 	return nil
 }
 
-func (e *beatsEncodingExtension) Shutdown(context.Context) error {
+func (*beatsEncodingExtension) Shutdown(context.Context) error {
 	return nil
 }
 
@@ -65,19 +209,85 @@ func (e *beatsEncodingExtension) Shutdown(context.Context) error {
 // the streaming decoder with flushing disabled, so all records are returned
 // in a single batch.
 func (e *beatsEncodingExtension) UnmarshalLogs(buf []byte) (plog.Logs, error) {
-	decoder, err := e.NewLogsDecoder(
-		bytes.NewReader(buf),
-		encoding.WithFlushBytes(0),
-		encoding.WithFlushItems(0),
-	)
+	switch e.config.Format {
+	case FormatText:
+		return e.unmarshalText(buf)
+	case FormatJSON:
+		return e.unmarshalJSON(buf)
+	default:
+		return plog.NewLogs(), fmt.Errorf("unsupported format: %q", e.config.Format)
+	}
+}
+
+func (e *beatsEncodingExtension) unmarshalText(buf []byte) (plog.Logs, error) {
+	scanner, err := xstreamencoding.NewScannerHelper(bytes.NewReader(buf))
 	if err != nil {
 		return plog.NewLogs(), err
 	}
-	logs, err := decoder.DecodeLogs()
-	if errors.Is(err, io.EOF) {
+
+	logs := plog.NewLogs()
+	sl := newScopeLogs(logs)
+	now := pcommon.NewTimestampFromTime(time.Now())
+	eventCreated := now.AsTime().UTC().Format(time.RFC3339Nano)
+
+	for {
+		line, _, err := scanner.ScanString()
+		if line != "" {
+			e.appendLogRecord(sl, now, eventCreated, line)
+		}
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return logs, err
+		}
+	}
+
+	return logs, nil
+}
+
+func (e *beatsEncodingExtension) unmarshalJSON(buf []byte) (plog.Logs, error) {
+	if len(e.config.Unwrap) == 0 {
+		trimmed := bytes.TrimSpace(buf)
+		if len(trimmed) == 0 {
+			return plog.NewLogs(), nil
+		}
+
+		logs := plog.NewLogs()
+		sl := newScopeLogs(logs)
+		now := pcommon.NewTimestampFromTime(time.Now())
+		e.appendLogRecord(sl, now, now.AsTime().UTC().Format(time.RFC3339Nano), string(trimmed))
+		return logs, nil
+	}
+
+	dec := json.NewDecoder(bytes.NewReader(buf))
+	if err := navigateToArray(dec, e.config.Unwrap); err != nil {
+		return plog.NewLogs(), fmt.Errorf("navigating to unwrap %v: %w", e.config.Unwrap, err)
+	}
+
+	logs := plog.NewLogs()
+	sl := newScopeLogs(logs)
+	now := pcommon.NewTimestampFromTime(time.Now())
+	eventCreated := now.AsTime().UTC().Format(time.RFC3339Nano)
+
+	for dec.More() {
+		var raw json.RawMessage
+		if err := dec.Decode(&raw); err != nil {
+			return logs, fmt.Errorf("decoding array element: %w", err)
+		}
+
+		trimmed := bytes.TrimSpace(raw)
+		if len(trimmed) == 0 {
+			continue
+		}
+
+		e.appendLogRecord(sl, now, eventCreated, string(trimmed))
+	}
+
+	if logs.LogRecordCount() == 0 {
 		return plog.NewLogs(), nil
 	}
-	return logs, err
+	return logs, nil
 }
 
 // NewLogsDecoder creates a streaming decoder for the configured format.
@@ -347,9 +557,12 @@ func writeFields(logger *zap.Logger, m pcommon.Map, fields map[string]any) {
 		case float64:
 			m.PutDouble(k, val)
 		case map[string]any:
-			writeFields(logger, m.PutEmptyMap(k), val)
+			nested := m.PutEmptyMap(k)
+			nested.EnsureCapacity(len(val))
+			writeFields(logger, nested, val)
 		case []any:
 			sl := m.PutEmptySlice(k)
+			sl.EnsureCapacity(len(val))
 			for _, item := range val {
 				switch elem := item.(type) {
 				case string:
@@ -382,7 +595,7 @@ func newScopeLogs(logs plog.Logs) plog.ScopeLogs {
 	return sl
 }
 
-func (e *beatsEncodingExtension) appendLogRecord(sl plog.ScopeLogs, ts pcommon.Timestamp, eventCreated string, record string) {
+func (e *beatsEncodingExtension) appendLogRecord(sl plog.ScopeLogs, ts pcommon.Timestamp, eventCreated, record string) {
 	lr := sl.LogRecords().AppendEmpty()
 	lr.SetTimestamp(ts)
 	lr.SetObservedTimestamp(ts)
@@ -411,12 +624,15 @@ func (e *beatsEncodingExtension) appendLogRecord(sl plog.ScopeLogs, ts pcommon.T
 		}
 	}
 
-	writeFields(e.logger, body, e.config.Fields)
+	if e.fieldWriter != nil {
+		e.fieldWriter(body)
+	}
 
 	// We need to set these attributes on the record itself for the
 	// Elasticsearch exporter to route the record to the correct
 	// data stream.
 	attrs := lr.Attributes()
+	attrs.EnsureCapacity(3)
 	attrs.PutStr("data_stream.type", "logs")
 	attrs.PutStr("data_stream.dataset", e.config.DataStream.Dataset)
 	attrs.PutStr("data_stream.namespace", e.config.DataStream.Namespace)

--- a/extension/beatsencodingextension/extension_test.go
+++ b/extension/beatsencodingextension/extension_test.go
@@ -196,6 +196,7 @@ func TestUnmarshalLogs_EmptyInput(t *testing.T) {
 			logs, err := ext.UnmarshalLogs(tt.input)
 			require.NoError(t, err)
 			assert.Equal(t, 0, logs.LogRecordCount())
+			assert.Equal(t, 0, logs.ResourceLogs().Len(), "empty input must not retain resource wrappers")
 		})
 	}
 }

--- a/extension/beatsencodingextension/extension_test.go
+++ b/extension/beatsencodingextension/extension_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest/plogtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.uber.org/zap"
 )
@@ -57,9 +58,9 @@ func TestUnmarshalLogs(t *testing.T) {
 		{
 			name: "azure diagnostic settings (json + unwrap)",
 			config: Config{
-				Format:      FormatJSON,
-				Unwrap:  []string{"records"},
-					DataStream:     DataStreamConfig{Dataset: "azure.events", Namespace: "default"},
+				Format:     FormatJSON,
+				Unwrap:     []string{"records"},
+				DataStream: DataStreamConfig{Dataset: "azure.events", Namespace: "default"},
 			},
 			inputFile:  "azure_diagnostic_settings.json",
 			goldenFile: "azure_diagnostic_settings_expected.yaml",
@@ -68,9 +69,9 @@ func TestUnmarshalLogs(t *testing.T) {
 		{
 			name: "aws cloudtrail (json + unwrap)",
 			config: Config{
-				Format:      FormatJSON,
-				Unwrap:  []string{"Records"},
-					DataStream:     DataStreamConfig{Dataset: "aws.cloudtrail", Namespace: "default"},
+				Format:     FormatJSON,
+				Unwrap:     []string{"Records"},
+				DataStream: DataStreamConfig{Dataset: "aws.cloudtrail", Namespace: "default"},
 			},
 			inputFile:  "aws_cloudtrail.json",
 			goldenFile: "aws_cloudtrail_expected.yaml",
@@ -79,8 +80,8 @@ func TestUnmarshalLogs(t *testing.T) {
 		{
 			name: "aws vpc flow logs (text)",
 			config: Config{
-				Format:      FormatText,
-					DataStream:     DataStreamConfig{Dataset: "aws.vpcflow", Namespace: "default"},
+				Format:     FormatText,
+				DataStream: DataStreamConfig{Dataset: "aws.vpcflow", Namespace: "default"},
 			},
 			inputFile:  "aws_vpcflow.txt",
 			goldenFile: "aws_vpcflow_expected.yaml",
@@ -89,8 +90,8 @@ func TestUnmarshalLogs(t *testing.T) {
 		{
 			name: "aws elb access logs (text)",
 			config: Config{
-				Format:      FormatText,
-					DataStream:     DataStreamConfig{Dataset: "aws.elb_logs", Namespace: "default"},
+				Format:     FormatText,
+				DataStream: DataStreamConfig{Dataset: "aws.elb_logs", Namespace: "default"},
 			},
 			inputFile:  "aws_elb.txt",
 			goldenFile: "aws_elb_expected.yaml",
@@ -99,8 +100,8 @@ func TestUnmarshalLogs(t *testing.T) {
 		{
 			name: "json without unwrap (single record)",
 			config: Config{
-				Format:      FormatJSON,
-					DataStream:     DataStreamConfig{Dataset: "generic", Namespace: "default"},
+				Format:     FormatJSON,
+				DataStream: DataStreamConfig{Dataset: "generic", Namespace: "default"},
 			},
 			inputFile:  "json_single.json",
 			goldenFile: "json_single_expected.yaml",
@@ -109,8 +110,8 @@ func TestUnmarshalLogs(t *testing.T) {
 		{
 			name: "json nested path unwrap",
 			config: Config{
-				Format:    FormatJSON,
-				Unwrap: []string{"data", "items"},
+				Format:     FormatJSON,
+				Unwrap:     []string{"data", "items"},
 				DataStream: DataStreamConfig{Dataset: "custom.nested", Namespace: "default"},
 			},
 			inputFile:  "json_nested.json",
@@ -118,7 +119,7 @@ func TestUnmarshalLogs(t *testing.T) {
 			wantLogs:   3,
 		},
 		{
-			name:   "fields",
+			name: "fields",
 			config: Config{
 				Format:     FormatText,
 				DataStream: DataStreamConfig{Dataset: "aws.vpcflow", Namespace: "default"},
@@ -131,10 +132,10 @@ func TestUnmarshalLogs(t *testing.T) {
 		{
 			name: "input_type and tags",
 			config: Config{
-				Format:    FormatText,
+				Format:     FormatText,
 				DataStream: DataStreamConfig{Dataset: "aws.vpcflow", Namespace: "default"},
-				InputType: "aws-s3",
-				Tags:      []string{"forwarded", "aws-vpcflow"},
+				InputType:  "aws-s3",
+				Tags:       []string{"forwarded", "aws-vpcflow"},
 			},
 			inputFile:  "aws_vpcflow.txt",
 			goldenFile: "aws_vpcflow_input_type_tags_expected.yaml",
@@ -202,7 +203,7 @@ func TestUnmarshalLogs_EmptyInput(t *testing.T) {
 func TestUnmarshalLogs_UnwrapFieldMissing(t *testing.T) {
 	ext := newTestExtension(t, &Config{
 		Format:     FormatJSON,
-		Unwrap: []string{"records"},
+		Unwrap:     []string{"records"},
 		DataStream: DataStreamConfig{Dataset: "test", Namespace: "default"},
 	})
 
@@ -217,7 +218,7 @@ func TestUnmarshalLogs_UnwrapFieldMissing(t *testing.T) {
 func TestUnmarshalLogs_StructuralChecks(t *testing.T) {
 	ext := newTestExtension(t, &Config{
 		Format:     FormatJSON,
-		Unwrap: []string{"records"},
+		Unwrap:     []string{"records"},
 		DataStream: DataStreamConfig{Dataset: "azure.events", Namespace: "default"},
 		InputType:  "azure-eventhub",
 		Tags:       []string{"forwarded", "azure-events"},
@@ -287,7 +288,7 @@ func TestUnmarshalLogs_StructuralChecks(t *testing.T) {
 func TestNewLogsDecoder_StreamingBatches(t *testing.T) {
 	ext := newTestExtension(t, &Config{
 		Format:     FormatJSON,
-		Unwrap: []string{"records"},
+		Unwrap:     []string{"records"},
 		DataStream: DataStreamConfig{Dataset: "test", Namespace: "default"},
 	})
 
@@ -321,7 +322,7 @@ func TestNewLogsDecoder_StreamingBatches(t *testing.T) {
 func TestNewLogsDecoder_JSONResumption(t *testing.T) {
 	ext := newTestExtension(t, &Config{
 		Format:     FormatJSON,
-		Unwrap: []string{"records"},
+		Unwrap:     []string{"records"},
 		DataStream: DataStreamConfig{Dataset: "azure.events", Namespace: "default"},
 	})
 
@@ -394,7 +395,7 @@ func TestNewLogsDecoder_TextStreamingBatches(t *testing.T) {
 func TestUnmarshalLogs_FieldsStructural(t *testing.T) {
 	ext := newTestExtension(t, &Config{
 		Format:     FormatJSON,
-		Unwrap: []string{"records"},
+		Unwrap:     []string{"records"},
 		DataStream: DataStreamConfig{Dataset: "azure.events", Namespace: "default"},
 		Fields: map[string]any{
 			"environment": "production",
@@ -457,6 +458,115 @@ func TestNewLogsDecoder_SingleRecordResumption(t *testing.T) {
 
 	_, err = decoder2.DecodeLogs()
 	assert.ErrorIs(t, err, io.EOF)
+}
+
+func TestCompileMapWriter(t *testing.T) {
+	cases := []struct {
+		name              string
+		fields            map[string]any
+		expectedWriterNil bool
+		expectedRaw       map[string]any
+	}{
+		{
+			name:              "empty fields returns nil writer",
+			fields:            map[string]any{},
+			expectedWriterNil: true,
+			expectedRaw:       map[string]any{},
+		},
+		{
+			name: "supported scalar nested and slice fields",
+			fields: map[string]any{
+				"environment": "production",
+				"enabled":     true,
+				"retries":     3,
+				"latency":     float64(1.5),
+				"nested":      map[string]any{"region": "us-east-1", "zone": "a"},
+				"tags":        []any{"forwarded", int64(7), map[string]any{"name": "security"}},
+			},
+			expectedWriterNil: false,
+			expectedRaw: map[string]any{
+				"environment": "production",
+				"enabled":     true,
+				"retries":     int64(3),
+				"latency":     float64(1.5),
+				"nested":      map[string]any{"region": "us-east-1", "zone": "a"},
+				"tags":        []any{"forwarded", int64(7), map[string]any{"name": "security"}},
+			},
+		},
+		{
+			name: "unsupported values are skipped",
+			fields: map[string]any{
+				"ok":      "value",
+				"bad":     struct{ Name string }{Name: "x"},
+				"badList": []any{"kept", struct{ ID int }{ID: 1}},
+			},
+			expectedWriterNil: false,
+			expectedRaw: map[string]any{
+				"ok":      "value",
+				"badList": []any{"kept"},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			writer := compileMapWriter(zap.NewNop(), tc.fields)
+			m := pcommon.NewMap()
+
+			if tc.expectedWriterNil {
+				require.Nil(t, writer)
+			} else {
+				require.NotNil(t, writer)
+				writer(m)
+			}
+
+			require.Equal(t, tc.expectedRaw, m.AsRaw())
+		})
+	}
+}
+
+func TestCompileSliceWriter(t *testing.T) {
+	cases := []struct {
+		name              string
+		values            []any
+		expectedWriterNil bool
+		expectedRaw       []any
+	}{
+		{
+			name:              "empty values returns nil writer",
+			values:            []any{},
+			expectedWriterNil: true,
+			expectedRaw:       []any{},
+		},
+		{
+			name:              "supported values and nested map",
+			values:            []any{"a", true, int(3), int64(4), float64(2.5), map[string]any{"k": "v"}},
+			expectedWriterNil: false,
+			expectedRaw:       []any{"a", true, int64(3), int64(4), float64(2.5), map[string]any{"k": "v"}},
+		},
+		{
+			name:              "unsupported values are skipped",
+			values:            []any{"kept", struct{ X int }{X: 1}},
+			expectedWriterNil: false,
+			expectedRaw:       []any{"kept"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			writer := compileSliceWriter(zap.NewNop(), "test", tc.values)
+			sl := pcommon.NewSlice()
+
+			if tc.expectedWriterNil {
+				require.Nil(t, writer)
+			} else {
+				require.NotNil(t, writer)
+				writer(sl)
+			}
+
+			require.Equal(t, tc.expectedRaw, sl.AsRaw())
+		})
+	}
 }
 
 // stripEventCreated removes the "event.created" key from all log record

--- a/extension/beatsencodingextension/hot_paths_bench_test.go
+++ b/extension/beatsencodingextension/hot_paths_bench_test.go
@@ -1,0 +1,118 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package beatsencodingextension
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.uber.org/zap"
+)
+
+// BenchmarkAppendLogRecord isolates the per-record allocation cost:
+// one pcommon.Map creation, 6+ body field writes, and 3 attribute writes.
+func BenchmarkAppendLogRecord(b *testing.B) {
+	ext, err := newBeatsEncodingExtension(&Config{
+		Format:     FormatText,
+		DataStream: DataStreamConfig{Dataset: "aws.vpcflow", Namespace: "default"},
+	}, zap.NewNop())
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	now := pcommon.NewTimestampFromTime(time.Now())
+	eventCreated := now.AsTime().UTC().Format(time.RFC3339Nano)
+	const record = `2 123456789010 eni-abc123 192.168.1.1 10.0.0.1 12345 80 6 10 840 1620000000 1620000060 ACCEPT OK`
+
+	b.ReportAllocs()
+	for b.Loop() {
+		logs := plog.NewLogs()
+		sl := newScopeLogs(logs)
+		ext.appendLogRecord(sl, now, eventCreated, record)
+	}
+}
+
+// BenchmarkWriteFields isolates the recursive type-switch that maps
+// map[string]any values onto a pcommon.Map, covering strings, float64,
+// a nested map, and a slice.
+func BenchmarkWriteFields(b *testing.B) {
+	logger := zap.NewNop()
+	fields := map[string]any{
+		"environment": "production",
+		"version":     float64(1),
+		"nested":      map[string]any{"region": "us-east-1", "az": "a"},
+		"tags":        []any{"forwarded", "aws-s3"},
+	}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		m := pcommon.NewMap()
+		writeFields(logger, m, fields)
+	}
+}
+
+// BenchmarkUnmarshalLogs_Text covers the end-to-end text path:
+// newline scanning → appendLogRecord for each line.
+func BenchmarkUnmarshalLogs_Text(b *testing.B) {
+	ext, err := newBeatsEncodingExtension(&Config{
+		Format:     FormatText,
+		DataStream: DataStreamConfig{Dataset: "aws.vpcflow", Namespace: "default"},
+	}, zap.NewNop())
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	input, err := os.ReadFile(filepath.Join(testDataDir, "aws_vpcflow.txt"))
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.SetBytes(int64(len(input)))
+	for b.Loop() {
+		_, _ = ext.UnmarshalLogs(input)
+	}
+}
+
+// BenchmarkUnmarshalLogs_JSONWithUnwrap covers the end-to-end JSON path:
+// navigateToArray → streaming json.Decode per element → appendLogRecord.
+func BenchmarkUnmarshalLogs_JSONWithUnwrap(b *testing.B) {
+	ext, err := newBeatsEncodingExtension(&Config{
+		Format:     FormatJSON,
+		Unwrap:     []string{"records"},
+		DataStream: DataStreamConfig{Dataset: "azure.events", Namespace: "default"},
+	}, zap.NewNop())
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	input, err := os.ReadFile(filepath.Join(testDataDir, "azure_diagnostic_settings.json"))
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.SetBytes(int64(len(input)))
+	for b.Loop() {
+		_, _ = ext.UnmarshalLogs(input)
+	}
+}


### PR DESCRIPTION
I did this with Cursor. I gave it these directions:

```
1. Identify: Locate the hot paths (bottlenecks) in the current logic.
2. Baseline: Create or identify the relevant Go benchmarks.
3. Capture Old: Run the baseline and save results:
go test -run='^$' -bench=. -count=10 > old.txt
4. Hypothesize & Edit: Pick one single improvement. Modify the code.
5. Capture New: Run the benchmarks again:
go test -run='^$' -bench=. -count=10 > new.txt
6. Analyze: Run benchstat old.txt new.txt to compare.
7. Evaluate: If benchstat confirms a statistically improvement, keep the change.If there is no improvement or a regression, revert the code.
8. Iterate: Repeat from step 4 until performance goals are met. 
```

Sometimes I had to do one or another adjustment, but in general it worked well.

From the new benchmarks, every metric improved:

```
 benchstat old.txt new.txt
goos: linux
goarch: amd64
pkg: github.com/elastic/opentelemetry-collector-components/extension/beatsencodingextension
cpu: Intel(R) Core(TM) Ultra 7 258V
                               │   old.txt    │               new.txt                │
                               │    sec/op    │    sec/op     vs base                │
AppendLogRecord-8                1.163µ ± 10%   1.100µ ±  8%        ~ (p=0.063 n=10)
WriteFields-8                    828.9n ± 18%   762.5n ± 14%        ~ (p=0.105 n=10)
UnmarshalLogs_Text-8             6.284µ ± 19%   5.091µ ± 14%  -18.99% (p=0.003 n=10)
UnmarshalLogs_JSONWithUnwrap-8   6.062µ ± 13%   4.128µ ± 22%  -31.90% (p=0.000 n=10)
geomean                          2.462µ         2.049µ        -16.79%

                               │   old.txt    │               new.txt                │
                               │     B/op     │     B/op      vs base                │
AppendLogRecord-8                 1096.0 ± 0%     968.0 ± 0%  -11.68% (p=0.000 n=10)
WriteFields-8                      552.0 ± 0%     504.0 ± 0%   -8.70% (p=0.000 n=10)
UnmarshalLogs_Text-8             7.625Ki ± 0%   7.195Ki ± 0%   -5.64% (p=0.000 n=10)
UnmarshalLogs_JSONWithUnwrap-8   5.031Ki ± 0%   4.594Ki ± 0%   -8.70% (p=0.000 n=10)
geomean                          2.169Ki        1.980Ki        -8.70%

                               │  old.txt   │              new.txt               │
                               │ allocs/op  │ allocs/op   vs base                │
AppendLogRecord-8                25.00 ± 0%   23.00 ± 0%   -8.00% (p=0.000 n=10)
WriteFields-8                    19.00 ± 0%   17.00 ± 0%  -10.53% (p=0.000 n=10)
UnmarshalLogs_Text-8             75.00 ± 0%   66.00 ± 0%  -12.00% (p=0.000 n=10)
UnmarshalLogs_JSONWithUnwrap-8   66.00 ± 0%   54.00 ± 0%  -18.18% (p=0.000 n=10)
geomean                          39.16        34.36       -12.26%

                               │    old.txt    │                new.txt                 │
                               │      B/s      │      B/s        vs base                │
UnmarshalLogs_Text-8             51.15Mi ± 23%    63.20Mi ± 16%  +23.58% (p=0.003 n=10)
UnmarshalLogs_JSONWithUnwrap-8   99.42Mi ± 15%   146.03Mi ± 18%  +46.88% (p=0.000 n=10)
geomean                          71.31Mi          96.07Mi        +34.73%
```

------

Autogenerated PR description:


## Summary
- Optimize `UnmarshalLogs` for no-flush/no-offset usage by using direct text/JSON paths instead of decoder adapter flow.
- Precompile configured field writers (`compileMapWriter`/`compileSliceWriter`) once at extension creation to reduce per-record type-switch overhead.
- Add hot-path benchmarks and table-driven unit tests for compiled writer behavior, and keep capacity hints that lower per-record allocations.

## Test plan
- [x] `go test ./...` in `extension/beatsencodingextension`
- [x] `go test -run='^$' -bench=. -count=10` and compare with `benchstat`
- [x] Validate end-to-end throughput and allocation improvements for text and JSON unwrap benchmarks