### PR TITLE
Add version check script to validate tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,11 @@ GOTOOLCHAIN ?= go1.25.7+auto
 .PHONY: all
 all: misspell
 
+# Ensure module-set version in versions.yaml is greater than latest per-component Git tags.
+.PHONY: versionscheck
+versionscheck:
+	@cd "$(SRC_ROOT)" && $(GOCMD) run -C internal/versionscheck .
+
 # Append root module to all modules
 GOMODULES = $(ALL_MODULES)
 
@@ -149,11 +154,10 @@ COMMIT?=HEAD
 MODSET?=edot-base
 REMOTE?=git@github.com:elastic/opentelemetry-collector-components.git
 .PHONY: push-tags
-push-tags: $(MULTIMOD)
+push-tags: $(MULTIMOD) versionscheck
 	$(MULTIMOD) verify
 	set -e; for tag in `$(MULTIMOD) tag -m ${MODSET} -c ${COMMIT} --print-tags | grep -v "Using" `; do \
 		echo "pushing tag $${tag}"; \
-		git push ${REMOTE} $${tag}; \
 	done;
 
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,12 @@ GOTOOLCHAIN ?= go1.25.7+auto
 .PHONY: all
 all: misspell
 
-# Ensure module-set version in versions.yaml is greater than latest per-component Git tags.
+# Compare versions.yaml module-set version to latest semver tags from repository
+VERSIONSCHECK_GITHUB_REPO ?= elastic/opentelemetry-collector-components
+
 .PHONY: versionscheck
 versionscheck:
-	@cd "$(SRC_ROOT)" && $(GOCMD) run -C internal/versionscheck .
+	@cd "$(SRC_ROOT)" && $(GOCMD) run -C internal/versionscheck . -versions $(SRC_ROOT)/versions.yaml -github-repo $(VERSIONSCHECK_GITHUB_REPO) -module-key $(MODSET)
 
 # Append root module to all modules
 GOMODULES = $(ALL_MODULES)
@@ -158,7 +160,7 @@ push-tags: $(MULTIMOD) versionscheck
 	$(MULTIMOD) verify
 	set -e; for tag in `$(MULTIMOD) tag -m ${MODSET} -c ${COMMIT} --print-tags | grep -v "Using" `; do \
 		echo "pushing tag $${tag}"; \
-		git push ${REMOTE} $${tag}; \
+		# git push ${REMOTE} $${tag}; \
 	done;
 
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -158,6 +158,7 @@ push-tags: $(MULTIMOD) versionscheck
 	$(MULTIMOD) verify
 	set -e; for tag in `$(MULTIMOD) tag -m ${MODSET} -c ${COMMIT} --print-tags | grep -v "Using" `; do \
 		echo "pushing tag $${tag}"; \
+		git push ${REMOTE} $${tag}; \
 	done;
 
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ push-tags: $(MULTIMOD) versionscheck
 	$(MULTIMOD) verify
 	set -e; for tag in `$(MULTIMOD) tag -m ${MODSET} -c ${COMMIT} --print-tags | grep -v "Using" `; do \
 		echo "pushing tag $${tag}"; \
-		# git push ${REMOTE} $${tag}; \
+		git push ${REMOTE} $${tag}; \
 	done;
 
 .PHONY: clean

--- a/internal/versionscheck/Makefile
+++ b/internal/versionscheck/Makefile
@@ -1,0 +1,1 @@
+include ../../Makefile.Common

--- a/internal/versionscheck/README.md
+++ b/internal/versionscheck/README.md
@@ -1,0 +1,49 @@
+# versionscheck
+
+`versionscheck` reads a `module-sets` entry from [`versions.yaml`](../versions.yaml), and compares the version from the module against the highest semver-shaped tag from the repo (e.g. `v1.2.3`, `component/v1.2.3`, or `path/component/v1.2.3`). It **requires** that the YAML version is **strictly greater** than the repo tag. If there are **no** semver tags, it fails unless `-allow-empty-tag` is set.
+
+It is run automatically before [`make push-tags`](../Makefile) (the `push-tags` target depends on `versionscheck`).
+
+## Usage
+
+**From the repository root (recommended):**
+
+```shell
+make versionscheck
+```
+
+This runs `go run -C internal/versionscheck .` with:
+
+- `-versions` → `<repo-root>/versions.yaml`
+- `-github-repo` → `$(VERSIONSCHECK_GITHUB_REPO)` (default: `elastic/opentelemetry-collector-components`)
+- `-module-key` → `$(MODSET)` (default: `edot-base`)
+
+Override as needed, for example:
+
+```shell
+make versionscheck MODSET=edot-base VERSIONSCHECK_GITHUB_REPO=owner/repo
+```
+
+**Manual invocation:**
+
+```shell
+go run -C internal/versionscheck . \
+  -versions /path/to/versions.yaml \
+  -github-repo owner/repo \
+  -module-key edot-base
+```
+
+Add optional flags (see below) at the end.
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `-versions` | **Required.** Path to `versions.yaml`. |
+| `-github-repo` | **Required.** GitHub repository as `owner/repo` (used with the GitHub API to list tags). |
+| `-module-key` | **Required.** Key under `module-sets` in `versions.yaml` (e.g. `edot-base`). |
+| `-allow-empty-tag` | If set, do not fail when the repository has no semver-shaped tags; otherwise exit with an error when no such tags exist. |
+| `-q` | Quiet: suppress the success message on stdout. |
+
+On failure the process exits non-zero and prints an error (via `log.Fatal`).
+

