### PR TITLE
[process/elasticapmprocessor] enable service language attribute processing for traces

### DIFF
--- a/processor/elasticapmprocessor/processor.go
+++ b/processor/elasticapmprocessor/processor.go
@@ -70,6 +70,7 @@ func NewTraceProcessor(cfg *Config, next consumer.Traces, logger *zap.Logger) *T
 	intakeECSEnricherConfig.Transaction.Result.Enabled = false
 	// The `host.os.type` field should not be added for APM events
 	intakeECSEnricherConfig.Resource.HostOSType.Enabled = false
+	// disable default service language to avoid adding it on apm events
 	intakeECSEnricherConfig.Resource.DefaultServiceLanguage.Enabled = false
 
 	return &TraceProcessor{
@@ -179,6 +180,7 @@ func newLogProcessor(cfg *Config, next consumer.Logs, logger *zap.Logger) *LogPr
 
 	intakeECSEnricherConfig := ecsEnricherConfig
 	intakeECSEnricherConfig.Resource.HostOSType.Enabled = false
+	// disable default service language to avoid adding it on apm events
 	intakeECSEnricherConfig.Resource.DefaultServiceLanguage.Enabled = false
 	intakeECSEnricherConfig.Log.TranslateUnsupportedAttributes.Enabled = false
 

--- a/processor/elasticapmprocessor/processor.go
+++ b/processor/elasticapmprocessor/processor.go
@@ -61,6 +61,7 @@ func NewTraceProcessor(cfg *Config, next consumer.Traces, logger *zap.Logger) *T
 	ecsEnricherConfig.Resource.HostOSType.Enabled = true
 	ecsEnricherConfig.Resource.ServiceName.Enabled = true
 	ecsEnricherConfig.Resource.DefaultDeploymentEnvironment.Enabled = true
+	ecsEnricherConfig.Resource.DefaultServiceLanguage.Enabled = true
 
 	intakeECSEnricherConfig := ecsEnricherConfig
 	// The intake receiver already sets transaction.root; skip re-deriving it
@@ -69,6 +70,7 @@ func NewTraceProcessor(cfg *Config, next consumer.Traces, logger *zap.Logger) *T
 	intakeECSEnricherConfig.Transaction.Result.Enabled = false
 	// The `host.os.type` field should not be added for APM events
 	intakeECSEnricherConfig.Resource.HostOSType.Enabled = false
+	intakeECSEnricherConfig.Resource.DefaultServiceLanguage.Enabled = false
 
 	return &TraceProcessor{
 		next:              next,

--- a/processor/elasticapmprocessor/testdata/ecs/elastic_hostname/spans_output.yaml
+++ b/processor/elasticapmprocessor/testdata/ecs/elastic_hostname/spans_output.yaml
@@ -28,6 +28,9 @@ resourceSpans:
         - key: service.instance.id
           value:
             stringValue: hostname-1
+        - key: telemetry.sdk.language
+          value:
+            stringValue: unknown
     scopeSpans:
       - scope: {}
         spans:

--- a/processor/elasticapmprocessor/testdata/ecs/elastic_log_device_crash_event/swift_crash_output.yaml
+++ b/processor/elasticapmprocessor/testdata/ecs/elastic_log_device_crash_event/swift_crash_output.yaml
@@ -48,7 +48,7 @@ resourceLogs:
                   stringValue: NSException
               - key: exception.stacktrace
                 value:
-                  stringValue: |2+
+                  stringValue: |+
                     Thread 0 Crashed:
                     0   libswiftCore.dylib                  0x0000000195712d2c 0x1956e8000 + 175404
                     1   MyApp                              0x0000000102a3b4c5 0x107050000 + 165
@@ -63,9 +63,6 @@ resourceLogs:
               - key: timestamp.us
                 value:
                   intValue: "1581452772000000"
-              - key: error.grouping_key
-                value:
-                  stringValue: 106766db872df672c31bfff1d30d0e7c
               - key: error.type
                 value:
                   stringValue: crash
@@ -83,12 +80,15 @@ resourceLogs:
                   stringValue: NSException
               - key: error.stack_trace
                 value:
-                  stringValue: |2+
+                  stringValue: |+
                     Thread 0 Crashed:
                     0   libswiftCore.dylib                  0x0000000195712d2c 0x1956e8000 + 175404
                     1   MyApp                              0x0000000102a3b4c5 0x107050000 + 165
                     2   UIKitCore                           0x00000001a4d5e7f2 0x184d72000 + 880
 
+              - key: error.grouping_key
+                value:
+                  stringValue: 106766db872df672c31bfff1d30d0e7c
               - key: data_stream.type
                 value:
                   stringValue: logs

--- a/processor/elasticapmprocessor/testdata/ecs/txn_db/output.yaml
+++ b/processor/elasticapmprocessor/testdata/ecs/txn_db/output.yaml
@@ -28,6 +28,9 @@ resourceSpans:
         - key: deployment.environment
           value:
             stringValue: unset
+        - key: telemetry.sdk.language
+          value:
+            stringValue: unknown
     scopeSpans:
       - scope: {}
         spans:


### PR DESCRIPTION
### Summary 

trace events currently do not populate the default service name for otlp ecs. This PR fixes that by enabling the enricher `DefaultServiceLanguage` flag

We need to set the field `telemetry.sdk.language` so that our [exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/elasticsearchexporter/model.go#L60) would map it to `service.language.name`

### Tests

- Updated processor tests and executed them  