### PR TITLE
[processor/elasticapmprocessor] refactor: use per-resource ECS enricher selection for logs and metrics

### DIFF
--- a/processor/elasticapmprocessor/internal/enrichments/enricher.go
+++ b/processor/elasticapmprocessor/internal/enrichments/enricher.go
@@ -72,19 +72,24 @@ func (e *Enricher) EnrichTraces(pt ptrace.Traces) {
 func (e *Enricher) EnrichLogs(pl plog.Logs) {
 	resLogs := pl.ResourceLogs()
 	for i := 0; i < resLogs.Len(); i++ {
-		resLog := resLogs.At(i)
-		resource := resLog.Resource()
-		EnrichResource(resource, e.Config.Resource)
-		resourceAttrs := resource.Attributes().AsRaw()
-		scopeLogs := resLog.ScopeLogs()
-		for j := 0; j < scopeLogs.Len(); j++ {
-			scopeSpan := scopeLogs.At(j)
-			EnrichScope(scopeSpan.Scope(), e.Config)
-			logRecords := scopeSpan.LogRecords()
-			for k := 0; k < logRecords.Len(); k++ {
-				logRecord := logRecords.At(k)
-				EnrichLog(resourceAttrs, logRecord, e.Config)
-			}
+		e.EnrichResourceLogs(resLogs.At(i))
+	}
+}
+
+// EnrichResourceLogs enriches a single ResourceLogs with the current enricher
+// configuration. This is used when ECS batches need per-resource enrichment
+// policies based on the origin of each ResourceLogs.
+func (e *Enricher) EnrichResourceLogs(resLog plog.ResourceLogs) {
+	resource := resLog.Resource()
+	EnrichResource(resource, e.Config.Resource)
+	resourceAttrs := resource.Attributes().AsRaw()
+	scopeLogs := resLog.ScopeLogs()
+	for j := 0; j < scopeLogs.Len(); j++ {
+		scopeLog := scopeLogs.At(j)
+		EnrichScope(scopeLog.Scope(), e.Config)
+		logRecords := scopeLog.LogRecords()
+		for k := 0; k < logRecords.Len(); k++ {
+			EnrichLog(resourceAttrs, logRecords.At(k), e.Config)
 		}
 	}
 }
@@ -95,18 +100,24 @@ func (e *Enricher) EnrichLogs(pl plog.Logs) {
 func (e *Enricher) EnrichMetrics(pl pmetric.Metrics) {
 	resMetrics := pl.ResourceMetrics()
 	for i := 0; i < resMetrics.Len(); i++ {
-		resMetric := resMetrics.At(i)
-		EnrichMetric(resMetric, e.Config)
-		EnrichResource(resMetric.Resource(), e.Config.Resource)
-		scopeMetics := resMetric.ScopeMetrics()
-		for j := 0; j < scopeMetics.Len(); j++ {
-			scopeMetric := scopeMetics.At(j)
-			EnrichScope(scopeMetric.Scope(), e.Config)
-			scopeAttrs := scopeMetric.Scope().Attributes()
-			metrics := scopeMetric.Metrics()
-			for k := 0; k < metrics.Len(); k++ {
-				EnrichMetricDataPoints(metrics.At(k), scopeAttrs, e.Config)
-			}
+		e.EnrichResourceMetrics(resMetrics.At(i))
+	}
+}
+
+// EnrichResourceMetrics enriches a single ResourceMetrics with the current
+// enricher configuration. This is used when ECS batches need per-resource
+// enrichment policies based on the origin of each ResourceMetrics.
+func (e *Enricher) EnrichResourceMetrics(resMetric pmetric.ResourceMetrics) {
+	EnrichMetric(resMetric, e.Config)
+	EnrichResource(resMetric.Resource(), e.Config.Resource)
+	scopeMetrics := resMetric.ScopeMetrics()
+	for j := 0; j < scopeMetrics.Len(); j++ {
+		scopeMetric := scopeMetrics.At(j)
+		EnrichScope(scopeMetric.Scope(), e.Config)
+		scopeAttrs := scopeMetric.Scope().Attributes()
+		metrics := scopeMetric.Metrics()
+		for k := 0; k < metrics.Len(); k++ {
+			EnrichMetricDataPoints(metrics.At(k), scopeAttrs, e.Config)
 		}
 	}
 }

--- a/processor/elasticapmprocessor/processor.go
+++ b/processor/elasticapmprocessor/processor.go
@@ -240,19 +240,13 @@ func (p *MetricProcessor) Capabilities() consumer.Capabilities {
 }
 
 func (p *MetricProcessor) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
-	enricher := p.enricher
 	ecsMode := isECS(ctx)
 	if ecsMode {
-		enricher = p.ecsEnricher
 		resourceMetrics := md.ResourceMetrics()
-		// ECS metric batches are assumed to be homogeneous by origin. We select
-		// the enricher from the first resource metric and apply it to the whole batch.
-		if resourceMetrics.Len() > 0 && isIntakeECS(resourceMetrics.At(0).Resource()) {
-			enricher = p.intakeECSEnricher
-		}
 		for i := 0; i < resourceMetrics.Len(); i++ {
 			resourceMetric := resourceMetrics.At(i)
 			resource := resourceMetric.Resource()
+			enricher := p.ecsMetricEnricher(resource)
 			ecs.TranslateResourceMetadata(resource)
 			ecs.ApplyResourceConventions(resource)
 			routing.EncodeDataStream(resource, routing.DataStreamTypeMetrics, p.cfg.ServiceNameInDataStreamDataset)
@@ -268,14 +262,24 @@ func (p *MetricProcessor) ConsumeMetrics(ctx context.Context, md pmetric.Metrics
 
 			// Route internal metrics to appropriate data streams if needed.
 			routeMetricsToDataStream(resourceMetric.ScopeMetrics(), hasServiceName)
+
+			enricher.EnrichResourceMetrics(resourceMetric)
 		}
+		return p.next.ConsumeMetrics(ctx, md)
 	}
 	// When skipEnrichment is true, only enrich when mapping mode is ecs
 	// When skipEnrichment is false (default), always enrich (backwards compatible)
-	if !p.cfg.SkipEnrichment || ecsMode {
-		enricher.EnrichMetrics(md)
+	if !p.cfg.SkipEnrichment {
+		p.enricher.EnrichMetrics(md)
 	}
 	return p.next.ConsumeMetrics(ctx, md)
+}
+
+func (p *MetricProcessor) ecsMetricEnricher(resource pcommon.Resource) *enrichments.Enricher {
+	if isIntakeECS(resource) {
+		return p.intakeECSEnricher
+	}
+	return p.ecsEnricher
 }
 
 func routeMetricsToDataStream(scopeMetrics pmetric.ScopeMetricsSlice, hasServiceName bool) {
@@ -339,31 +343,35 @@ func routeMetricsToDataStream(scopeMetrics pmetric.ScopeMetricsSlice, hasService
 }
 
 func (p *LogProcessor) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
-	enricher := p.enricher
 	ecsMode := isECS(ctx)
 	if ecsMode {
-		enricher = p.ecsEnricher
 		resourceLogs := ld.ResourceLogs()
-		// ECS log batches are assumed to be homogeneous by origin. We select the
-		// enricher from the first resource log and apply it to the whole batch.
-		if resourceLogs.Len() > 0 && isIntakeECS(resourceLogs.At(0).Resource()) {
-			enricher = p.intakeECSEnricher
-		}
 		for i := 0; i < resourceLogs.Len(); i++ {
 			resourceLog := resourceLogs.At(i)
 			resource := resourceLog.Resource()
+			enricher := p.ecsLogEnricher(resource)
 			ecs.TranslateResourceMetadata(resource)
 			ecs.ApplyResourceConventions(resource)
 			routing.EncodeDataStream(resource, routing.DataStreamTypeLogs, p.cfg.ServiceNameInDataStreamDataset)
 			if p.cfg.HostIPEnabled {
 				ecs.SetHostIP(ctx, resource.Attributes())
 			}
+
+			enricher.EnrichResourceLogs(resourceLog)
 		}
+		return p.next.ConsumeLogs(ctx, ld)
 	}
 	// When skipEnrichment is true, only enrich when mapping mode is ecs
 	// When skipEnrichment is false (default), always enrich (backwards compatible)
-	if !p.cfg.SkipEnrichment || ecsMode {
-		enricher.EnrichLogs(ld)
+	if !p.cfg.SkipEnrichment {
+		p.enricher.EnrichLogs(ld)
 	}
 	return p.next.ConsumeLogs(ctx, ld)
+}
+
+func (p *LogProcessor) ecsLogEnricher(resource pcommon.Resource) *enrichments.Enricher {
+	if isIntakeECS(resource) {
+		return p.intakeECSEnricher
+	}
+	return p.ecsEnricher
 }

--- a/processor/elasticapmprocessor/processor_test.go
+++ b/processor/elasticapmprocessor/processor_test.go
@@ -455,7 +455,7 @@ func TestConsumeLogs_ECSIntakeSkipsOTLPFallbacks(t *testing.T) {
 	assert.False(t, ok)
 }
 
-func TestConsumeLogs_ECSAssumesHomogeneousBatchOrigin(t *testing.T) {
+func TestConsumeLogs_ECSMixedOriginUsesPerResourceEnricher(t *testing.T) {
 	ctx := client.NewContext(context.Background(), client.Info{
 		Metadata: client.NewMetadata(map[string][]string{"x-elastic-mapping-mode": {"ecs"}}),
 	})
@@ -488,21 +488,20 @@ func TestConsumeLogs_ECSAssumesHomogeneousBatchOrigin(t *testing.T) {
 
 	require.Equal(t, 2, actual.ResourceLogs().Len())
 
-	// Mixed-origin batches are not supported. The first resource log determines
-	// which ECS log enricher is used for the whole batch.
 	intakeAttrs := actual.ResourceLogs().At(0).Resource().Attributes()
 	_, ok := intakeAttrs.Get(string(semconv.TelemetrySDKLanguageKey))
 	assert.False(t, ok)
 
 	otlpAttrs := actual.ResourceLogs().At(1).Resource().Attributes()
-	_, ok = otlpAttrs.Get(string(semconv.TelemetrySDKLanguageKey))
-	assert.False(t, ok)
+	value, ok := otlpAttrs.Get(string(semconv.TelemetrySDKLanguageKey))
+	require.True(t, ok)
+	assert.Equal(t, "unknown", value.Str())
 
 	otlpLogAttrs := actual.ResourceLogs().At(1).ScopeLogs().At(0).LogRecords().At(0).Attributes()
-	value, ok := otlpLogAttrs.Get("http.method")
+	value, ok = otlpLogAttrs.Get("labels.http_method")
 	require.True(t, ok)
 	assert.Equal(t, "GET", value.Str())
-	_, ok = otlpLogAttrs.Get("labels.http_method")
+	_, ok = otlpLogAttrs.Get("http.method")
 	assert.False(t, ok)
 }
 
@@ -674,7 +673,7 @@ func TestConsumeMetrics_ECSIntakeSkipsOTLPFallbacks(t *testing.T) {
 	assert.False(t, ok)
 }
 
-func TestConsumeMetrics_ECSAssumesHomogeneousBatchOrigin(t *testing.T) {
+func TestConsumeMetrics_ECSMixedOriginUsesPerResourceEnricher(t *testing.T) {
 	ctx := client.NewContext(context.Background(), client.Info{
 		Metadata: client.NewMetadata(map[string][]string{"x-elastic-mapping-mode": {"ecs"}}),
 	})
@@ -720,31 +719,32 @@ func TestConsumeMetrics_ECSAssumesHomogeneousBatchOrigin(t *testing.T) {
 
 	require.Equal(t, 2, actual.ResourceMetrics().Len())
 
-	// Mixed-origin batches are not supported. The first resource metric determines
-	// which ECS metric enricher is used for the whole batch.
 	intakeAttrs := actual.ResourceMetrics().At(0).Resource().Attributes()
 	_, ok := intakeAttrs.Get(string(semconv.TelemetrySDKLanguageKey))
 	assert.False(t, ok)
 
 	otlpAttrsAfter := actual.ResourceMetrics().At(1).Resource().Attributes()
-	_, ok = otlpAttrsAfter.Get(string(semconv.TelemetrySDKLanguageKey))
-	assert.False(t, ok)
+	value, ok := otlpAttrsAfter.Get(string(semconv.TelemetrySDKLanguageKey))
+	require.True(t, ok)
+	assert.Equal(t, "unknown", value.Str())
 
 	actualDPAttrs := actual.ResourceMetrics().At(1).ScopeMetrics().At(0).Metrics().At(0).Sum().DataPoints().At(0).Attributes()
-	value, ok := actualDPAttrs.Get("http.request.method")
+	value, ok = actualDPAttrs.Get("labels.http_request_method")
 	require.True(t, ok)
 	assert.Equal(t, "GET", value.Str())
-	value, ok = actualDPAttrs.Get("host")
+	value, ok = actualDPAttrs.Get("labels.host")
 	require.True(t, ok)
 	assert.Equal(t, "server-01", value.Str())
-	_, ok = actualDPAttrs.Get("labels.http_request_method")
+	_, ok = actualDPAttrs.Get("http.request.method")
 	assert.False(t, ok)
-	_, ok = actualDPAttrs.Get("labels.host")
+	_, ok = actualDPAttrs.Get("host")
 	assert.False(t, ok)
-	_, ok = actualDPAttrs.Get(elasticattr.ServiceFrameworkName)
-	assert.False(t, ok)
-	_, ok = actualDPAttrs.Get(elasticattr.ServiceFrameworkVersion)
-	assert.False(t, ok)
+	value, ok = actualDPAttrs.Get(elasticattr.ServiceFrameworkName)
+	require.True(t, ok)
+	assert.Equal(t, "metrics-instrumentation", value.Str())
+	value, ok = actualDPAttrs.Get(elasticattr.ServiceFrameworkVersion)
+	require.True(t, ok)
+	assert.Equal(t, "1.0.0", value.Str())
 }
 
 // TestSkipEnrichmentMetrics tests that metrics are only enriched when skipEnrichment is false or when mapping mode is ecs


### PR DESCRIPTION
### Summary

Refactors to the enrichment structure
- Adds two new methods, `EnrichResourceLogs` and `EnrichResourceMetrics`, to encapsulate per-resource enrichment logic. 
- The `EnrichLogs` and `EnrichMetrics` methods now delegate to these helpers rather than performing enrichment inline. 
- The log and metric processors were updated to select enrichers on a per-resource basis instead of batch-wide selection based on the first resource. 
- Tests were revised to validate correct per-resource enrichment behavior in mixed-origin batches.