--- a/internal/versionscheck/go.mod
+++ b/internal/versionscheck/go.mod
@@ -1,0 +1,8 @@
+module github.com/elastic/opentelemetry-collector-components/internal/versionscheck
+
+go 1.25.0
+
+require (
+	golang.org/x/mod v0.14.0
+	gopkg.in/yaml.v3 v3.0.1
+)

--- a/internal/versionscheck/go.mod
+++ b/internal/versionscheck/go.mod
@@ -3,6 +3,9 @@ module github.com/elastic/opentelemetry-collector-components/internal/versionsch
 go 1.25.0
 
 require (
+	github.com/google/go-github/v84 v84.0.0
 	golang.org/x/mod v0.14.0
 	gopkg.in/yaml.v3 v3.0.1
 )
+
+require github.com/google/go-querystring v1.2.0 // indirect

--- a/internal/versionscheck/go.sum
+++ b/internal/versionscheck/go.sum
@@ -1,0 +1,6 @@
+golang.org/x/mod v0.14.0 h1:dGoOF9QVLYng8IHTm7BAyWqCqSheQ5pYWGhzW00YJr0=
+golang.org/x/mod v0.14.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/versionscheck/go.sum
+++ b/internal/versionscheck/go.sum
@@ -1,3 +1,10 @@
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/go-github/v84 v84.0.0 h1:I/0Xn5IuChMe8TdmI2bbim5nyhaRFJ7DEdzmD2w+yVA=
+github.com/google/go-github/v84 v84.0.0/go.mod h1:WwYL1z1ajRdlaPszjVu/47x1L0PXukJBn73xsiYrRRQ=
+github.com/google/go-querystring v1.2.0 h1:yhqkPbu2/OH+V9BfpCVPZkNmUXhb2gBxJArfhIxNtP0=
+github.com/google/go-querystring v1.2.0/go.mod h1:8IFJqpSRITyJ8QhQ13bmbeMBDfmeEJZD5A0egEOmkqU=
 golang.org/x/mod v0.14.0 h1:dGoOF9QVLYng8IHTm7BAyWqCqSheQ5pYWGhzW00YJr0=
 golang.org/x/mod v0.14.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/internal/versionscheck/main.go
+++ b/internal/versionscheck/main.go
@@ -19,18 +19,19 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
-	"os/exec"
 	"strings"
+	"time"
 
+	"github.com/google/go-github/v84/github"
 	"golang.org/x/mod/semver"
 	"gopkg.in/yaml.v3"
 )
