### PR TITLE
[processor/elasticapmprocessor] support legacy span attributes

### DIFF
--- a/processor/elasticapmprocessor/internal/ecs/ecs_translation.go
+++ b/processor/elasticapmprocessor/internal/ecs/ecs_translation.go
@@ -259,6 +259,15 @@ func RemapSpanAttributesToECSLabels(attributes pcommon.Map) {
 			string(semconv25.NetHostNameKey),
 			string(semconv25.NetPeerNameKey),
 			string(semconv25.NetPeerPortKey),
+			string(semconv12.NetPeerIPKey),
+			string(semconv25.NetSockPeerAddrKey),
+			string(semconv.NetworkPeerAddressKey),
+			// peer.*
+			"peer.address",
+			"peer.hostname",
+			"peer.ipv4",
+			"peer.ipv6",
+			"peer.port",
 			// network.*
 			string(semconv.NetworkCarrierIccKey),
 			string(semconv.NetworkCarrierMccKey),

--- a/processor/elasticapmprocessor/internal/ecs/ecs_translation.go
+++ b/processor/elasticapmprocessor/internal/ecs/ecs_translation.go
@@ -223,6 +223,10 @@ func RemapSpanAttributesToECSLabels(attributes pcommon.Map) {
 			"type",
 			"code.stacktrace",
 			// db.*
+			"sql.query",
+			"db.type",
+			"db.instance",
+			"db.elasticsearch.cluster.name",
 			string(semconv25.DBNameKey),
 			string(semconv37.DBNamespaceKey),
 			string(semconv37.DBQueryTextKey),

--- a/processor/elasticapmprocessor/internal/enrichments/span.go
+++ b/processor/elasticapmprocessor/internal/enrichments/span.go
@@ -449,14 +449,13 @@ func (s *spanEnrichmentContext) normalizeAttributes(userAgentPraser *uaparser.Pa
 		s.rpcSystem = "grpc"
 	}
 	if s.serverAddress == "" {
-		// apm-data treats peer.address as a hostname fallback only when it is not
-		// obviously a connection string / ip:port, then uses the normalized peer
-		// host and port when synthesizing HTTP URLs and destinations:
+		// apm-data prefers hostname-like peer.address over net.peer.ip, and only
+		// uses peer.address when it is not obviously a connection string / ip:port:
 		// https://github.com/elastic/apm-data/blob/26adeeef7f92ba5e01e59fb9e4c735fb8c31b58e/input/otlp/traces.go#L840-L878
-		if s.netPeerIP != "" {
-			s.serverAddress = s.netPeerIP
-		} else if s.peerAddress != "" && (!strings.ContainsRune(s.peerAddress, ':') || net.ParseIP(s.peerAddress) != nil) {
+		if s.peerAddress != "" && (!strings.ContainsRune(s.peerAddress, ':') || net.ParseIP(s.peerAddress) != nil) {
 			s.serverAddress = s.peerAddress
+		} else if s.netPeerIP != "" {
+			s.serverAddress = s.netPeerIP
 		}
 	}
 	if s.urlFull == nil {
@@ -677,10 +676,9 @@ func (s *spanEnrichmentContext) setDestinationService(span ptrace.Span) {
 	var destnResource string
 	if s.peerService != "" {
 		destnResource = s.peerService
-	}
-
-	if s.peerAddress != "" {
-		destnResource = s.peerAddress
+		if s.peerAddress != "" {
+			destnResource = s.peerAddress
+		}
 	}
 
 	switch {

--- a/processor/elasticapmprocessor/internal/enrichments/span.go
+++ b/processor/elasticapmprocessor/internal/enrichments/span.go
@@ -673,12 +673,9 @@ func (s *spanEnrichmentContext) setServiceTarget(span ptrace.Span) {
 
 func (s *spanEnrichmentContext) setDestinationService(span ptrace.Span) {
 	attributes := span.Attributes()
-	var destnResource string
-	if s.peerService != "" {
-		destnResource = s.peerService
-		if s.peerAddress != "" {
-			destnResource = s.peerAddress
-		}
+	destnResource := s.peerService
+	if destnResource != "" && s.peerAddress != "" {
+		destnResource = s.peerAddress
 	}
 
 	switch {

--- a/processor/elasticapmprocessor/internal/enrichments/span.go
+++ b/processor/elasticapmprocessor/internal/enrichments/span.go
@@ -27,6 +27,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling"
 	"github.com/ua-parser/uap-go/uaparser"
@@ -83,6 +84,8 @@ type spanEnrichmentContext struct {
 	processorEvent           string
 	eventOutcome             string
 	peerService              string
+	peerAddress              string
+	netPeerIP                string
 	httpHost                 string
 	serverAddress            string
 	httpTarget               string
@@ -164,20 +167,28 @@ func (s *spanEnrichmentContext) capture(span ptrace.Span) {
 			s.serverAddress = v.Str()
 		case string(semconv25.ServerPortKey):
 			s.serverPort = v.Int()
-		case string(semconv25.NetPeerNameKey):
+		case string(semconv25.NetPeerNameKey), "peer.hostname":
 			if s.serverAddress == "" {
 				// net.peer.name is deprecated, so has lower priority
 				// only set when not already set with server.address
 				// and allowed to be overridden by server.address.
 				s.serverAddress = v.Str()
 			}
-		case string(semconv25.NetPeerPortKey):
+		case string(semconv25.NetPeerPortKey), "peer.port":
 			if s.serverPort == 0 {
 				// net.peer.port is deprecated, so has lower priority
 				// only set when not already set with server.port and
 				// allowed to be overridden by server.port.
 				s.serverPort = v.Int()
 			}
+		case string(semconv12.NetPeerIPKey),
+			string(semconv25.NetSockPeerAddrKey),
+			string(semconv27.NetworkPeerAddressKey),
+			"peer.ipv4",
+			"peer.ipv6":
+			s.netPeerIP = v.Str()
+		case "peer.address":
+			s.peerAddress = v.Str()
 		case string(semconv16.MessagingDestinationKey),
 			string(semconv25.MessagingDestinationNameKey),
 			"message_bus.destination":
@@ -246,12 +257,21 @@ func (s *spanEnrichmentContext) capture(span ptrace.Span) {
 		case string(semconv25.DBStatementKey),
 			string(semconv25.DBUserKey), string(semconv37.DBQueryTextKey):
 			s.isDB = true
-		case string(semconv25.DBNameKey), string(semconv37.DBNamespaceKey):
+		case string(semconv25.DBNameKey),
+			string(semconv37.DBNamespaceKey),
+			"db.instance",
+			"db.elasticsearch.cluster.name":
 			s.isDB = true
 			s.dbName = v.Str()
-		case string(semconv25.DBSystemKey), string(semconv37.DBSystemNameKey):
+		case string(semconv25.DBSystemKey), string(semconv37.DBSystemNameKey), "db.type":
 			s.isDB = true
 			s.dbSystem = v.Str()
+		case "sql.query":
+			s.isDB = true
+			// fallback if not already set
+			if s.dbSystem == "" {
+				s.dbSystem = "sql"
+			}
 		case string(semconv27.GenAISystemKey), string(semconv37.GenAIProviderNameKey):
 			s.isGenAi = true
 			s.genAiSystem = v.Str()
@@ -427,6 +447,17 @@ func (s *spanEnrichmentContext) enrichSpan(
 func (s *spanEnrichmentContext) normalizeAttributes(userAgentPraser *uaparser.Parser) {
 	if s.rpcSystem == "" && s.grpcStatus != "" {
 		s.rpcSystem = "grpc"
+	}
+	if s.serverAddress == "" {
+		// apm-data treats peer.address as a hostname fallback only when it is not
+		// obviously a connection string / ip:port, then uses the normalized peer
+		// host and port when synthesizing HTTP URLs and destinations:
+		// https://github.com/elastic/apm-data/blob/26adeeef7f92ba5e01e59fb9e4c735fb8c31b58e/input/otlp/traces.go#L840-L878
+		if s.netPeerIP != "" {
+			s.serverAddress = s.netPeerIP
+		} else if s.peerAddress != "" && (!strings.ContainsRune(s.peerAddress, ':') || net.ParseIP(s.peerAddress) != nil) {
+			s.serverAddress = s.peerAddress
+		}
 	}
 	if s.urlFull == nil {
 		s.urlFull = s.buildURLFromComponents()
@@ -646,6 +677,10 @@ func (s *spanEnrichmentContext) setDestinationService(span ptrace.Span) {
 	var destnResource string
 	if s.peerService != "" {
 		destnResource = s.peerService
+	}
+
+	if s.peerAddress != "" {
+		destnResource = s.peerAddress
 	}
 
 	switch {

--- a/processor/elasticapmprocessor/internal/enrichments/span_test.go
+++ b/processor/elasticapmprocessor/internal/enrichments/span_test.go
@@ -1585,6 +1585,42 @@ func TestElasticSpanEnrich(t *testing.T) {
 			},
 		},
 		{
+			name: "http_span_peer_address_preferred_over_net_peer_ip",
+			input: func() ptrace.Span {
+				span := getElasticSpan()
+				span.SetName("testspan")
+				span.Status().SetCode(ptrace.StatusCodeOk)
+				span.Attributes().PutInt(
+					string(semconv25.HTTPResponseStatusCodeKey),
+					http.StatusOK,
+				)
+				span.Attributes().PutStr(string(semconv25.HTTPTargetKey), "/search?q=OpenTelemetry")
+				span.Attributes().PutStr("peer.address", "api.example.com")
+				span.Attributes().PutStr(string(semconv12.NetPeerIPKey), "10.0.0.7")
+				span.Attributes().PutInt("peer.port", 8080)
+				return span
+			}(),
+			config: config.Enabled().Span,
+			enrichedAttrs: map[string]any{
+				elasticattr.TimestampUs:                    startTs.AsTime().UnixMicro(),
+				elasticattr.ProcessorEvent:                 "span",
+				elasticattr.SpanRepresentativeCount:        float64(1),
+				elasticattr.SpanType:                       "external",
+				elasticattr.SpanSubtype:                    "http",
+				elasticattr.SpanDurationUs:                 expectedDuration.Microseconds(),
+				elasticattr.EventOutcome:                   outcomeSuccess,
+				elasticattr.SuccessCount:                   int64(1),
+				"destination.address":                      "api.example.com",
+				"destination.port":                         int64(8080),
+				elasticattr.ServiceTargetType:              "http",
+				elasticattr.ServiceTargetName:              "api.example.com:8080",
+				elasticattr.SpanDestinationServiceName:     "http://api.example.com:8080",
+				elasticattr.SpanDestinationServiceType:     "external",
+				elasticattr.SpanDestinationServiceResource: "api.example.com:8080",
+				"url.original":                             "http://api.example.com:8080/search?q=OpenTelemetry",
+			},
+		},
+		{
 			name: "http_span_legacy_http_host",
 			input: func() ptrace.Span {
 				span := getElasticSpan()
@@ -1880,6 +1916,31 @@ func TestElasticSpanEnrich(t *testing.T) {
 				span.Attributes().PutStr(string(semconv25.RPCServiceKey), "service.Test")
 				span.Attributes().PutStr(string(semconv25.NetPeerNameKey), "10.2.20.18")
 				span.Attributes().PutInt(string(semconv25.NetPeerPortKey), 8081)
+				return span
+			}(),
+			config: config.Enabled().Span,
+			enrichedAttrs: map[string]any{
+				elasticattr.TimestampUs:                    startTs.AsTime().UnixMicro(),
+				elasticattr.ProcessorEvent:                 "span",
+				elasticattr.SpanRepresentativeCount:        float64(1),
+				elasticattr.SpanType:                       "external",
+				elasticattr.SpanDurationUs:                 expectedDuration.Microseconds(),
+				elasticattr.EventOutcome:                   outcomeSuccess,
+				elasticattr.SuccessCount:                   int64(1),
+				elasticattr.ServiceTargetType:              "external",
+				elasticattr.ServiceTargetName:              "service.Test",
+				elasticattr.SpanDestinationServiceResource: "10.2.20.18:8081",
+			},
+		},
+		{
+			name: "rpc_span_peer.address_port_fallback",
+			input: func() ptrace.Span {
+				span := getElasticSpan()
+				span.SetName("testspan")
+				// No peer.service is set.
+				span.Attributes().PutStr(string(semconv25.RPCServiceKey), "service.Test")
+				span.Attributes().PutStr("peer.address", "10.2.20.18")
+				span.Attributes().PutInt("peer.port", 8081)
 				return span
 			}(),
 			config: config.Enabled().Span,
@@ -2552,7 +2613,8 @@ func TestElasticSpanEnrich(t *testing.T) {
 				span.Attributes().PutInt(string(semconv25.NetPeerPortKey), 5432)
 				return span
 			}(),
-			config: config.Enabled().Span,
+			config:           config.Enabled().Span,
+			remapToECSLabels: true,
 			enrichedAttrs: map[string]any{
 				elasticattr.SpanDestinationServiceResource: "postgresql",
 				elasticattr.SpanType:                       "db",
@@ -2576,7 +2638,8 @@ func TestElasticSpanEnrich(t *testing.T) {
 				span.Attributes().PutStr("db.type", "elasticsearch")
 				return span
 			}(),
-			config: config.Enabled().Span,
+			config:           config.Enabled().Span,
+			remapToECSLabels: true,
 			enrichedAttrs: map[string]any{
 				elasticattr.SpanDestinationServiceResource: "elasticsearch",
 				elasticattr.SpanType:                       "db",

--- a/processor/elasticapmprocessor/internal/enrichments/span_test.go
+++ b/processor/elasticapmprocessor/internal/enrichments/span_test.go
@@ -1550,6 +1550,41 @@ func TestElasticSpanEnrich(t *testing.T) {
 			},
 		},
 		{
+			name: "http_span_peer_address_port_fallback",
+			input: func() ptrace.Span {
+				span := getElasticSpan()
+				span.SetName("testspan")
+				span.Status().SetCode(ptrace.StatusCodeOk)
+				span.Attributes().PutInt(
+					string(semconv25.HTTPResponseStatusCodeKey),
+					http.StatusOK,
+				)
+				span.Attributes().PutStr(string(semconv25.HTTPTargetKey), "/search?q=OpenTelemetry")
+				span.Attributes().PutStr("peer.address", "api.example.com")
+				span.Attributes().PutInt("peer.port", 8080)
+				return span
+			}(),
+			config: config.Enabled().Span,
+			enrichedAttrs: map[string]any{
+				elasticattr.TimestampUs:                    startTs.AsTime().UnixMicro(),
+				elasticattr.ProcessorEvent:                 "span",
+				elasticattr.SpanRepresentativeCount:        float64(1),
+				elasticattr.SpanType:                       "external",
+				elasticattr.SpanSubtype:                    "http",
+				elasticattr.SpanDurationUs:                 expectedDuration.Microseconds(),
+				elasticattr.EventOutcome:                   outcomeSuccess,
+				elasticattr.SuccessCount:                   int64(1),
+				"destination.address":                      "api.example.com",
+				"destination.port":                         int64(8080),
+				elasticattr.ServiceTargetType:              "http",
+				elasticattr.ServiceTargetName:              "api.example.com:8080",
+				elasticattr.SpanDestinationServiceName:     "http://api.example.com:8080",
+				elasticattr.SpanDestinationServiceType:     "external",
+				elasticattr.SpanDestinationServiceResource: "api.example.com:8080",
+				"url.original":                             "http://api.example.com:8080/search?q=OpenTelemetry",
+			},
+		},
+		{
 			name: "http_span_legacy_http_host",
 			input: func() ptrace.Span {
 				span := getElasticSpan()
@@ -1889,6 +1924,33 @@ func TestElasticSpanEnrich(t *testing.T) {
 			},
 		},
 		{
+			name: "messaging_legacy_aliases",
+			input: func() ptrace.Span {
+				span := getElasticSpan()
+				span.SetName("testspan")
+				span.Attributes().PutStr(string(semconv25.MessagingSystemKey), "kafka")
+				span.Attributes().PutStr("message_bus.destination", "t1")
+				span.Attributes().PutStr(string(semconv27.MessagingOperationTypeKey), "publish")
+				return span
+			}(),
+			config: config.Enabled().Span,
+			enrichedAttrs: map[string]any{
+				elasticattr.TimestampUs:                    startTs.AsTime().UnixMicro(),
+				elasticattr.ProcessorEvent:                 "span",
+				elasticattr.SpanRepresentativeCount:        float64(1),
+				elasticattr.SpanType:                       "messaging",
+				elasticattr.SpanSubtype:                    "kafka",
+				elasticattr.SpanAction:                     "publish",
+				elasticattr.SpanDurationUs:                 expectedDuration.Microseconds(),
+				elasticattr.EventOutcome:                   outcomeSuccess,
+				elasticattr.SuccessCount:                   int64(1),
+				elasticattr.ServiceTargetType:              "kafka",
+				elasticattr.ServiceTargetName:              "t1",
+				elasticattr.SpanDestinationServiceResource: "kafka/t1",
+				elasticattr.SpanMessageQueueName:           "t1",
+			},
+		},
+		{
 			name: "messaging_with_existing_attributes_are_preserved",
 			input: func() ptrace.Span {
 				span := getElasticSpan()
@@ -1954,6 +2016,33 @@ func TestElasticSpanEnrich(t *testing.T) {
 				span.SetName("testspan")
 				span.Attributes().PutStr(string(semconv25.PeerServiceKey), "testsvc")
 				span.Attributes().PutBool(string(semconv25.MessagingDestinationTemporaryKey), true)
+				span.Attributes().PutStr(string(semconv25.MessagingOperationKey), "receive")
+				span.Attributes().PutStr(string(semconv25.MessagingDestinationNameKey), "t1")
+				return span
+			}(),
+			config: config.Enabled().Span,
+			enrichedAttrs: map[string]any{
+				elasticattr.TimestampUs:                    startTs.AsTime().UnixMicro(),
+				elasticattr.ProcessorEvent:                 "span",
+				elasticattr.SpanRepresentativeCount:        float64(1),
+				elasticattr.SpanType:                       "messaging",
+				elasticattr.SpanAction:                     "receive",
+				elasticattr.SpanDurationUs:                 expectedDuration.Microseconds(),
+				elasticattr.EventOutcome:                   outcomeSuccess,
+				elasticattr.SuccessCount:                   int64(1),
+				elasticattr.ServiceTargetType:              "messaging",
+				elasticattr.ServiceTargetName:              "testsvc",
+				elasticattr.SpanDestinationServiceResource: "testsvc/t1",
+				elasticattr.SpanMessageQueueName:           "t1",
+			},
+		},
+		{
+			name: "messaging_legacy_temp_destination",
+			input: func() ptrace.Span {
+				span := getElasticSpan()
+				span.SetName("testspan")
+				span.Attributes().PutStr(string(semconv25.PeerServiceKey), "testsvc")
+				span.Attributes().PutBool(string(semconv16.MessagingTempDestinationKey), true)
 				span.Attributes().PutStr(string(semconv25.MessagingOperationKey), "receive")
 				span.Attributes().PutStr(string(semconv25.MessagingDestinationNameKey), "t1")
 				return span
@@ -2449,6 +2538,57 @@ func TestElasticSpanEnrich(t *testing.T) {
 				elasticattr.TransactionResult:              "existing-result",
 				elasticattr.EventOutcome:                   "existing-outcome",
 				elasticattr.SuccessCount:                   int64(99),
+			},
+		},
+		{
+			name: "db_span_legacy_aliases",
+			input: func() ptrace.Span {
+				span := getElasticSpan()
+				span.SetName("select users")
+				span.Attributes().PutStr("sql.query", "select * from users")
+				span.Attributes().PutStr("db.type", "postgresql")
+				span.Attributes().PutStr("db.instance", "users")
+				span.Attributes().PutStr("peer.hostname", "db.example.com")
+				span.Attributes().PutInt(string(semconv25.NetPeerPortKey), 5432)
+				return span
+			}(),
+			config: config.Enabled().Span,
+			enrichedAttrs: map[string]any{
+				elasticattr.SpanDestinationServiceResource: "postgresql",
+				elasticattr.SpanType:                       "db",
+				elasticattr.SpanSubtype:                    "postgresql",
+				elasticattr.TimestampUs:                    startTs.AsTime().UnixMicro(),
+				elasticattr.SpanDurationUs:                 expectedDuration.Microseconds(),
+				elasticattr.ProcessorEvent:                 "span",
+				elasticattr.EventOutcome:                   outcomeSuccess,
+				elasticattr.SuccessCount:                   int64(1),
+				elasticattr.SpanRepresentativeCount:        float64(1),
+				elasticattr.ServiceTargetType:              "postgresql",
+				elasticattr.ServiceTargetName:              "users",
+			},
+		},
+		{
+			name: "db_span_elasticsearch_cluster_name_alias",
+			input: func() ptrace.Span {
+				span := getElasticSpan()
+				span.SetName("select users")
+				span.Attributes().PutStr("db.elasticsearch.cluster.name", "cluster-a")
+				span.Attributes().PutStr("db.type", "elasticsearch")
+				return span
+			}(),
+			config: config.Enabled().Span,
+			enrichedAttrs: map[string]any{
+				elasticattr.SpanDestinationServiceResource: "elasticsearch",
+				elasticattr.SpanType:                       "db",
+				elasticattr.SpanSubtype:                    "elasticsearch",
+				elasticattr.TimestampUs:                    startTs.AsTime().UnixMicro(),
+				elasticattr.SpanDurationUs:                 expectedDuration.Microseconds(),
+				elasticattr.ProcessorEvent:                 "span",
+				elasticattr.EventOutcome:                   outcomeSuccess,
+				elasticattr.SuccessCount:                   int64(1),
+				elasticattr.SpanRepresentativeCount:        float64(1),
+				elasticattr.ServiceTargetType:              "elasticsearch",
+				elasticattr.ServiceTargetName:              "cluster-a",
 			},
 		},
 		{


### PR DESCRIPTION
Add support for legacy span attributes in `elasticapmprocessor` to better match `apm-data` behavior