### PR TITLE
[intakereceiver]Fix global labels shadowing

### DIFF
--- a/receiver/elasticapmintakereceiver/receiver.go
+++ b/receiver/elasticapmintakereceiver/receiver.go
@@ -261,7 +261,7 @@ func (r *elasticAPMIntakeReceiver) processBatch(ctx context.Context, batch *mode
 		for key, lv := range event.Labels {
 			if lv != nil && lv.Global {
 				if _, ok := keyIndex[key]; !ok {
-					keyIndex[key] = globalKeyInfo{bitPos: bitPos, isNumeric: false}
+					keyIndex[key] = globalKeyInfo{bitPos: bitPos, prefixedKey: "labels." + key}
 					bitPos++
 				}
 			}
@@ -269,7 +269,7 @@ func (r *elasticAPMIntakeReceiver) processBatch(ctx context.Context, batch *mode
 		for key, nv := range event.NumericLabels {
 			if nv != nil && nv.Global {
 				if _, ok := keyIndex[key]; !ok {
-					keyIndex[key] = globalKeyInfo{bitPos: bitPos, isNumeric: true}
+					keyIndex[key] = globalKeyInfo{bitPos: bitPos, prefixedKey: "numeric_labels." + key}
 					bitPos++
 				}
 			}
@@ -419,10 +419,11 @@ func (r *elasticAPMIntakeReceiver) consumeOTel(ctx context.Context, ld *plog.Log
 	return errs
 }
 
-// globalKeyInfo stores a global label key's bit position and type.
+// globalKeyInfo stores a global label key's bit position and its
+// prefixed name for use in x-elastic-dynamic-resource-attributes.
 type globalKeyInfo struct {
-	bitPos    int
-	isNumeric bool
+	bitPos      int
+	prefixedKey string
 }
 
 // setResourceAttributes maps event fields to attributes.
@@ -844,15 +845,11 @@ func eventGlobalMask(event *modelpb.APMEvent, keyIndex map[string]globalKeyInfo)
 // names. If mask is nil, all keys in keyIndex are included.
 func resolveGlobalKeys(mask *big.Int, keyIndex map[string]globalKeyInfo) []string {
 	keys := make([]string, 0, len(keyIndex))
-	for key, info := range keyIndex {
+	for _, info := range keyIndex {
 		if mask != nil && mask.Bit(info.bitPos) == 0 {
 			continue
 		}
-		if info.isNumeric {
-			keys = append(keys, "numeric_labels."+key)
-		} else {
-			keys = append(keys, "labels."+key)
-		}
+		keys = append(keys, info.prefixedKey)
 	}
 	return keys
 }

--- a/receiver/elasticapmintakereceiver/receiver.go
+++ b/receiver/elasticapmintakereceiver/receiver.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"hash"
+	"math/big"
 	"net"
 	"net/http"
 	"strings"
@@ -225,9 +226,9 @@ func (r *elasticAPMIntakeReceiver) newElasticAPMEventsHandler(ctxFunc func(*http
 }
 
 func (r *elasticAPMIntakeReceiver) processBatch(ctx context.Context, batch *modelpb.Batch) error {
-	ld := plog.NewLogs()
-	md := pmetric.NewMetrics()
-	td := ptrace.NewTraces()
+	var ld *plog.Logs
+	var md *pmetric.Metrics
+	var td *ptrace.Traces
 
 	processors := modelprocessor.Chained{
 		modelprocessor.SetGroupingKey{
@@ -242,112 +243,186 @@ func (r *elasticAPMIntakeReceiver) processBatch(ctx context.Context, batch *mode
 		r.settings.Logger.Error("failed to process batch", zap.Error(err))
 	}
 
-	// Collect label keys marked as Global across all events. Global labels
-	// originate from the intake v2 metadata and are cloned onto every event
-	// by the apm-data library (see GlobalLabelsFrom):
-	// https://github.com/elastic/apm-data/blob/main/input/elasticapm/internal/modeldecoder/modeldecoderutil/labels.go
+	// Collect label keys marked as Global across all events, assigning each
+	// unique key a bit position. Global labels originate from the intake v2
+	// metadata and are cloned onto every event by the apm-data library.
 	//
-	// We scan all events rather than just the first because an event-level
-	// tag can shadow a metadata label, flipping its Global flag to false on
-	// that particular event (see Labels.Set):
-	// https://github.com/elastic/apm-data/blob/main/model/modelpb/labels.go
-	//
-	// Note: this collects the union of global keys across the batch, which
-	// differs from apm-aggregation where global labels are evaluated
-	// per-event (see marshalEventGlobalLabels):
-	// https://github.com/elastic/apm-aggregation/blob/main/aggregators/converter.go
-	// If an event shadows a global key, apm-aggregation excludes that key
-	// from that event's aggregation grouping. Here, the shadowed key is
-	// still included in x-elastic-dynamic-resource-attributes because we operate
-	// at the batch level, not per-event.
-	labelKeySet := make(map[string]struct{})
-	numericKeySet := make(map[string]struct{})
+	// When an event has a tag with the same key as a metadata label,
+	// Labels.Set() replaces the value and resets Global to false on that
+	// event only. To match apm-aggregation's per-event behavior
+	// (marshalEventGlobalLabels), events that shadow a global key are
+	// separated into shadowed batches grouped by their effective global key
+	// set (represented as a bitmask). Each shadowed batch is consumed with
+	// its own context so that the shadowed key is excluded from
+	// "x-elastic-dynamic-resource-attributes" for those events.
+	keyIndex := make(map[string]globalKeyInfo)
+	bitPos := 0
 	for _, event := range *batch {
 		for key, lv := range event.Labels {
 			if lv != nil && lv.Global {
-				labelKeySet[key] = struct{}{}
+				if _, ok := keyIndex[key]; !ok {
+					keyIndex[key] = globalKeyInfo{bitPos: bitPos, isNumeric: false}
+					bitPos++
+				}
 			}
 		}
 		for key, nv := range event.NumericLabels {
 			if nv != nil && nv.Global {
-				numericKeySet[key] = struct{}{}
+				if _, ok := keyIndex[key]; !ok {
+					keyIndex[key] = globalKeyInfo{bitPos: bitPos, isNumeric: true}
+					bitPos++
+				}
 			}
-		}
-
-		timestampNanos := event.GetTimestamp()
-
-		// TODO record metrics about events processed by type?
-		switch event.Type() {
-		case modelpb.MetricEventType:
-			rm := md.ResourceMetrics().AppendEmpty()
-
-			r.setResourceAttributes(rm.Resource().Attributes(), event)
-
-			if err := r.elasticMetricsToOtelMetrics(&rm, event, timestampNanos); err != nil {
-				return err
-			}
-		case modelpb.ErrorEventType:
-			rl := ld.ResourceLogs().AppendEmpty()
-
-			r.setResourceAttributes(rl.Resource().Attributes(), event)
-
-			r.elasticErrorToOtelLogRecord(&rl, event, timestampNanos)
-		case modelpb.LogEventType:
-			rl := ld.ResourceLogs().AppendEmpty()
-
-			r.setResourceAttributes(rl.Resource().Attributes(), event)
-
-			r.elasticLogToOtelLogRecord(&rl, event, timestampNanos)
-		case modelpb.SpanEventType, modelpb.TransactionEventType:
-			rs := td.ResourceSpans().AppendEmpty()
-
-			r.setResourceAttributes(rs.Resource().Attributes(), event)
-
-			s := r.elasticEventToOtelSpan(&rs, event, timestampNanos)
-
-			isTransaction := event.Type() == modelpb.TransactionEventType
-			if isTransaction {
-				r.elasticTransactionToOtelSpan(&s, event)
-			} else {
-				r.elasticSpanToOTelSpan(&s, event)
-			}
-		default:
-			return fmt.Errorf("unhandled event type %q", event.Type())
 		}
 	}
 
-	// collect all unique global label keys to add to the client metadata
-	if len(labelKeySet)+len(numericKeySet) > 0 {
-		globalKeys := make([]string, 0, len(labelKeySet)+len(numericKeySet))
-		for k := range labelKeySet {
-			globalKeys = append(globalKeys, "labels."+k)
+	var shadowedBatches []shadowedBatch
+	var shadowIndex map[string]int // mask.String() → index, created lazily
+
+	for _, event := range *batch {
+		if !eventShadowsGlobalKey(event, keyIndex) {
+			if err := r.appendEvent(event, &ld, &md, &td); err != nil {
+				return err
+			}
+			continue
 		}
-		for k := range numericKeySet {
-			globalKeys = append(globalKeys, "numeric_labels."+k)
+
+		mask := eventGlobalMask(event, keyIndex)
+		maskKey := mask.String()
+		if shadowIndex == nil {
+			shadowIndex = make(map[string]int)
 		}
-		ctx = withDynamicResourceAttributes(ctx, globalKeys)
+		if idx, ok := shadowIndex[maskKey]; ok {
+			if err := r.appendEvent(event, &shadowedBatches[idx].ld, &shadowedBatches[idx].md, &shadowedBatches[idx].td); err != nil {
+				return err
+			}
+		} else {
+			shadowIndex[maskKey] = len(shadowedBatches)
+			sb := shadowedBatch{
+				globalKeyMask: mask,
+			}
+			if err := r.appendEvent(event, &sb.ld, &sb.md, &sb.td); err != nil {
+				return err
+			}
+			shadowedBatches = append(shadowedBatches, sb)
+		}
+	}
+
+	// Consume the main batch with the full set of global keys.
+	mainCtx := ctx
+	if len(keyIndex) > 0 {
+		mainCtx = withDynamicResourceAttributes(ctx, resolveGlobalKeys(nil, keyIndex))
 	}
 
 	var errs []error
-	if numRecords := ld.LogRecordCount(); numRecords != 0 && r.nextLogs != nil {
-		ctx := r.obsreport.StartLogsOp(ctx)
-		err := r.nextLogs.ConsumeLogs(ctx, ld)
-		r.obsreport.EndLogsOp(ctx, dataFormatElasticAPM, numRecords, err)
-		errs = append(errs, err)
-	}
-	if numDataPoints := md.DataPointCount(); numDataPoints != 0 && r.nextMetrics != nil {
-		ctx := r.obsreport.StartMetricsOp(ctx)
-		err := r.nextMetrics.ConsumeMetrics(ctx, md)
-		r.obsreport.EndMetricsOp(ctx, dataFormatElasticAPM, numDataPoints, err)
-		errs = append(errs, err)
-	}
-	if numSpans := td.SpanCount(); numSpans != 0 && r.nextTraces != nil {
-		ctx := r.obsreport.StartTracesOp(ctx)
-		err := r.nextTraces.ConsumeTraces(ctx, td)
-		r.obsreport.EndTracesOp(ctx, dataFormatElasticAPM, numSpans, err)
-		errs = append(errs, err)
+	errs = append(errs, r.consumeOTel(mainCtx, ld, md, td)...)
+
+	// Consume shadowed batches, each with its own global key set.
+	for _, sb := range shadowedBatches {
+		sbCtx := withDynamicResourceAttributes(ctx, resolveGlobalKeys(&sb.globalKeyMask, keyIndex))
+		errs = append(errs, r.consumeOTel(sbCtx, sb.ld, sb.md, sb.td)...)
 	}
 	return errors.Join(errs...)
+}
+
+// appendEvent converts an APM event to its OTel representation and appends
+// it to the appropriate pdata structure. The pdata pointers are lazily
+// initialized on first use.
+func (r *elasticAPMIntakeReceiver) appendEvent(event *modelpb.APMEvent, ld **plog.Logs, md **pmetric.Metrics, td **ptrace.Traces) error {
+	timestampNanos := event.GetTimestamp()
+
+	// TODO record metrics about events processed by type?
+	switch event.Type() {
+	case modelpb.MetricEventType:
+		if *md == nil {
+			m := pmetric.NewMetrics()
+			*md = &m
+		}
+		rm := (*md).ResourceMetrics().AppendEmpty()
+
+		r.setResourceAttributes(rm.Resource().Attributes(), event)
+
+		if err := r.elasticMetricsToOtelMetrics(&rm, event, timestampNanos); err != nil {
+			return err
+		}
+	case modelpb.ErrorEventType:
+		if *ld == nil {
+			l := plog.NewLogs()
+			*ld = &l
+		}
+		rl := (*ld).ResourceLogs().AppendEmpty()
+
+		r.setResourceAttributes(rl.Resource().Attributes(), event)
+
+		r.elasticErrorToOtelLogRecord(&rl, event, timestampNanos)
+	case modelpb.LogEventType:
+		if *ld == nil {
+			l := plog.NewLogs()
+			*ld = &l
+		}
+		rl := (*ld).ResourceLogs().AppendEmpty()
+
+		r.setResourceAttributes(rl.Resource().Attributes(), event)
+
+		r.elasticLogToOtelLogRecord(&rl, event, timestampNanos)
+	case modelpb.SpanEventType, modelpb.TransactionEventType:
+		if *td == nil {
+			tr := ptrace.NewTraces()
+			*td = &tr
+		}
+		rs := (*td).ResourceSpans().AppendEmpty()
+
+		r.setResourceAttributes(rs.Resource().Attributes(), event)
+
+		s := r.elasticEventToOtelSpan(&rs, event, timestampNanos)
+
+		isTransaction := event.Type() == modelpb.TransactionEventType
+		if isTransaction {
+			r.elasticTransactionToOtelSpan(&s, event)
+		} else {
+			r.elasticSpanToOTelSpan(&s, event)
+		}
+	default:
+		return fmt.Errorf("unhandled event type %q", event.Type())
+	}
+	return nil
+}
+
+// consumeOTel sends the populated pdata structures to downstream consumers.
+// Nil pointers are skipped.
+func (r *elasticAPMIntakeReceiver) consumeOTel(ctx context.Context, ld *plog.Logs, md *pmetric.Metrics, td *ptrace.Traces) []error {
+	var errs []error
+	if ld != nil {
+		if numRecords := ld.LogRecordCount(); numRecords != 0 && r.nextLogs != nil {
+			obsCtx := r.obsreport.StartLogsOp(ctx)
+			err := r.nextLogs.ConsumeLogs(obsCtx, *ld)
+			r.obsreport.EndLogsOp(obsCtx, dataFormatElasticAPM, numRecords, err)
+			errs = append(errs, err)
+		}
+	}
+	if md != nil {
+		if numDataPoints := md.DataPointCount(); numDataPoints != 0 && r.nextMetrics != nil {
+			obsCtx := r.obsreport.StartMetricsOp(ctx)
+			err := r.nextMetrics.ConsumeMetrics(obsCtx, *md)
+			r.obsreport.EndMetricsOp(obsCtx, dataFormatElasticAPM, numDataPoints, err)
+			errs = append(errs, err)
+		}
+	}
+	if td != nil {
+		if numSpans := td.SpanCount(); numSpans != 0 && r.nextTraces != nil {
+			obsCtx := r.obsreport.StartTracesOp(ctx)
+			err := r.nextTraces.ConsumeTraces(obsCtx, *td)
+			r.obsreport.EndTracesOp(obsCtx, dataFormatElasticAPM, numSpans, err)
+			errs = append(errs, err)
+		}
+	}
+	return errs
+}
+
+// globalKeyInfo stores a global label key's bit position and type.
+type globalKeyInfo struct {
+	bitPos    int
+	isNumeric bool
 }
 
 // setResourceAttributes maps event fields to attributes.
@@ -711,4 +786,73 @@ func withDynamicResourceAttributes(ctx context.Context, globalLabelKeys []string
 		Auth:     info.Auth,
 		Metadata: client.NewMetadata(newMeta),
 	})
+}
+
+// shadowedBatch holds events that shadow at least one global label key
+// and share the same effective global key set (represented as a bitmask).
+// The pdata fields are lazily initialized by appendEvent on first use.
+type shadowedBatch struct {
+	globalKeyMask big.Int
+	ld            *plog.Logs
+	md            *pmetric.Metrics
+	td            *ptrace.Traces
+}
+
+// eventShadowsGlobalKey reports whether the event has a non-global label
+// whose key is present in the batch-level global key set, meaning an
+// event-level tag has shadowed a metadata label.
+func eventShadowsGlobalKey(event *modelpb.APMEvent, keyIndex map[string]globalKeyInfo) bool {
+	for key, lv := range event.Labels {
+		if lv != nil && !lv.Global {
+			if _, ok := keyIndex[key]; ok {
+				return true
+			}
+		}
+	}
+	for key, nv := range event.NumericLabels {
+		if nv != nil && !nv.Global {
+			if _, ok := keyIndex[key]; ok {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// eventGlobalMask returns a bitmask representing the global label keys
+// that are still Global: true on this event.
+func eventGlobalMask(event *modelpb.APMEvent, keyIndex map[string]globalKeyInfo) big.Int {
+	var mask big.Int
+	for key, lv := range event.Labels {
+		if lv != nil && lv.Global {
+			if info, ok := keyIndex[key]; ok {
+				mask.SetBit(&mask, info.bitPos, 1)
+			}
+		}
+	}
+	for key, nv := range event.NumericLabels {
+		if nv != nil && nv.Global {
+			if info, ok := keyIndex[key]; ok {
+				mask.SetBit(&mask, info.bitPos, 1)
+			}
+		}
+	}
+	return mask
+}
+
+// resolveGlobalKeys converts a bitmask back to prefixed global label key
+// names. If mask is nil, all keys in keyIndex are included.
+func resolveGlobalKeys(mask *big.Int, keyIndex map[string]globalKeyInfo) []string {
+	keys := make([]string, 0, len(keyIndex))
+	for key, info := range keyIndex {
+		if mask != nil && mask.Bit(info.bitPos) == 0 {
+			continue
+		}
+		if info.isNumeric {
+			keys = append(keys, "numeric_labels."+key)
+		} else {
+			keys = append(keys, "labels."+key)
+		}
+	}
+	return keys
 }

--- a/receiver/elasticapmintakereceiver/receiver.go
+++ b/receiver/elasticapmintakereceiver/receiver.go
@@ -280,14 +280,14 @@ func (r *elasticAPMIntakeReceiver) processBatch(ctx context.Context, batch *mode
 	var shadowIndex map[string]int // mask.String() → index, created lazily
 
 	for _, event := range *batch {
-		if !eventShadowsGlobalKey(event, keyIndex) {
+		mask, shadowed := eventShadowMask(event, keyIndex)
+		if !shadowed {
 			if err := r.appendEvent(event, &ld, &md, &td); err != nil {
 				return err
 			}
 			continue
 		}
 
-		mask := eventGlobalMask(event, keyIndex)
 		maskKey := mask.String()
 		if shadowIndex == nil {
 			shadowIndex = make(map[string]int)
@@ -799,46 +799,46 @@ type shadowedBatch struct {
 	td            *ptrace.Traces
 }
 
-// eventShadowsGlobalKey reports whether the event has a non-global label
-// whose key is present in the batch-level global key set, meaning an
-// event-level tag has shadowed a metadata label.
-func eventShadowsGlobalKey(event *modelpb.APMEvent, keyIndex map[string]globalKeyInfo) bool {
-	for key, lv := range event.Labels {
-		if lv != nil && !lv.Global {
-			if _, ok := keyIndex[key]; ok {
-				return true
-			}
-		}
-	}
-	for key, nv := range event.NumericLabels {
-		if nv != nil && !nv.Global {
-			if _, ok := keyIndex[key]; ok {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-// eventGlobalMask returns a bitmask representing the global label keys
-// that are still Global: true on this event.
-func eventGlobalMask(event *modelpb.APMEvent, keyIndex map[string]globalKeyInfo) big.Int {
+// eventShadowMask checks whether the event shadows any global label key
+// and returns a bitmask of the global keys that are still Global: true
+// on this event along with a bool indicating whether shadowing was
+// detected. When shadowed is false, the mask has all bits set (i.e. all
+// global keys are retained) and can be ignored — the bool avoids the
+// need to compare the mask against a full mask for this common case.
+// Events with identical masks need the same set of keys in their
+// x-elastic-dynamic-resource-attributes context and can share a batch.
+func eventShadowMask(event *modelpb.APMEvent, keyIndex map[string]globalKeyInfo) (big.Int, bool) {
 	var mask big.Int
+	var shadowed bool
 	for key, lv := range event.Labels {
-		if lv != nil && lv.Global {
-			if info, ok := keyIndex[key]; ok {
-				mask.SetBit(&mask, info.bitPos, 1)
-			}
+		if lv == nil {
+			continue
+		}
+		info, ok := keyIndex[key]
+		if !ok {
+			continue
+		}
+		if lv.Global {
+			mask.SetBit(&mask, info.bitPos, 1)
+		} else {
+			shadowed = true
 		}
 	}
 	for key, nv := range event.NumericLabels {
-		if nv != nil && nv.Global {
-			if info, ok := keyIndex[key]; ok {
-				mask.SetBit(&mask, info.bitPos, 1)
-			}
+		if nv == nil {
+			continue
+		}
+		info, ok := keyIndex[key]
+		if !ok {
+			continue
+		}
+		if nv.Global {
+			mask.SetBit(&mask, info.bitPos, 1)
+		} else {
+			shadowed = true
 		}
 	}
-	return mask
+	return mask, shadowed
 }
 
 // resolveGlobalKeys converts a bitmask back to prefixed global label key

--- a/receiver/elasticapmintakereceiver/receiver.go
+++ b/receiver/elasticapmintakereceiver/receiver.go
@@ -256,7 +256,7 @@ func (r *elasticAPMIntakeReceiver) processBatch(ctx context.Context, batch *mode
 	// its own context so that the shadowed key is excluded from
 	// "x-elastic-dynamic-resource-attributes" for those events.
 	keyIndex := make(map[string]globalKeyInfo)
-	bitPos := 0
+	var bitPos int
 	for _, event := range *batch {
 		for key, lv := range event.Labels {
 			if lv != nil && lv.Global {

--- a/receiver/elasticapmintakereceiver/receiver_bench_test.go
+++ b/receiver/elasticapmintakereceiver/receiver_bench_test.go
@@ -1,0 +1,125 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package elasticapmintakereceiver
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"testing"
+
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config/confighttp"
+	"go.opentelemetry.io/collector/config/confignet"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/receiver/receivertest"
+
+	"github.com/elastic/opentelemetry-collector-components/internal/testutil"
+	"github.com/elastic/opentelemetry-collector-components/receiver/elasticapmintakereceiver/internal/metadata"
+)
+
+// payloadGlobalLabelsNoShadow has 10 transactions with metadata global labels
+// (tag1 string, tag2 numeric). No event shadows any global label.
+var payloadGlobalLabelsNoShadow = []byte(`{"metadata": {"service": {"name": "bench-svc", "agent": {"name": "elastic-node", "version": "1.0.0"}}, "labels": {"tag1": "global_val", "tag2": 42}}}
+{"transaction": {"id": "aa00000000000001", "trace_id": "aa00000000000001aa00000000000001", "name": "tx1", "type": "request", "duration": 1, "timestamp": 1000000, "outcome": "success", "sampled": true, "span_count": {"started": 0}}}
+{"transaction": {"id": "aa00000000000002", "trace_id": "aa00000000000002aa00000000000002", "name": "tx2", "type": "request", "duration": 1, "timestamp": 2000000, "outcome": "success", "sampled": true, "span_count": {"started": 0}}}
+{"transaction": {"id": "aa00000000000003", "trace_id": "aa00000000000003aa00000000000003", "name": "tx3", "type": "request", "duration": 1, "timestamp": 3000000, "outcome": "success", "sampled": true, "span_count": {"started": 0}}}
+{"transaction": {"id": "aa00000000000004", "trace_id": "aa00000000000004aa00000000000004", "name": "tx4", "type": "request", "duration": 1, "timestamp": 4000000, "outcome": "success", "sampled": true, "span_count": {"started": 0}}}
+{"transaction": {"id": "aa00000000000005", "trace_id": "aa00000000000005aa00000000000005", "name": "tx5", "type": "request", "duration": 1, "timestamp": 5000000, "outcome": "success", "sampled": true, "span_count": {"started": 0}}}
+{"transaction": {"id": "aa00000000000006", "trace_id": "aa00000000000006aa00000000000006", "name": "tx6", "type": "request", "duration": 1, "timestamp": 6000000, "outcome": "success", "sampled": true, "span_count": {"started": 0}}}
+{"transaction": {"id": "aa00000000000007", "trace_id": "aa00000000000007aa00000000000007", "name": "tx7", "type": "request", "duration": 1, "timestamp": 7000000, "outcome": "success", "sampled": true, "span_count": {"started": 0}}}
+{"transaction": {"id": "aa00000000000008", "trace_id": "aa00000000000008aa00000000000008", "name": "tx8", "type": "request", "duration": 1, "timestamp": 8000000, "outcome": "success", "sampled": true, "span_count": {"started": 0}}}
+{"transaction": {"id": "aa00000000000009", "trace_id": "aa00000000000009aa00000000000009", "name": "tx9", "type": "request", "duration": 1, "timestamp": 9000000, "outcome": "success", "sampled": true, "span_count": {"started": 0}}}
+{"transaction": {"id": "aa0000000000000a", "trace_id": "aa0000000000000aaa0000000000000a", "name": "tx10", "type": "request", "duration": 1, "timestamp": 10000000, "outcome": "success", "sampled": true, "span_count": {"started": 0}}}
+`)
+
+// payloadGlobalLabelsWithShadow has 10 transactions with metadata global
+// labels (tag1 string, tag2 numeric). Transaction 3 shadows tag1 and
+// transaction 7 shadows tag2, producing two overflow groups.
+var payloadGlobalLabelsWithShadow = []byte(`{"metadata": {"service": {"name": "bench-svc", "agent": {"name": "elastic-node", "version": "1.0.0"}}, "labels": {"tag1": "global_val", "tag2": 42}}}
+{"transaction": {"id": "aa00000000000001", "trace_id": "aa00000000000001aa00000000000001", "name": "tx1", "type": "request", "duration": 1, "timestamp": 1000000, "outcome": "success", "sampled": true, "span_count": {"started": 0}}}
+{"transaction": {"id": "aa00000000000002", "trace_id": "aa00000000000002aa00000000000002", "name": "tx2", "type": "request", "duration": 1, "timestamp": 2000000, "outcome": "success", "sampled": true, "span_count": {"started": 0}}}
+{"transaction": {"id": "aa00000000000003", "trace_id": "aa00000000000003aa00000000000003", "name": "tx3", "type": "request", "duration": 1, "timestamp": 3000000, "outcome": "success", "sampled": true, "span_count": {"started": 0}, "context": {"tags": {"tag1": "event_val"}}}}
+{"transaction": {"id": "aa00000000000004", "trace_id": "aa00000000000004aa00000000000004", "name": "tx4", "type": "request", "duration": 1, "timestamp": 4000000, "outcome": "success", "sampled": true, "span_count": {"started": 0}}}
+{"transaction": {"id": "aa00000000000005", "trace_id": "aa00000000000005aa00000000000005", "name": "tx5", "type": "request", "duration": 1, "timestamp": 5000000, "outcome": "success", "sampled": true, "span_count": {"started": 0}}}
+{"transaction": {"id": "aa00000000000006", "trace_id": "aa00000000000006aa00000000000006", "name": "tx6", "type": "request", "duration": 1, "timestamp": 6000000, "outcome": "success", "sampled": true, "span_count": {"started": 0}}}
+{"transaction": {"id": "aa00000000000007", "trace_id": "aa00000000000007aa00000000000007", "name": "tx7", "type": "request", "duration": 1, "timestamp": 7000000, "outcome": "success", "sampled": true, "span_count": {"started": 0}, "context": {"tags": {"tag2": 99}}}}
+{"transaction": {"id": "aa00000000000008", "trace_id": "aa00000000000008aa00000000000008", "name": "tx8", "type": "request", "duration": 1, "timestamp": 8000000, "outcome": "success", "sampled": true, "span_count": {"started": 0}}}
+{"transaction": {"id": "aa00000000000009", "trace_id": "aa00000000000009aa00000000000009", "name": "tx9", "type": "request", "duration": 1, "timestamp": 9000000, "outcome": "success", "sampled": true, "span_count": {"started": 0}}}
+{"transaction": {"id": "aa0000000000000a", "trace_id": "aa0000000000000aaa0000000000000a", "name": "tx10", "type": "request", "duration": 1, "timestamp": 10000000, "outcome": "success", "sampled": true, "span_count": {"started": 0}}}
+`)
+
+func BenchmarkProcessBatch(b *testing.B) {
+	cases := []struct {
+		name    string
+		payload []byte
+	}{
+		{"global_labels_no_shadow", payloadGlobalLabelsNoShadow},
+		{"global_labels_with_shadow", payloadGlobalLabelsWithShadow},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			factory := NewFactory()
+			endpoint := testutil.GetAvailableLocalAddress(b)
+			cfg := &Config{
+				ServerConfig: confighttp.ServerConfig{
+					NetAddr: confignet.AddrConfig{
+						Endpoint:  endpoint,
+						Transport: confignet.TransportTypeTCP,
+					},
+				},
+			}
+
+			set := receivertest.NewNopSettings(metadata.Type)
+			sink := new(consumertest.TracesSink)
+			rcv, err := factory.CreateTraces(context.Background(), set, cfg, sink)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if err := rcv.Start(context.Background(), componenttest.NewNopHost()); err != nil {
+				b.Fatal(err)
+			}
+			defer func() { _ = rcv.Shutdown(context.Background()) }()
+
+			url := "http://" + endpoint + intakeV2EventsPath
+
+			// Warm up: send one request to ensure the server is ready.
+			resp, err := http.Post(url, "application/x-ndjson", bytes.NewReader(tc.payload))
+			if err != nil {
+				b.Fatal(err)
+			}
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+
+			sink.Reset()
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			for i := 0; i < b.N; i++ {
+				resp, err := http.Post(url, "application/x-ndjson", bytes.NewReader(tc.payload))
+				if err != nil {
+					b.Fatal(err)
+				}
+				_, _ = io.Copy(io.Discard, resp.Body)
+				_ = resp.Body.Close()
+			}
+		})
+	}
+}

--- a/receiver/elasticapmintakereceiver/receiver_test.go
+++ b/receiver/elasticapmintakereceiver/receiver_test.go
@@ -42,6 +42,9 @@ import (
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/confignet"
 	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 
 	"github.com/elastic/opentelemetry-collector-components/internal/elasticattr"
@@ -682,7 +685,11 @@ func TestGlobalLabelsMetadataPropagation(t *testing.T) {
 		inputFile            string
 		signal               string // "traces" or "metrics"
 		expectedDynamicAttrs []string
-		expectedYamlFile     string // if non-empty, compare output against this golden file
+		// expectedPerGroupDynamicAttrs, if set, verifies each group's
+		// context independently (one entry per ConsumeX call, in order).
+		// When set, expectedDynamicAttrs is ignored.
+		expectedPerGroupDynamicAttrs [][]string
+		expectedYamlFile             string // if non-empty, compare output against this golden file
 	}{
 		{
 			name:                 "metadata global labels propagated",
@@ -696,22 +703,20 @@ func TestGlobalLabelsMetadataPropagation(t *testing.T) {
 			// same key as a metadata label, Labels.Set() replaces the value
 			// and resets Global to false on that event only.
 			//
-			// In apm-aggregation, marshalEventGlobalLabels() checks Global
-			// per-event, so the shadowed event would exclude that key from
-			// its aggregation grouping. Here, we collect the union of global
-			// keys across all events in the batch, so the shadowed key is
-			// still present in x-elastic-dynamic-resource-attributes as long as at
-			// least one other event retains it as Global: true.
-			//
-			// This test sends two metricsets: one without tags (global_tag
-			// stays Global: true) and one with tags: {"global_tag": "from_event"}
-			// which shadows the metadata label (Global: false on that event).
-			// The key "global_tag" should still appear in the dynamic attrs.
-			name:                 "event-level tag shadows metadata global label",
-			inputFile:            "metric_global_label_shadow.ndjson",
-			signal:               "metrics",
-			expectedDynamicAttrs: []string{"labels.global_tag"},
-			expectedYamlFile:     "metric_global_label_shadow_expected.yaml",
+			// Events are grouped by their per-event global key set (bitmask)
+			// to match apm-aggregation's per-event behavior:
+			//   - Event 1: no tags → both globals retained → main batch
+			//   - Events 2,3: shadow global_tag → grouped (same mask) → shadowed batch A
+			//   - Event 4: shadows num_tag → different mask → shadowed batch B
+			name:      "event-level tag shadows metadata global label",
+			inputFile: "metric_global_label_shadow.ndjson",
+			signal:    "metrics",
+			expectedPerGroupDynamicAttrs: [][]string{
+				{"labels.global_tag", "numeric_labels.num_tag"}, // main: event 1, both globals
+				{"numeric_labels.num_tag"},                      // shadowed batch A: events 2,3 shadow global_tag
+				{"labels.global_tag"},                           // shadowed batch B: event 4 shadows num_tag
+			},
+			expectedYamlFile: "metric_global_label_shadow_expected.yaml",
 		},
 	}
 
@@ -754,12 +759,25 @@ func TestGlobalLabelsMetadataPropagation(t *testing.T) {
 			sendInput(t, tc.inputFile, testEndpoint)
 
 			ctxs := ctxsFn()
-			require.GreaterOrEqual(t, len(ctxs), 1)
-			got := client.FromContext(ctxs[0]).Metadata.Get(elasticattr.MetadataDynamicResourceAttributes)
-			require.ElementsMatch(t, tc.expectedDynamicAttrs, got)
+			if tc.expectedPerGroupDynamicAttrs != nil {
+				require.Len(t, ctxs, len(tc.expectedPerGroupDynamicAttrs))
+				for i, expectedAttrs := range tc.expectedPerGroupDynamicAttrs {
+					got := client.FromContext(ctxs[i]).Metadata.Get(elasticattr.MetadataDynamicResourceAttributes)
+					assert.ElementsMatch(t, expectedAttrs, got, "mismatch at context index %d", i)
+				}
+			} else {
+				require.GreaterOrEqual(t, len(ctxs), 1)
+				got := client.FromContext(ctxs[0]).Metadata.Get(elasticattr.MetadataDynamicResourceAttributes)
+				require.ElementsMatch(t, tc.expectedDynamicAttrs, got)
+			}
 
 			if tc.expectedYamlFile != "" && metricsSink != nil {
-				actualMetrics := metricsSink.AllMetrics()[0]
+				// Merge metrics from all consume calls for golden file comparison.
+				allMetrics := metricsSink.AllMetrics()
+				actualMetrics := pmetric.NewMetrics()
+				for _, m := range allMetrics {
+					m.ResourceMetrics().MoveAndAppendTo(actualMetrics.ResourceMetrics())
+				}
 				expectedFile := filepath.Join(testData, tc.expectedYamlFile)
 				if *update {
 					err := golden.WriteMetrics(t, expectedFile, actualMetrics, golden.SkipMetricTimestampNormalization())
@@ -803,7 +821,13 @@ func runComparisonForTraces(t *testing.T, inputJsonFileName string, expectedYaml
 	nextTrace.Reset()
 
 	sendInput(t, inputJsonFileName, testEndpoint)
-	actualTraces := nextTrace.AllTraces()[0]
+	// Merge traces from all consume calls (there may be multiple when
+	// events are separated due to global label shadowing).
+	allTraces := nextTrace.AllTraces()
+	actualTraces := ptrace.NewTraces()
+	for _, tr := range allTraces {
+		tr.ResourceSpans().MoveAndAppendTo(actualTraces.ResourceSpans())
+	}
 	expectedFile := filepath.Join(testData, expectedYamlFileName)
 	if *update {
 		err := golden.WriteTraces(t, expectedFile, actualTraces)
@@ -811,8 +835,11 @@ func runComparisonForTraces(t *testing.T, inputJsonFileName string, expectedYaml
 	}
 	expectedTraces, err := golden.ReadTraces(expectedFile)
 	require.NoError(t, err)
-	require.NoError(t, ptracetest.CompareTraces(expectedTraces, actualTraces, ptracetest.IgnoreStartTimestamp(),
-		ptracetest.IgnoreEndTimestamp()))
+	require.NoError(t, ptracetest.CompareTraces(expectedTraces, actualTraces,
+		ptracetest.IgnoreStartTimestamp(),
+		ptracetest.IgnoreEndTimestamp(),
+		ptracetest.IgnoreResourceSpansOrder(),
+	))
 }
 
 func runComparisonForLogs(t *testing.T, inputJsonFileName string, expectedYamlFileName string,
@@ -821,15 +848,19 @@ func runComparisonForLogs(t *testing.T, inputJsonFileName string, expectedYamlFi
 	nextLog.Reset()
 
 	sendInput(t, inputJsonFileName, testEndpoint)
-	actualMetrics := nextLog.AllLogs()[0]
+	allLogs := nextLog.AllLogs()
+	actualLogs := plog.NewLogs()
+	for _, l := range allLogs {
+		l.ResourceLogs().MoveAndAppendTo(actualLogs.ResourceLogs())
+	}
 	expectedFile := filepath.Join(testData, expectedYamlFileName)
 	if *update {
-		err := golden.WriteLogs(t, expectedFile, actualMetrics)
+		err := golden.WriteLogs(t, expectedFile, actualLogs)
 		assert.NoError(t, err)
 	}
-	expectedMetrics, err := golden.ReadLogs(expectedFile)
+	expectedLogs, err := golden.ReadLogs(expectedFile)
 	require.NoError(t, err)
-	require.NoError(t, plogtest.CompareLogs(expectedMetrics, actualMetrics, plogtest.IgnoreLogRecordsOrder()))
+	require.NoError(t, plogtest.CompareLogs(expectedLogs, actualLogs, plogtest.IgnoreLogRecordsOrder()))
 }
 
 func runComparisonForMetrics(t *testing.T, inputJsonFileName string, expectedYamlFileName string,
@@ -837,7 +868,11 @@ func runComparisonForMetrics(t *testing.T, inputJsonFileName string, expectedYam
 ) {
 	nextMetric.Reset()
 	sendInput(t, inputJsonFileName, testEndpoint)
-	actualMetrics := nextMetric.AllMetrics()[0]
+	allMetrics := nextMetric.AllMetrics()
+	actualMetrics := pmetric.NewMetrics()
+	for _, m := range allMetrics {
+		m.ResourceMetrics().MoveAndAppendTo(actualMetrics.ResourceMetrics())
+	}
 	expectedFile := filepath.Join(testData, expectedYamlFileName)
 	if *update {
 		err := golden.WriteMetrics(t, expectedFile, actualMetrics, golden.SkipMetricTimestampNormalization())

--- a/receiver/elasticapmintakereceiver/testdata/metric_global_label_shadow.ndjson
+++ b/receiver/elasticapmintakereceiver/testdata/metric_global_label_shadow.ndjson
@@ -1,3 +1,5 @@
-{"metadata": {"service": {"name": "shadow-test", "agent": {"name": "elastic-node", "version": "1.0.0"}}, "labels": {"global_tag": "from_metadata"}}}
+{"metadata": {"service": {"name": "shadow-test", "agent": {"name": "elastic-node", "version": "1.0.0"}}, "labels": {"global_tag": "from_metadata", "num_tag": 100}}}
 {"metricset": {"samples": {"app.request.count": {"value": 1}}, "timestamp": 1496170422281000}}
 {"metricset": {"samples": {"app.request.count": {"value": 2}}, "tags": {"global_tag": "from_event"}, "timestamp": 1496170422282000}}
+{"metricset": {"samples": {"app.request.count": {"value": 3}}, "tags": {"global_tag": "from_event_2"}, "timestamp": 1496170422283000}}
+{"metricset": {"samples": {"app.request.count": {"value": 4}}, "tags": {"num_tag": 200}, "timestamp": 1496170422284000}}

--- a/receiver/elasticapmintakereceiver/testdata/metric_global_label_shadow_expected.yaml
+++ b/receiver/elasticapmintakereceiver/testdata/metric_global_label_shadow_expected.yaml
@@ -13,6 +13,9 @@ resourceMetrics:
         - key: metricset.name
           value:
             stringValue: app
+        - key: numeric_labels.num_tag
+          value:
+            doubleValue: 100
         - key: service.name
           value:
             stringValue: shadow-test
@@ -41,10 +44,48 @@ resourceMetrics:
             stringValue: 1.0.0
         - key: labels.global_tag
           value:
+            stringValue: from_event_2
+        - key: metricset.name
+          value:
+            stringValue: app
+        - key: numeric_labels.num_tag
+          value:
+            doubleValue: 100
+        - key: service.name
+          value:
+            stringValue: shadow-test
+        - key: telemetry.sdk.name
+          value:
+            stringValue: ElasticAPM
+    scopeMetrics:
+      - metrics:
+          - gauge:
+              dataPoints:
+                - asDouble: 3
+                  attributes:
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                  timeUnixNano: "1496170422283000000"
+            name: app.request.count
+        scope: {}
+  - resource:
+      attributes:
+        - key: agent.name
+          value:
+            stringValue: elastic-node
+        - key: agent.version
+          value:
+            stringValue: 1.0.0
+        - key: labels.global_tag
+          value:
             stringValue: from_metadata
         - key: metricset.name
           value:
             stringValue: app
+        - key: numeric_labels.num_tag
+          value:
+            doubleValue: 100
         - key: service.name
           value:
             stringValue: shadow-test
@@ -61,5 +102,40 @@ resourceMetrics:
                       value:
                         stringValue: metric
                   timeUnixNano: "1496170422281000000"
+            name: app.request.count
+        scope: {}
+  - resource:
+      attributes:
+        - key: agent.name
+          value:
+            stringValue: elastic-node
+        - key: agent.version
+          value:
+            stringValue: 1.0.0
+        - key: labels.global_tag
+          value:
+            stringValue: from_metadata
+        - key: metricset.name
+          value:
+            stringValue: app
+        - key: numeric_labels.num_tag
+          value:
+            doubleValue: 200
+        - key: service.name
+          value:
+            stringValue: shadow-test
+        - key: telemetry.sdk.name
+          value:
+            stringValue: ElasticAPM
+    scopeMetrics:
+      - metrics:
+          - gauge:
+              dataPoints:
+                - asDouble: 4
+                  attributes:
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                  timeUnixNano: "1496170422284000000"
             name: app.request.count
         scope: {}


### PR DESCRIPTION
## Fix global label shadowing in aggregated metrics

**Fixes:** elastic/hosted-otel-collector#2865

### Problem

When an event-level tag shadows a metadata (global) label, the receiver includes the shadowed key in `x-elastic-dynamic-resource-attributes` for all events in the batch. The downstream connector then uses this key for aggregation grouping on the shadowing event, diverging from `apm-aggregation` which excludes shadowed keys per-event via `marshalEventGlobalLabels()`.

### Solution

During batch processing, detect events that shadow a global label and separate them into dedicated batches, each consumed with its own client metadata context containing only that event's effective global keys.

- First pass collects the batch-level global key set into a `keyIndex` map with bit positions for efficient grouping
- Second pass checks each event for shadowing; non-shadowed events stay in the main batch
- Shadowed events are grouped by a `big.Int` bitmask of their effective global keys, so events with identical shadow patterns share a batch
- Pdata structures (`Logs`, `Metrics`, `Traces`) are lazily initialized on first use, avoiding allocations for unused signal types

### Performance

Benchmarked against main (`-benchtime=5s -count=6`, `benchstat`):

| Scenario | sec/op | allocs/op |
|----------|--------|-----------|
| No shadowing (common) | ~ (no change) | **-2** (894 vs 896) |
| With shadowing (rare) | ~ (no change) | +43 (959 vs 916) |

The no-shadow path is allocation-equivalent to (or better than) main. The shadow path adds allocations proportional to the number of distinct shadow patterns, which is expected and rare in production.