-
-const edotBaseKey = "edot-base"
 
 type versionsYAML struct {
 	ModuleSets      map[string]moduleSet `yaml:"module-sets"`
@@ -42,6 +43,17 @@ type moduleSet struct {
 	Modules []string `yaml:"modules"`
 }
 
+// tagFetchDeadline bounds how long we wait for paginated ListTags calls to GitHub.
+const tagFetchDeadline = 5 * time.Minute
+
+var httpClient = newVersionscheckHTTPClient()
+
+func newVersionscheckHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout: tagFetchDeadline,
+	}
+}
+
 func main() {
 	log.SetFlags(0)
 	log.SetPrefix("versionscheck: ")
@@ -51,16 +63,25 @@ func main() {
 }
 
 func run() error {
-	versionsPath := flag.String("versions", "../../versions.yaml", "path to versions.yaml")
+	versionsPath := flag.String("versions", "", "required: path to versions.yaml")
+	githubRepo := flag.String("github-repo", "", "required: GitHub repository as owner/repo;")
+	moduleKey := flag.String("module-key", "", "required: module-sets key in versions.yaml (e.g. edot-base)")
+	allowEmptyTag := flag.Bool("allow-empty-tag", false, "allow a repository with no semver-shaped tags; otherwise fail when GitHub returns no v* tags")
+
 	quiet := flag.Bool("q", false, "suppress success message on stdout")
 	flag.Parse()
 
-	vpath := *versionsPath
-	if vpath == "" {
-		vpath = "../../versions.yaml"
+	if *versionsPath == "" {
+		return fmt.Errorf("-versions is required")
+	}
+	if *githubRepo == "" {
+		return fmt.Errorf("-github-repo is required (owner/repo)")
+	}
+	if *moduleKey == "" {
+		return fmt.Errorf("-module-key is required")
 	}
 
-	data, err := os.ReadFile(vpath)
+	data, err := os.ReadFile(*versionsPath)
 	if err != nil {
 		return fmt.Errorf("read versions file: %w", err)
 	}
@@ -70,44 +91,64 @@ func run() error {
 		return err
 	}
 
-	ms, ok := cfg.ModuleSets[edotBaseKey]
+	ms, ok := cfg.ModuleSets[*moduleKey]
 	if !ok {
-		return fmt.Errorf("no entry %s in %s", edotBaseKey, vpath)
+		return fmt.Errorf("no entry %s in %s", *moduleKey, *versionsPath)
 	}
 	if ms.Version == "" {
-		return fmt.Errorf("empty version for %s", edotBaseKey)
+		return fmt.Errorf("empty version for %s", *moduleKey)
 	}
 	if !semver.IsValid(ms.Version) {
-		return fmt.Errorf("invalid semver for %s version: %q", edotBaseKey, ms.Version)
+		return fmt.Errorf("invalid semver for %s version: %q", *moduleKey, ms.Version)
 	}
 
-	tagOut, err := gitTagList()
+	tags, err := gitTagListFromGitHub(*githubRepo)
 	if err != nil {
 		return err
 	}
-	latest := latestComponentVersion(strings.Split(tagOut, "\n"))
+	latest, tagName := latestComponentVersion(tags)
 
-	// Require edot-base to be strictly greater than the highest semver tag (if any).
-	if latest != "" && semver.Compare(ms.Version, latest) <= 0 {
-		return fmt.Errorf("module-sets version %s must be greater than tag %s",
-			ms.Version, latest)
+	if err := validateModuleSetVersionAgainstTagList(ms.Version, latest, tagName, *allowEmptyTag, *githubRepo); err != nil {
+		return err
 	}
 
 	if !*quiet {
-		if _, err := fmt.Fprintf(os.Stdout, "versionscheck: ok (%s version %s, %d modules checked)\n", edotBaseKey, ms.Version, len(ms.Modules)); err != nil {
+		msg := formatVersionscheckOK(*moduleKey, ms.Version, latest, tagName, *githubRepo)
+		if _, err := fmt.Fprint(os.Stdout, msg); err != nil {
 			log.Printf("warning: could not write success message: %v", err)
 		}
 	}
 	return nil
 }
 
-func gitTagList() (string, error) {
-	cmd := exec.Command("git", "tag", "-l")
-	out, err := cmd.Output()
-	if err != nil {
-		return "", fmt.Errorf("git tag -l: %w", err)
+// splitGitHubRepo parses "owner/repo" for use with the GitHub API.
+func splitGitHubRepo(githubRepo string) (owner, repo string, err error) {
+	parts := strings.Split(githubRepo, "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf(`github-repo must be "owner/repo", got %q`, githubRepo)
 	}
-	return string(out), nil
+	return parts[0], parts[1], nil
+}
+
+func gitTagListFromGitHub(githubRepo string) ([]*github.RepositoryTag, error) {
+	owner, repo, err := splitGitHubRepo(githubRepo)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), tagFetchDeadline)
+	defer cancel()
+
+	client := github.NewClient(httpClient)
+	var all []*github.RepositoryTag
+	tagsIter := client.Repositories.ListTagsIter(ctx, owner, repo, &github.ListOptions{PerPage: 100})
+	for tag, err := range tagsIter {
+		if err != nil {
+			return nil, fmt.Errorf("list tags for %q on GitHub: %w (check owner/repo, network, and GitHub API availability or rate limits)", githubRepo, err)
+		}
+		all = append(all, tag)
+	}
+	return all, nil
 }
 
 func parseVersionsYAML(data []byte) (*versionsYAML, error) {
@@ -118,28 +159,49 @@ func parseVersionsYAML(data []byte) (*versionsYAML, error) {
 	return &cfg, nil
 }
 
-// latestComponentVersion returns the highest valid version amongst all components
-// The tags must follow the format "component/v1.2.3" or "path/component/v1.2.3"
-func latestComponentVersion(tagLines []string) string {
-	highest := ""
+// validateModuleSetVersionAgainstTagList enforces that, if a tag exists (i.e. latest is not empty),
+// then the module set version must be greater than the latest tag.
+// If latest is empty, an error is returned unless allowEmptyTag flag is set.
+func validateModuleSetVersionAgainstTagList(msVersion, latest, tagName string, allowEmptyTag bool, githubRepo string) error {
+	if latest == "" && !allowEmptyTag {
+		return fmt.Errorf("no semver tags found for repo %s", githubRepo)
+	}
+	if latest != "" && semver.Compare(msVersion, latest) <= 0 {
+		return fmt.Errorf("module-sets version %s must be greater than version %s from tag %s",
+			msVersion, latest, tagName)
+	}
+	return nil
+}
 
-	for _, line := range tagLines {
-		line = strings.TrimSpace(line)
-		if line == "" {
+func formatVersionscheckOK(moduleKey, msVersion, latest, tagName, githubRepo string) string {
+	if latest == "" {
+		return fmt.Sprintf("versionscheck: ok (%s version %s; no semver tags in %s)\n", moduleKey, msVersion, githubRepo)
+	}
+	return fmt.Sprintf("versionscheck: ok (%s version %s is greater than latest %s in tag %s)\n", moduleKey, msVersion, latest, tagName)
+}
+
+// latestComponentVersion returns the highest valid version amongst all components and the complete tag name
+// The tags must follow the format "v1.2.3" or "component/v1.2.3" or "path/component/v1.2.3"
+func latestComponentVersion(tags []*github.RepositoryTag) (string, string) {
+	highest := ""
+	tagName := ""
+
+	for _, tag := range tags {
+		if tag == nil || tag.Name == nil {
 			continue
 		}
-		i := strings.LastIndex(line, "/")
-		if i <= 0 {
-			continue
+		ver := *tag.Name
+		if i := strings.LastIndex(ver, "/"); i != -1 {
+			ver = ver[i+1:]
 		}
-		ver := line[i+1:]
 		if !semver.IsValid(ver) {
 			continue
 		}
 		canonical := semver.Canonical(ver)
 		if highest == "" || semver.Compare(canonical, highest) > 0 {
 			highest = canonical
+			tagName = *tag.Name
 		}
 	}
-	return highest
+	return highest, tagName
 }

--- a/internal/versionscheck/main.go
+++ b/internal/versionscheck/main.go
@@ -94,7 +94,9 @@ func run() error {
 	}
 
 	if !*quiet {
-		fmt.Fprintf(os.Stdout, "versionscheck: ok (%s version %s, %d modules checked)\n", edotBaseKey, ms.Version, len(ms.Modules))
+		if _, err := fmt.Fprintf(os.Stdout, "versionscheck: ok (%s version %s, %d modules checked)\n", edotBaseKey, ms.Version, len(ms.Modules)); err != nil {
+			log.Printf("warning: could not write success message: %v", err)
+		}
 	}
 	return nil
 }

--- a/internal/versionscheck/main.go
+++ b/internal/versionscheck/main.go
@@ -1,0 +1,143 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Versionscheck is a development tool that compares versions.yaml with Git tags.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+
+	"golang.org/x/mod/semver"
+	"gopkg.in/yaml.v3"
+)
+
+const edotBaseKey = "edot-base"
+
+type versionsYAML struct {
+	ModuleSets      map[string]moduleSet `yaml:"module-sets"`
+	ExcludedModules []string             `yaml:"excluded-modules"`
+}
+
+type moduleSet struct {
+	Version string   `yaml:"version"`
+	Modules []string `yaml:"modules"`
+}
+
+func main() {
+	log.SetFlags(0)
+	log.SetPrefix("versionscheck: ")
+	if err := run(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func run() error {
+	versionsPath := flag.String("versions", "../../versions.yaml", "path to versions.yaml")
+	quiet := flag.Bool("q", false, "suppress success message on stdout")
+	flag.Parse()
+
+	vpath := *versionsPath
+	if vpath == "" {
+		vpath = "../../versions.yaml"
+	}
+
+	data, err := os.ReadFile(vpath)
+	if err != nil {
+		return fmt.Errorf("read versions file: %w", err)
+	}
+
+	cfg, err := parseVersionsYAML(data)
+	if err != nil {
+		return err
+	}
+
+	ms, ok := cfg.ModuleSets[edotBaseKey]
+	if !ok {
+		return fmt.Errorf("no entry %s in %s", edotBaseKey, vpath)
+	}
+	if ms.Version == "" {
+		return fmt.Errorf("empty version for %s", edotBaseKey)
+	}
+	if !semver.IsValid(ms.Version) {
+		return fmt.Errorf("invalid semver for %s version: %q", edotBaseKey, ms.Version)
+	}
+
+	tagOut, err := gitTagList()
+	if err != nil {
+		return err
+	}
+	latest := latestComponentVersion(strings.Split(tagOut, "\n"))
+
+	// Require edot-base to be strictly greater than the highest semver tag (if any).
+	if latest != "" && semver.Compare(ms.Version, latest) <= 0 {
+		return fmt.Errorf("module-sets version %s must be greater than tag %s",
+			ms.Version, latest)
+	}
+
+	if !*quiet {
+		fmt.Fprintf(os.Stdout, "versionscheck: ok (%s version %s, %d modules checked)\n", edotBaseKey, ms.Version, len(ms.Modules))
+	}
+	return nil
+}
+
+func gitTagList() (string, error) {
+	cmd := exec.Command("git", "tag", "-l")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("git tag -l: %w", err)
+	}
+	return string(out), nil
+}
+
+func parseVersionsYAML(data []byte) (*versionsYAML, error) {
+	var cfg versionsYAML
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parse versions.yaml: %w", err)
+	}
+	return &cfg, nil
+}
+
+// latestComponentVersion returns the highest valid version amongst all components
+// The tags must follow the format "component/v1.2.3" or "path/component/v1.2.3"
+func latestComponentVersion(tagLines []string) string {
+	highest := ""
+
+	for _, line := range tagLines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		i := strings.LastIndex(line, "/")
+		if i <= 0 {
+			continue
+		}
+		ver := line[i+1:]
+		if !semver.IsValid(ver) {
+			continue
+		}
+		canonical := semver.Canonical(ver)
+		if highest == "" || semver.Compare(canonical, highest) > 0 {
+			highest = canonical
+		}
+	}
+	return highest
+}

--- a/internal/versionscheck/main_test.go
+++ b/internal/versionscheck/main_test.go
@@ -1,0 +1,163 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package main
+
+import (
+	"testing"
+
+	"golang.org/x/mod/semver"
+)
+
+func TestLatestComponentVersion(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   []string
+		want string
+	}{
+		{
+			name: "highest semver across paths",
+			in: []string{
+				"receiver/foo/v1.0.0",
+				"receiver/foo/v1.1.0",
+				"receiver/foo/v1.0.1",
+				"not-a-semver-tag",
+				"no-slash",
+				"processor/bar/v2.0.0",
+				"deep/nested/path/v0.1.0",
+				"invalid/ver/notsemver",
+			},
+			want: "v2.0.0",
+		},
+		{
+			name: "empty input",
+			in:   nil,
+			want: "",
+		},
+		{
+			name: "only invalid lines",
+			in: []string{
+				"",
+				"   ",
+				"no-slash",
+				"nope",
+				"bad/tail/notsemver",
+			},
+			want: "",
+		},
+		{
+			name: "trims whitespace and ignores blank lines",
+			in: []string{
+				"  a/v1.0.0  ",
+				"",
+				"b/v1.1.0",
+			},
+			want: "v1.1.0",
+		},
+		{
+			name: "canonical semver",
+			in: []string{
+				"x/v1.0.0+build",
+				"y/v1.0.1",
+			},
+			want: semver.Canonical("v1.0.1"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := latestComponentVersion(tt.in)
+			if got != tt.want {
+				t.Fatalf("latestComponentVersion() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// edotBaseCheckWouldError mirrors the gate in run() after latestComponentVersion:
+// when there is at least one semver tag, semver.Compare(edotVersion, latestTag) <= 0
+// triggers the error return path (edot-base must be strictly greater than latest tag).
+func edotBaseCheckWouldError(edotVersion, latestTag string) bool {
+	if latestTag == "" {
+		return false
+	}
+	return semver.Compare(edotVersion, latestTag) <= 0
+}
+
+func TestEdotBaseVersusLatestTagGate(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		edot       string
+		latestTag  string
+		wantError bool
+	}{
+		{
+			name:       "edot strictly greater than latest tag",
+			edot:       "v2.0.0",
+			latestTag:  "v1.0.0",
+			wantError: false,
+		},
+		{
+			name:       "edot equal to latest tag",
+			edot:       "v1.0.0",
+			latestTag:  "v1.0.0",
+			wantError: true,
+		},
+		{
+			name:       "edot strictly less than latest tag",
+			edot:       "v1.0.0",
+			latestTag:  "v2.0.0",
+			wantError: true,
+		},
+		{
+			name:       "no semver tags (latest empty)",
+			edot:       "v1.0.0",
+			latestTag:  "",
+			wantError: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := edotBaseCheckWouldError(tt.edot, tt.latestTag)
+			if got != tt.wantError {
+				t.Fatalf("edotBaseCheckWouldError(%q, %q) = %v, want %v", tt.edot, tt.latestTag, got, tt.wantError)
+			}
+		})
+	}
+}
+
+func TestParseVersionsYAML(t *testing.T) {
+	t.Parallel()
+	const sample = `
+module-sets:
+  edot-base:
+    version: v1.2.3
+    modules:
+      - github.com/elastic/opentelemetry-collector-components/receiver/foo
+`
+	cfg, err := parseVersionsYAML([]byte(sample))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ms := cfg.ModuleSets["edot-base"]
+	if ms.Version != "v1.2.3" || len(ms.Modules) != 1 {
+		t.Fatalf("unexpected parse: %#v", ms)
+	}
+}

--- a/internal/versionscheck/main_test.go
+++ b/internal/versionscheck/main_test.go
@@ -18,129 +18,237 @@
 package main
 
 import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
 	"testing"
 
+	"github.com/google/go-github/v84/github"
 	"golang.org/x/mod/semver"
 )
+
+func repoTag(name string) *github.RepositoryTag {
+	return &github.RepositoryTag{Name: github.Ptr(name)}
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
 
 func TestLatestComponentVersion(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name string
-		in   []string
-		want string
+		name        string
+		in          []*github.RepositoryTag
+		wantLatest  string
+		wantTagName string
 	}{
 		{
 			name: "highest semver across paths",
-			in: []string{
-				"receiver/foo/v1.0.0",
-				"receiver/foo/v1.1.0",
-				"receiver/foo/v1.0.1",
-				"not-a-semver-tag",
-				"no-slash",
-				"processor/bar/v2.0.0",
-				"deep/nested/path/v0.1.0",
-				"invalid/ver/notsemver",
+			in: []*github.RepositoryTag{
+				repoTag("receiver/foo/v1.0.0"),
+				repoTag("receiver/foo/v1.1.0"),
+				repoTag("receiver/foo/v1.0.1"),
+				repoTag("not-a-semver-tag"),
+				repoTag("no-slash"),
+				repoTag("processor/bar/v2.0.0"),
+				repoTag("deep/nested/path/v0.1.0"),
+				repoTag("invalid/ver/notsemver"),
 			},
-			want: "v2.0.0",
+			wantLatest:  "v2.0.0",
+			wantTagName: "processor/bar/v2.0.0",
 		},
 		{
-			name: "empty input",
-			in:   nil,
-			want: "",
+			name:        "empty input",
+			in:          nil,
+			wantLatest:  "",
+			wantTagName: "",
 		},
 		{
-			name: "only invalid lines",
-			in: []string{
-				"",
-				"   ",
-				"no-slash",
-				"nope",
-				"bad/tail/notsemver",
+			name: "only invalid or nil names",
+			in: []*github.RepositoryTag{
+				nil,
+				repoTag(""),
+				repoTag("no-slash"),
+				repoTag("bad/tail/notsemver"),
 			},
-			want: "",
-		},
-		{
-			name: "trims whitespace and ignores blank lines",
-			in: []string{
-				"  a/v1.0.0  ",
-				"",
-				"b/v1.1.0",
-			},
-			want: "v1.1.0",
+			wantLatest:  "",
+			wantTagName: "",
 		},
 		{
 			name: "canonical semver",
-			in: []string{
-				"x/v1.0.0+build",
-				"y/v1.0.1",
+			in: []*github.RepositoryTag{
+				repoTag("x/v1.0.0+build"),
+				repoTag("y/v1.0.1"),
 			},
-			want: semver.Canonical("v1.0.1"),
+			wantLatest:  semver.Canonical("v1.0.1"),
+			wantTagName: "y/v1.0.1",
+		},
+		{
+			name: "plain v tag without path",
+			in: []*github.RepositoryTag{
+				repoTag("v3.0.0"),
+				repoTag("other/v2.0.0"),
+			},
+			wantLatest:  "v3.0.0",
+			wantTagName: "v3.0.0",
+		},
+		{
+			name: "tie same semver keeps first winning tag name",
+			in: []*github.RepositoryTag{
+				repoTag("path/a/v1.0.0"),
+				repoTag("path/b/v1.0.0"),
+			},
+			wantLatest:  "v1.0.0",
+			wantTagName: "path/a/v1.0.0",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := latestComponentVersion(tt.in)
-			if got != tt.want {
-				t.Fatalf("latestComponentVersion() = %q, want %q", got, tt.want)
+			gotLatest, gotTag := latestComponentVersion(tt.in)
+			if gotLatest != tt.wantLatest || gotTag != tt.wantTagName {
+				t.Fatalf("latestComponentVersion() = (%q, %q), want (%q, %q)", gotLatest, gotTag, tt.wantLatest, tt.wantTagName)
 			}
 		})
 	}
 }
 
-// edotBaseCheckWouldError mirrors the gate in run() after latestComponentVersion:
-// when there is at least one semver tag, semver.Compare(edotVersion, latestTag) <= 0
-// triggers the error return path (edot-base must be strictly greater than latest tag).
-func edotBaseCheckWouldError(edotVersion, latestTag string) bool {
-	if latestTag == "" {
-		return false
-	}
-	return semver.Compare(edotVersion, latestTag) <= 0
-}
-
-func TestEdotBaseVersusLatestTagGate(t *testing.T) {
+func TestSplitGitHubRepo(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name      string
-		edot      string
-		latestTag string
-		wantError bool
+		in      string
+		wantO   string
+		wantR   string
+		wantErr bool
+	}{
+		{"elastic/opentelemetry-collector-components", "elastic", "opentelemetry-collector-components", false},
+		{"", "", "", true},
+		{"onlyone", "", "", true},
+		{"a/b/c", "", "", true},
+		{"/repo", "", "", true},
+		{"owner/", "", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			t.Parallel()
+			o, r, err := splitGitHubRepo(tt.in)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if o != tt.wantO || r != tt.wantR {
+				t.Fatalf("splitGitHubRepo(%q) = (%q, %q), want (%q, %q)", tt.in, o, r, tt.wantO, tt.wantR)
+			}
+		})
+	}
+}
+
+func TestValidateModuleSetVersionAgainstTagList(t *testing.T) {
+	t.Parallel()
+	const repo = "elastic/opentelemetry-collector-components"
+	tests := []struct {
+		name          string
+		msVersion     string
+		latest        string
+		tagName       string
+		allowEmptyTag bool
+		wantErr       bool
+		wantErrSubstr string
 	}{
 		{
-			name:      "edot strictly greater than latest tag",
-			edot:      "v2.0.0",
-			latestTag: "v1.0.0",
-			wantError: false,
+			name:          "strictly greater than latest tag",
+			msVersion:     "v2.0.0",
+			latest:        "v1.0.0",
+			tagName:       "processor/bar/v1.0.0",
+			allowEmptyTag: false,
+			wantErr:       false,
 		},
 		{
-			name:      "edot equal to latest tag",
-			edot:      "v1.0.0",
-			latestTag: "v1.0.0",
-			wantError: true,
+			name:          "equal to latest tag",
+			msVersion:     "v1.0.0",
+			latest:        "v1.0.0",
+			tagName:       "x/v1.0.0",
+			allowEmptyTag: false,
+			wantErr:       true,
+			wantErrSubstr: "must be greater than version",
 		},
 		{
-			name:      "edot strictly less than latest tag",
-			edot:      "v1.0.0",
-			latestTag: "v2.0.0",
-			wantError: true,
+			name:          "strictly less than latest tag",
+			msVersion:     "v1.0.0",
+			latest:        "v2.0.0",
+			tagName:       "y/v2.0.0",
+			allowEmptyTag: false,
+			wantErr:       true,
+			wantErrSubstr: "must be greater than version",
 		},
 		{
-			name:      "no semver tags (latest empty)",
-			edot:      "v1.0.0",
-			latestTag: "",
-			wantError: false,
+			name:          "no semver tags and allow empty",
+			msVersion:     "v1.0.0",
+			latest:        "",
+			tagName:       "",
+			allowEmptyTag: true,
+			wantErr:       false,
+		},
+		{
+			name:          "no semver tags and not allowed",
+			msVersion:     "v1.0.0",
+			latest:        "",
+			tagName:       "",
+			allowEmptyTag: false,
+			wantErr:       true,
+			wantErrSubstr: "no semver tags found for",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := edotBaseCheckWouldError(tt.edot, tt.latestTag)
-			if got != tt.wantError {
-				t.Fatalf("edotBaseCheckWouldError(%q, %q) = %v, want %v", tt.edot, tt.latestTag, got, tt.wantError)
+			err := validateModuleSetVersionAgainstTagList(tt.msVersion, tt.latest, tt.tagName, tt.allowEmptyTag, repo)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				if tt.wantErrSubstr != "" && !strings.Contains(err.Error(), tt.wantErrSubstr) {
+					t.Fatalf("error %q should contain %q", err.Error(), tt.wantErrSubstr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
 			}
 		})
 	}
+}
+
+func TestFormatVersionscheckOK(t *testing.T) {
+	t.Parallel()
+	const key = "edot-base"
+	const ver = "v0.42.0"
+	const gh = "elastic/opentelemetry-collector-components"
+	t.Run("with latest tag", func(t *testing.T) {
+		t.Parallel()
+		got := formatVersionscheckOK(key, ver, "v0.41.0", "processor/x/v0.41.0", gh)
+		want := "versionscheck: ok (edot-base version v0.42.0 is greater than latest v0.41.0 in tag processor/x/v0.41.0)\n"
+		if got != want {
+			t.Fatalf("got %q, want %q", got, want)
+		}
+	})
+	t.Run("no semver tags", func(t *testing.T) {
+		t.Parallel()
+		got := formatVersionscheckOK(key, ver, "", "", gh)
+		want := "versionscheck: ok (edot-base version v0.42.0; no semver tags in elastic/opentelemetry-collector-components)\n"
+		if got != want {
+			t.Fatalf("got %q, want %q", got, want)
+		}
+	})
 }
 
 func TestParseVersionsYAML(t *testing.T) {
@@ -159,5 +267,127 @@ module-sets:
 	ms := cfg.ModuleSets["edot-base"]
 	if ms.Version != "v1.2.3" || len(ms.Modules) != 1 {
 		t.Fatalf("unexpected parse: %#v", ms)
+	}
+}
+
+func TestGitTagListFromGitHub_invalidRepo(t *testing.T) {
+	t.Parallel()
+	_, err := gitTagListFromGitHub("not-a-valid-repo")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), `github-repo must be "owner/repo"`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGitTagListFromGitHub_tagsJSON(t *testing.T) {
+	orig := httpClient
+	t.Cleanup(func() { httpClient = orig })
+
+	httpClient = &http.Client{
+		Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			wantPrefix := "/repos/elastic/collector/tags"
+			if !strings.HasPrefix(req.URL.Path, wantPrefix) {
+				return nil, fmt.Errorf("unexpected path %q, want prefix %q", req.URL.Path, wantPrefix)
+			}
+			if req.Method != http.MethodGet {
+				return nil, fmt.Errorf("unexpected method %s", req.Method)
+			}
+			body := `[{"name":"receiver/foo/v1.2.0"},{"name":"not-semver"}]`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Request:    req,
+			}, nil
+		}),
+	}
+
+	tags, err := gitTagListFromGitHub("elastic/collector")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tags) != 2 {
+		t.Fatalf("len(tags) = %d, want 2", len(tags))
+	}
+	if tags[0] == nil || tags[0].Name == nil || *tags[0].Name != "receiver/foo/v1.2.0" {
+		t.Fatalf("first tag = %#v, want name receiver/foo/v1.2.0", tags[0])
+	}
+	if tags[1] == nil || tags[1].Name == nil || *tags[1].Name != "not-semver" {
+		t.Fatalf("second tag = %#v, want name not-semver", tags[1])
+	}
+}
+
+func TestGitTagListFromGitHub_pagination(t *testing.T) {
+	orig := httpClient
+	t.Cleanup(func() { httpClient = orig })
+
+	var n int
+	httpClient = &http.Client{
+		Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			n++
+			if !strings.HasPrefix(req.URL.Path, "/repos/elastic/collector/tags") {
+				return nil, fmt.Errorf("unexpected path %q", req.URL.Path)
+			}
+			switch n {
+			case 1:
+				body := `[{"name":"a/v1.0.0"}]`
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(body)),
+					Header: http.Header{
+						"Content-Type": []string{"application/json"},
+						"Link":         []string{`<https://api.github.com/repos/elastic/collector/tags?per_page=100&page=2>; rel="next"`},
+					},
+					Request: req,
+				}, nil
+			case 2:
+				body := `[{"name":"b/v2.0.0"}]`
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(body)),
+					Header:     http.Header{"Content-Type": []string{"application/json"}},
+					Request:    req,
+				}, nil
+			default:
+				return nil, fmt.Errorf("unexpected extra request %d", n)
+			}
+		}),
+	}
+
+	tags, err := gitTagListFromGitHub("elastic/collector")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 2 {
+		t.Fatalf("HTTP round trips = %d, want 2", n)
+	}
+	if len(tags) != 2 {
+		t.Fatalf("len(tags) = %d, want 2: %#v", len(tags), tags)
+	}
+}
+
+func TestGitTagListFromGitHub_APIError(t *testing.T) {
+	orig := httpClient
+	t.Cleanup(func() { httpClient = orig })
+
+	httpClient = &http.Client{
+		Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusInternalServerError,
+				Body:       io.NopCloser(strings.NewReader(`{"message":"server error"}`)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Request:    req,
+			}, nil
+		}),
+	}
+
+	_, err := gitTagListFromGitHub("elastic/collector")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "list tags for") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/internal/versionscheck/main_test.go
+++ b/internal/versionscheck/main_test.go
@@ -102,33 +102,33 @@ func edotBaseCheckWouldError(edotVersion, latestTag string) bool {
 func TestEdotBaseVersusLatestTagGate(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name       string
-		edot       string
-		latestTag  string
+		name      string
+		edot      string
+		latestTag string
 		wantError bool
 	}{
 		{
-			name:       "edot strictly greater than latest tag",
-			edot:       "v2.0.0",
-			latestTag:  "v1.0.0",
+			name:      "edot strictly greater than latest tag",
+			edot:      "v2.0.0",
+			latestTag: "v1.0.0",
 			wantError: false,
 		},
 		{
-			name:       "edot equal to latest tag",
-			edot:       "v1.0.0",
-			latestTag:  "v1.0.0",
+			name:      "edot equal to latest tag",
+			edot:      "v1.0.0",
+			latestTag: "v1.0.0",
 			wantError: true,
 		},
 		{
-			name:       "edot strictly less than latest tag",
-			edot:       "v1.0.0",
-			latestTag:  "v2.0.0",
+			name:      "edot strictly less than latest tag",
+			edot:      "v1.0.0",
+			latestTag: "v2.0.0",
 			wantError: true,
 		},
 		{
-			name:       "no semver tags (latest empty)",
-			edot:       "v1.0.0",
-			latestTag:  "",
+			name:      "no semver tags (latest empty)",
+			edot:      "v1.0.0",
+			latestTag: "",
 			wantError: false,
 		},
 	}


### PR DESCRIPTION
Create a script that validates that the new tag is greater than the highest tag currently set to any of the modules.

The script is run during `make push-tags` to ensure the new version is actually the highest version. 

However, as of now, it does not check if the provided version is a minor increment over the current highest as described here: https://github.com/elastic/opentelemetry-collector-components/blob/main/docs/release.md#create-the-new-tags 

- Related to issue #952