### PR TITLE
Backport: elasticapmconnector: expose error_mode config option (v0.39.1)

### DIFF
--- a/connector/elasticapmconnector/config.go
+++ b/connector/elasticapmconnector/config.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	signaltometricsconfig "github.com/open-telemetry/opentelemetry-collector-contrib/connector/signaltometricsconnector/config"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configoptional"
 
@@ -38,6 +39,11 @@ var defaultIntervals []time.Duration = []time.Duration{
 }
 
 type Config struct {
+	// ErrorMode determines how the connector reacts to errors that occur
+	// while processing an OTTL condition or statement. Valid values are
+	// `propagate`, `ignore`, and `silent`. The default value is `propagate`.
+	ErrorMode ottl.ErrorMode `mapstructure:"error_mode"`
+
 	// Aggregation holds configuration related to aggregation of Elastic APM
 	// metrics from other signals.
 	Aggregation *AggregationConfig `mapstructure:"aggregation"`
@@ -288,6 +294,7 @@ func (cfg Config) signaltometricsConfig() *signaltometricsconfig.Config {
 	}
 
 	return &signaltometricsconfig.Config{
+		ErrorMode: cfg.ErrorMode,
 		Logs: []signaltometricsconfig.MetricInfo{{
 			Name:                      "service_summary",
 			IncludeResourceAttributes: serviceSummaryResourceAttributes,

--- a/connector/elasticapmconnector/config_test.go
+++ b/connector/elasticapmconnector/config_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
@@ -57,6 +58,7 @@ func TestConfig(t *testing.T) {
 		{
 			path: "full",
 			expected: &Config{
+				ErrorMode: ottl.SilentError,
 				Aggregation: &AggregationConfig{
 					Directory:    "/path/to/aggregation/state",
 					MetadataKeys: []string{"a", "B", "c"},

--- a/connector/elasticapmconnector/factory.go
+++ b/connector/elasticapmconnector/factory.go
@@ -20,6 +20,7 @@ package elasticapmconnector // import "github.com/elastic/opentelemetry-collecto
 import (
 	"context"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/connector"
 	"go.opentelemetry.io/collector/consumer"
@@ -49,6 +50,7 @@ func NewFactory() connector.Factory {
 // createDefaultConfig creates the default configuration.
 func createDefaultConfig() component.Config {
 	return &Config{
+		ErrorMode: ottl.PropagateError,
 		Aggregation: &AggregationConfig{
 			Limits: AggregationLimitConfig{
 				ResourceLimit: LimitConfig{

--- a/connector/elasticapmconnector/go.mod
+++ b/connector/elasticapmconnector/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/elastic/opentelemetry-collector-components/processor/lsmintervalprocessor v0.8.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/connector/signaltometricsconnector v0.148.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.148.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.148.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.148.0
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/client v1.54.0
@@ -73,7 +74,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.148.0 // indirect
-	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.148.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.148.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling v0.148.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/connector/elasticapmconnector/testdata/config/full.yaml
+++ b/connector/elasticapmconnector/testdata/config/full.yaml
@@ -1,4 +1,5 @@
 elasticapm:
+  error_mode: silent
   aggregation:
     directory: /path/to/aggregation/state
     metadata_keys: [a, B, c]


### PR DESCRIPTION
## Summary

Backport of #1150 (`f73af6f84b26`) to the v0.39.x line, targeting a release as `connector/elasticapmconnector/v0.39.1`.

This avoids pulling in the v0.149.0 OTel dependency bump that comes with v0.43.0.

### Changes

- Expose `error_mode` from the wrapped `signaltometricsconnector` in `elasticapmconnector`'s config
- Default to `propagate` (matching upstream behavior)
- Valid values: `propagate`, `ignore`, `silent`
- The only `go.mod` change is promoting `pkg/ottl v0.148.0` from indirect to direct — no version bumps

### Context

Needed for PR #2881 which uses `error_mode: ignore` to prevent a single malformed span from failing the entire batch and blocking the Kafka consumer.

### Test plan

- [ ] Review the diff against the original commit (#1150)
- [ ] Verify no v0.149.0 dependencies are introduced
- [ ] Once approved, tag `connector/elasticapmconnector/v0.39.1` and push


Made with [Cursor](https://cursor.com)