### PR TITLE
Handle representative count and composite spans for intake-v2

### DIFF
--- a/connector/elasticapmconnector/config.go
+++ b/connector/elasticapmconnector/config.go
@@ -389,19 +389,54 @@ func (cfg Config) signaltometricsConfig() *signaltometricsconfig.Config {
 			Unit:      "us",
 			Histogram: configoptional.Some(transactionDurationSummaryHistogram),
 		}, {
+			// For composite spans, the response time sum is the composite
+			// duration (total of all compressed sub-spans).
 			Name:                      "span.destination.service.response_time.sum.us",
 			Description:               "APM span destination metrics",
 			IncludeResourceAttributes: spanDestinationResourceAttributes,
 			Attributes:                spanDestinationAttributes,
-			Unit:                      "us",
+			Conditions: []string{
+				`attributes["span.composite.sum.us"] != nil`,
+			},
+			Unit: "us",
+			Sum: configoptional.Some(signaltometricsconfig.Sum{
+				Value: `Double(attributes["span.composite.sum.us"])`,
+			}),
+		}, {
+			// For non-composite spans, use the span wall-clock duration.
+			Name:                      "span.destination.service.response_time.sum.us",
+			Description:               "APM span destination metrics",
+			IncludeResourceAttributes: spanDestinationResourceAttributes,
+			Attributes:                spanDestinationAttributes,
+			Conditions: []string{
+				`attributes["span.composite.sum.us"] == nil`,
+			},
+			Unit: "us",
 			Sum: configoptional.Some(signaltometricsconfig.Sum{
 				Value: "Double(Microseconds(end_time - start_time))",
 			}),
 		}, {
+			// For composite spans, the count is the number of compressed
+			// operations.
 			Name:                      "span.destination.service.response_time.count",
 			Description:               "APM span destination metrics",
 			IncludeResourceAttributes: spanDestinationResourceAttributes,
 			Attributes:                spanDestinationAttributes,
+			Conditions: []string{
+				`attributes["span.composite.count"] != nil`,
+			},
+			Sum: configoptional.Some(signaltometricsconfig.Sum{
+				Value: `Int(attributes["span.composite.count"])`,
+			}),
+		}, {
+			// For non-composite spans, count is the sampling weight.
+			Name:                      "span.destination.service.response_time.count",
+			Description:               "APM span destination metrics",
+			IncludeResourceAttributes: spanDestinationResourceAttributes,
+			Attributes:                spanDestinationAttributes,
+			Conditions: []string{
+				`attributes["span.composite.count"] == nil`,
+			},
 			Sum: configoptional.Some(signaltometricsconfig.Sum{
 				Value: "Int(AdjustedCount())",
 			}),

--- a/receiver/elasticapmintakereceiver/internal/mappers/intakeV2ToOtlpTopLevelFields.go
+++ b/receiver/elasticapmintakereceiver/internal/mappers/intakeV2ToOtlpTopLevelFields.go
@@ -121,7 +121,15 @@ func probabilityToTValue(probability float64) string {
 	if probability == 1 {
 		return "0"
 	}
-	threshold := uint64(math.Round((1.0 - probability) * (1 << 56)))
+	const maxThreshold = (1 << 56) - 1
+	raw := math.Round((1.0 - probability) * (1 << 56))
+	if raw < 0 {
+		raw = 0
+	}
+	if raw > maxThreshold {
+		raw = maxThreshold
+	}
+	threshold := uint64(raw)
 	s := fmt.Sprintf("%014x", threshold)
 	s = strings.TrimRight(s, "0")
 	if s == "" {

--- a/receiver/elasticapmintakereceiver/internal/mappers/intakeV2ToOtlpTopLevelFields.go
+++ b/receiver/elasticapmintakereceiver/internal/mappers/intakeV2ToOtlpTopLevelFields.go
@@ -100,6 +100,7 @@ func SetTopLevelFieldsSpan(event *modelpb.APMEvent, timestampNanos uint64, s ptr
 	// correct sampling weight. We only set the tracestate when the
 	// representative count differs from 1 (the AdjustedCount default)
 	// to avoid noisy tracestate on every span.
+	// see: https://opentelemetry.io/docs/specs/otel/trace/tracestate-handling/#sampling-threshold-value-th
 	if span := event.GetSpan(); span != nil {
 		repCount := span.GetRepresentativeCount()
 		if repCount > 0 && repCount != 1 {

--- a/receiver/elasticapmintakereceiver/internal/mappers/intakeV2ToOtlpTopLevelFields.go
+++ b/receiver/elasticapmintakereceiver/internal/mappers/intakeV2ToOtlpTopLevelFields.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"math"
 	"strings"
-	"time"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
@@ -93,36 +92,19 @@ func SetTopLevelFieldsSpan(event *modelpb.APMEvent, timestampNanos uint64, s ptr
 	}
 
 	durationNanos := event.GetEvent().GetDuration()
-
-	// For composite spans, use the composite sum as the effective duration
-	// so that downstream aggregation (end_time - start_time) reflects the
-	// total duration of all compressed sub-spans.
-	if composite := event.GetSpan().GetComposite(); composite != nil {
-		compositeSumNanos := uint64(composite.GetSum() * float64(time.Millisecond))
-		durationNanos = compositeSumNanos
-	}
-
 	s.SetStartTimestamp(pcommon.Timestamp(timestampNanos))
 	s.SetEndTimestamp(pcommon.Timestamp(timestampNanos + durationNanos))
 
-	// Encode the effective representative count into the W3C tracestate
-	// so that AdjustedCount() in the signal-to-metrics connector returns
-	// the correct multiplier. For composite spans, the effective count is
-	// composite.count * representative_count. For non-composite spans, it
-	// is representative_count alone.
-	//
-	// We only set the tracestate when the effective count differs from 1
-	// (the default AdjustedCount) to avoid noisy tracestate on every span.
+	// Encode representative_count into the W3C tracestate so that
+	// AdjustedCount() in the signal-to-metrics connector returns the
+	// correct sampling weight. We only set the tracestate when the
+	// representative count differs from 1 (the AdjustedCount default)
+	// to avoid noisy tracestate on every span.
 	if span := event.GetSpan(); span != nil {
 		repCount := span.GetRepresentativeCount()
-		if repCount > 0 {
-			if composite := span.GetComposite(); composite != nil && composite.GetCount() > 0 {
-				repCount *= float64(composite.GetCount())
-			}
-			if repCount != 1 {
-				if tvalue := probabilityToTValue(1.0 / repCount); tvalue != "" {
-					s.TraceState().FromRaw(fmt.Sprintf("ot=th:%s", tvalue))
-				}
+		if repCount > 0 && repCount != 1 {
+			if tvalue := probabilityToTValue(1.0 / repCount); tvalue != "" {
+				s.TraceState().FromRaw(fmt.Sprintf("ot=th:%s", tvalue))
 			}
 		}
 	}
@@ -137,11 +119,9 @@ func probabilityToTValue(probability float64) string {
 		return ""
 	}
 	if probability == 1 {
-		// Always-sample threshold: T-value "0"
 		return "0"
 	}
 	threshold := uint64(math.Round((1.0 - probability) * (1 << 56)))
-	// Encode as hex, stripping trailing zeros for canonical form
 	s := fmt.Sprintf("%014x", threshold)
 	s = strings.TrimRight(s, "0")
 	if s == "" {

--- a/receiver/elasticapmintakereceiver/internal/mappers/intakeV2ToOtlpTopLevelFields.go
+++ b/receiver/elasticapmintakereceiver/internal/mappers/intakeV2ToOtlpTopLevelFields.go
@@ -18,7 +18,10 @@
 package mappers // import "github.com/elastic/opentelemetry-collector-components/receiver/elasticapmintakereceiver/internal/mappers"
 
 import (
+	"fmt"
+	"math"
 	"strings"
+	"time"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
@@ -90,8 +93,61 @@ func SetTopLevelFieldsSpan(event *modelpb.APMEvent, timestampNanos uint64, s ptr
 	}
 
 	durationNanos := event.GetEvent().GetDuration()
+
+	// For composite spans, use the composite sum as the effective duration
+	// so that downstream aggregation (end_time - start_time) reflects the
+	// total duration of all compressed sub-spans.
+	if composite := event.GetSpan().GetComposite(); composite != nil {
+		compositeSumNanos := uint64(composite.GetSum() * float64(time.Millisecond))
+		durationNanos = compositeSumNanos
+	}
+
 	s.SetStartTimestamp(pcommon.Timestamp(timestampNanos))
 	s.SetEndTimestamp(pcommon.Timestamp(timestampNanos + durationNanos))
+
+	// Encode the effective representative count into the W3C tracestate
+	// so that AdjustedCount() in the signal-to-metrics connector returns
+	// the correct multiplier. For composite spans, the effective count is
+	// composite.count * representative_count. For non-composite spans, it
+	// is representative_count alone.
+	//
+	// We only set the tracestate when the effective count differs from 1
+	// (the default AdjustedCount) to avoid noisy tracestate on every span.
+	if span := event.GetSpan(); span != nil {
+		repCount := span.GetRepresentativeCount()
+		if repCount > 0 {
+			if composite := span.GetComposite(); composite != nil && composite.GetCount() > 0 {
+				repCount *= float64(composite.GetCount())
+			}
+			if repCount != 1 {
+				if tvalue := probabilityToTValue(1.0 / repCount); tvalue != "" {
+					s.TraceState().FromRaw(fmt.Sprintf("ot=th:%s", tvalue))
+				}
+			}
+		}
+	}
+}
+
+// probabilityToTValue converts a sampling probability (0, 1] to a W3C
+// tracestate T-value hex string. The T-value encodes the rejection
+// threshold: threshold = (1 - probability) * 2^56. AdjustedCount() then
+// returns 1/probability.
+func probabilityToTValue(probability float64) string {
+	if probability <= 0 || probability > 1 {
+		return ""
+	}
+	if probability == 1 {
+		// Always-sample threshold: T-value "0"
+		return "0"
+	}
+	threshold := uint64(math.Round((1.0 - probability) * (1 << 56)))
+	// Encode as hex, stripping trailing zeros for canonical form
+	s := fmt.Sprintf("%014x", threshold)
+	s = strings.TrimRight(s, "0")
+	if s == "" {
+		return "0"
+	}
+	return s
 }
 
 // Sets top level fields on plog.LogRecord based on the APMEvent

--- a/receiver/elasticapmintakereceiver/receiver_test.go
+++ b/receiver/elasticapmintakereceiver/receiver_test.go
@@ -574,6 +574,7 @@ var inputFiles = []struct {
 	{"language_name_mapping.ndjson", "language_name_mapping_expected.yaml", nil},
 	{"span-links.ndjson", "span-links_expected.yaml", nil},
 	{"hostdata.ndjson", "hostdata_expected.yaml", nil},
+	{"spans_representative_count.ndjson", "spans_representative_count_expected.yaml", nil},
 }
 
 func TestTransactionsAndSpans(t *testing.T) {

--- a/receiver/elasticapmintakereceiver/testdata/spans_expected.yaml
+++ b/receiver/elasticapmintakereceiver/testdata/spans_expected.yaml
@@ -2107,12 +2107,13 @@ resourceSpans:
               - key: span.representative_count
                 value:
                   doubleValue: 1
-            endTimeUnixNano: "1532976822422581000"
+            endTimeUnixNano: "1532976822281000000"
             name: Rabbitmq receive
             parentSpanId: abcdef0123456789
             startTimeUnixNano: "1532976822281000000"
             status: {}
             traceId: fdedef0123456789abcdef9876543210
+            traceState: ot=th:e6666666666668
   - resource:
       attributes:
         - key: service.name
@@ -2290,7 +2291,7 @@ resourceSpans:
               - key: span.representative_count
                 value:
                   doubleValue: 1
-            endTimeUnixNano: "1625572686060463200"
+            endTimeUnixNano: "1625572686041570100"
             name: SELECT FROM p_details
             parentSpanId: abcdef0123456789
             spanId: abcdef0123456700
@@ -2298,3 +2299,4 @@ resourceSpans:
             status:
               code: 1
             traceId: edcbaf0123456789abcdef9876543210
+            traceState: ot=th:e6666666666668

--- a/receiver/elasticapmintakereceiver/testdata/spans_expected.yaml
+++ b/receiver/elasticapmintakereceiver/testdata/spans_expected.yaml
@@ -2107,13 +2107,12 @@ resourceSpans:
               - key: span.representative_count
                 value:
                   doubleValue: 1
-            endTimeUnixNano: "1532976822281000000"
+            endTimeUnixNano: "1532976822422581000"
             name: Rabbitmq receive
             parentSpanId: abcdef0123456789
             startTimeUnixNano: "1532976822281000000"
             status: {}
             traceId: fdedef0123456789abcdef9876543210
-            traceState: ot=th:e6666666666668
   - resource:
       attributes:
         - key: service.name
@@ -2291,7 +2290,7 @@ resourceSpans:
               - key: span.representative_count
                 value:
                   doubleValue: 1
-            endTimeUnixNano: "1625572686041570100"
+            endTimeUnixNano: "1625572686060463200"
             name: SELECT FROM p_details
             parentSpanId: abcdef0123456789
             spanId: abcdef0123456700
@@ -2299,4 +2298,3 @@ resourceSpans:
             status:
               code: 1
             traceId: edcbaf0123456789abcdef9876543210
-            traceState: ot=th:e6666666666668

--- a/receiver/elasticapmintakereceiver/testdata/spans_representative_count.ndjson
+++ b/receiver/elasticapmintakereceiver/testdata/spans_representative_count.ndjson
@@ -1,0 +1,2 @@
+{"metadata": {"service": {"name": "rep-count-test", "agent": {"name": "elastic-node", "version": "1.0.0"}}}}
+{"span": {"trace_id": "abcdef0123456789abcdef9876543210", "parent_id": "0000000011111111", "id": "abcdef0123456789", "transaction_id": "ab45781d265894fe", "name": "GET /api", "type": "request", "duration": 10, "timestamp": 1532976822281000, "sample_rate": 0.25, "outcome": "success", "context": {"destination": {"service": {"resource": "api.example.com:443"}}}}}

--- a/receiver/elasticapmintakereceiver/testdata/spans_representative_count_expected.yaml
+++ b/receiver/elasticapmintakereceiver/testdata/spans_representative_count_expected.yaml
@@ -1,0 +1,70 @@
+resourceSpans:
+  - resource:
+      attributes:
+        - key: service.name
+          value:
+            stringValue: rep-count-test
+        - key: telemetry.sdk.name
+          value:
+            stringValue: ElasticAPM
+        - key: agent.name
+          value:
+            stringValue: elastic-node
+        - key: agent.version
+          value:
+            stringValue: 1.0.0
+    scopeSpans:
+      - scope: {}
+        spans:
+          - attributes:
+              - key: timestamp.us
+                value:
+                  intValue: "1532976822281000"
+              - key: event.outcome
+                value:
+                  stringValue: success
+              - key: processor.event
+                value:
+                  stringValue: span
+              - key: span.duration.us
+                value:
+                  intValue: "10000"
+              - key: transaction.id
+                value:
+                  stringValue: ab45781d265894fe
+              - key: service.target.type
+                value:
+                  stringValue: ""
+              - key: service.target.name
+                value:
+                  stringValue: api.example.com:443
+              - key: span.id
+                value:
+                  stringValue: abcdef0123456789
+              - key: span.name
+                value:
+                  stringValue: GET /api
+              - key: span.type
+                value:
+                  stringValue: request
+              - key: span.destination.service.resource
+                value:
+                  stringValue: api.example.com:443
+              - key: span.destination.service.name
+                value:
+                  stringValue: ""
+              - key: span.destination.service.type
+                value:
+                  stringValue: ""
+              - key: span.representative_count
+                value:
+                  doubleValue: 4
+            endTimeUnixNano: "1532976822291000000"
+            name: GET /api
+            parentSpanId: "0000000011111111"
+            spanId: abcdef0123456789
+            startTimeUnixNano: "1532976822281000000"
+            status:
+              code: 1
+            traceId: abcdef0123456789abcdef9876543210
+            traceState: ot=th:c


### PR DESCRIPTION
  - Encode `representative_count` into W3C tracestate T-value in the intake receiver so that `AdjustedCount()` in the signal-to-metrics connector returns the correct sampling weight
  - Handle composite spans in the connector by reading `span.composite.count` and `span.composite.sum.us` attributes for span destination metrics instead of using span wall-clock duration and default count of 1
 
Closes: https://github.com/elastic/hosted-otel-collector/issues/2710