### PR TITLE
receiver/entityanalyticsreceiver: wire Jamf into provider registry

### DIFF
--- a/receiver/entityanalyticsreceiver/README.md
+++ b/receiver/entityanalyticsreceiver/README.md
@@ -67,6 +67,6 @@ distribution.
 
 ## Status
 
-This receiver is in **development** stability. The provider registry is
-currently empty — concrete provider implementations (Okta, EntraID,
-Active Directory, Jamf) will be added in subsequent work.
+This receiver is in **development** stability. The Jamf provider is
+registered. Further providers (Okta, EntraID, Active Directory) will
+be added in subsequent work.

--- a/receiver/entityanalyticsreceiver/config.go
+++ b/receiver/entityanalyticsreceiver/config.go
@@ -51,5 +51,8 @@ func (cfg *Config) Validate() error {
 	if cfg.UpdateInterval <= 0 {
 		return fmt.Errorf("update_interval must be positive")
 	}
+	if cfg.SyncInterval <= cfg.UpdateInterval {
+		return fmt.Errorf("sync_interval must be greater than update_interval")
+	}
 	return nil
 }

--- a/receiver/entityanalyticsreceiver/go.mod
+++ b/receiver/entityanalyticsreceiver/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/component v1.55.0
 	go.opentelemetry.io/collector/component/componenttest v0.149.0
+	go.opentelemetry.io/collector/config/configopaque v1.55.0
 	go.opentelemetry.io/collector/confmap v1.55.0
 	go.opentelemetry.io/collector/consumer v1.55.0
 	go.opentelemetry.io/collector/consumer/consumertest v0.149.0
@@ -37,6 +38,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
+	go.opentelemetry.io/collector/confmap/xconfmap v0.149.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror v0.149.0 // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.149.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.55.0 // indirect

--- a/receiver/entityanalyticsreceiver/go.mod
+++ b/receiver/entityanalyticsreceiver/go.mod
@@ -3,7 +3,7 @@ module github.com/elastic/opentelemetry-collector-components/receiver/entityanal
 go 1.25.0
 
 require (
-	github.com/elastic/entcollect v0.0.0-20260408214411-765a9bedd20c
+	github.com/elastic/entcollect v0.0.0-20260501012805-5fd94422b104
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/component v1.55.0
 	go.opentelemetry.io/collector/component/componenttest v0.149.0

--- a/receiver/entityanalyticsreceiver/go.sum
+++ b/receiver/entityanalyticsreceiver/go.sum
@@ -3,8 +3,8 @@ github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/elastic/entcollect v0.0.0-20260408214411-765a9bedd20c h1:Mad7EnSJiXwg0HokotucGjGRLyrdHSqFEkVWw75xU2M=
-github.com/elastic/entcollect v0.0.0-20260408214411-765a9bedd20c/go.mod h1:jEKK/XEA4Xnu0ssVhLBlExQHPwb1A0b1E2MsPLlpxmY=
+github.com/elastic/entcollect v0.0.0-20260501012805-5fd94422b104 h1:en8CqvVRWRToaE++kq+pjJGD7WZJtY8hGRmuc3O8zso=
+github.com/elastic/entcollect v0.0.0-20260501012805-5fd94422b104/go.mod h1:jEKK/XEA4Xnu0ssVhLBlExQHPwb1A0b1E2MsPLlpxmY=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=

--- a/receiver/entityanalyticsreceiver/go.sum
+++ b/receiver/entityanalyticsreceiver/go.sum
@@ -59,8 +59,12 @@ go.opentelemetry.io/collector/component v1.55.0 h1:45nb42/UqPDhRdS8FgGRDybRsWSuv
 go.opentelemetry.io/collector/component v1.55.0/go.mod h1:7EpGxVpqFkZ2HidyiE9MLvh4cuKU7ye6i5OtxxiYKps=
 go.opentelemetry.io/collector/component/componenttest v0.149.0 h1:7SSYIiLpe84LGfYAp7RCkzYuYLuYVSZVn/K/qsJZgHY=
 go.opentelemetry.io/collector/component/componenttest v0.149.0/go.mod h1:8xPU3XMsI+J4vfy87YG1bsCVTeedligKWgBcPEZ0yzw=
+go.opentelemetry.io/collector/config/configopaque v1.55.0 h1:j8I6lotzrJX29X1YhKUQTuJs/9HWgFV3Ckbe/tZZzhI=
+go.opentelemetry.io/collector/config/configopaque v1.55.0/go.mod h1:xEWgIwWn8J3cn5E6DybThH0Cdu3Be8IVEItWkbWU2Xc=
 go.opentelemetry.io/collector/confmap v1.55.0 h1:pBJbjWfIT3q8cy+eVcHCCYXx984NxOjaGTHqIWsXC1A=
 go.opentelemetry.io/collector/confmap v1.55.0/go.mod h1:rSKNE5ztWU6fS0pT8rwACn573r4jJc4QzJyoQzZIVtE=
+go.opentelemetry.io/collector/confmap/xconfmap v0.149.0 h1:D/WzrxKOKedRztoY/MiAj9z8W0/2unpTCbANFCwvuuY=
+go.opentelemetry.io/collector/confmap/xconfmap v0.149.0/go.mod h1:lJ1nHIQbH6L5wnj5vTWGr7RWi5Kib2KX5stAxar13Jo=
 go.opentelemetry.io/collector/consumer v1.55.0 h1:7Per8P4J0nlBrFVSXb+nwZ+egiel1BRtggZngyykGsM=
 go.opentelemetry.io/collector/consumer v1.55.0/go.mod h1:Qrn5fDp/HpDmUp+l2RGKsdKyOPlgGlaZPKvw/z9FfEc=
 go.opentelemetry.io/collector/consumer/consumererror v0.149.0 h1:lXJv8UySfvnISJnCbkxf9ghYRQoWcXC78PxGurdnhKY=

--- a/receiver/entityanalyticsreceiver/jamf.go
+++ b/receiver/entityanalyticsreceiver/jamf.go
@@ -71,19 +71,25 @@ func jamfProvider(cfg *confmap.Conf) (entcollect.Provider, error) {
 		ec.Username = os.Getenv("JAMF_USERNAME")
 		ec.Password = os.Getenv("JAMF_PASSWORD")
 		if v := os.Getenv("JAMF_PAGE_SIZE"); v != "" {
-			if n, err := strconv.Atoi(v); err == nil {
-				ec.PageSize = n
+			n, err := strconv.Atoi(v)
+			if err != nil {
+				return nil, fmt.Errorf("jamf: parse JAMF_PAGE_SIZE: %w", err)
 			}
+			ec.PageSize = n
 		}
 		if v := os.Getenv("JAMF_IDSET_SHARDS"); v != "" {
-			if n, err := strconv.Atoi(v); err == nil {
-				ec.IDSetShards = n
+			n, err := strconv.Atoi(v)
+			if err != nil {
+				return nil, fmt.Errorf("jamf: parse JAMF_IDSET_SHARDS: %w", err)
 			}
+			ec.IDSetShards = n
 		}
 		if v := os.Getenv("JAMF_TOKEN_GRACE_PERIOD"); v != "" {
-			if d, err := time.ParseDuration(v); err == nil {
-				ec.TokenGrace = d
+			d, err := time.ParseDuration(v)
+			if err != nil {
+				return nil, fmt.Errorf("jamf: parse JAMF_TOKEN_GRACE_PERIOD: %w", err)
 			}
+			ec.TokenGrace = d
 		}
 	}
 	err := ec.Validate()

--- a/receiver/entityanalyticsreceiver/jamf.go
+++ b/receiver/entityanalyticsreceiver/jamf.go
@@ -1,0 +1,81 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package entityanalyticsreceiver // import "github.com/elastic/opentelemetry-collector-components/receiver/entityanalyticsreceiver"
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	"go.opentelemetry.io/collector/confmap"
+
+	"github.com/elastic/entcollect"
+	ecjamf "github.com/elastic/entcollect/provider/jamf"
+)
+
+func init() {
+	Register("jamf", jamfProvider)
+}
+
+func jamfProvider(cfg *confmap.Conf) (entcollect.Provider, error) {
+	ec := ecjamf.DefaultConfig()
+	if cfg != nil {
+		// jamfLocalConf mirrors ecjamf.Config with mapstructure tags for confmap.Conf
+		// Unmarshal. If ecjamf.Config gains a new field, add it here too.
+		type jamfLocalConf struct {
+			TenantID    string        `mapstructure:"jamf_tenant"`
+			Username    string        `mapstructure:"jamf_username"`
+			Password    string        `mapstructure:"jamf_password"`
+			PageSize    int           `mapstructure:"page_size"`
+			IDSetShards int           `mapstructure:"idset_shards"`
+			TokenGrace  time.Duration `mapstructure:"token_grace_period"`
+		}
+
+		lc := jamfLocalConf{
+			IDSetShards: ec.IDSetShards,
+			TokenGrace:  ec.TokenGrace,
+		}
+		err := cfg.Unmarshal(&lc)
+		if err != nil {
+			return nil, fmt.Errorf("jamf: unmarshal config: %w", err)
+		}
+		ec.TenantID = lc.TenantID
+		ec.Username = lc.Username
+		ec.Password = lc.Password
+		ec.PageSize = lc.PageSize
+		ec.IDSetShards = lc.IDSetShards
+		ec.TokenGrace = lc.TokenGrace
+	} else {
+		// cfg is nil when the receiver has no provider-specific sub-config
+		// (the current default). Credentials are read from environment variables.
+		ec.TenantID = os.Getenv("JAMF_TENANT")
+		ec.Username = os.Getenv("JAMF_USERNAME")
+		ec.Password = os.Getenv("JAMF_PASSWORD")
+		if v := os.Getenv("JAMF_PAGE_SIZE"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil {
+				ec.PageSize = n
+			}
+		}
+	}
+	err := ec.Validate()
+	if err != nil {
+		return nil, err
+	}
+	return ecjamf.New(ec), nil
+}

--- a/receiver/entityanalyticsreceiver/jamf.go
+++ b/receiver/entityanalyticsreceiver/jamf.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 	"time"
 
+	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/confmap"
 
 	"github.com/elastic/entcollect"
@@ -39,15 +40,16 @@ func jamfProvider(cfg *confmap.Conf) (entcollect.Provider, error) {
 		// jamfLocalConf mirrors ecjamf.Config with mapstructure tags for confmap.Conf
 		// Unmarshal. If ecjamf.Config gains a new field, add it here too.
 		type jamfLocalConf struct {
-			TenantID    string        `mapstructure:"jamf_tenant"`
-			Username    string        `mapstructure:"jamf_username"`
-			Password    string        `mapstructure:"jamf_password"`
-			PageSize    int           `mapstructure:"page_size"`
-			IDSetShards int           `mapstructure:"idset_shards"`
-			TokenGrace  time.Duration `mapstructure:"token_grace_period"`
+			TenantID    configopaque.String `mapstructure:"jamf_tenant"`
+			Username    configopaque.String `mapstructure:"jamf_username"`
+			Password    configopaque.String `mapstructure:"jamf_password"`
+			PageSize    int                 `mapstructure:"page_size"`
+			IDSetShards int                 `mapstructure:"idset_shards"`
+			TokenGrace  time.Duration       `mapstructure:"token_grace_period"`
 		}
 
 		lc := jamfLocalConf{
+			PageSize:    ec.PageSize,
 			IDSetShards: ec.IDSetShards,
 			TokenGrace:  ec.TokenGrace,
 		}
@@ -55,21 +57,32 @@ func jamfProvider(cfg *confmap.Conf) (entcollect.Provider, error) {
 		if err != nil {
 			return nil, fmt.Errorf("jamf: unmarshal config: %w", err)
 		}
-		ec.TenantID = lc.TenantID
-		ec.Username = lc.Username
-		ec.Password = lc.Password
+		ec.TenantID = string(lc.TenantID)
+		ec.Username = string(lc.Username)
+		ec.Password = string(lc.Password)
 		ec.PageSize = lc.PageSize
 		ec.IDSetShards = lc.IDSetShards
 		ec.TokenGrace = lc.TokenGrace
 	} else {
 		// cfg is nil when the receiver has no provider-specific sub-config
-		// (the current default). Credentials are read from environment variables.
+		// (the current default). Credentials and optional settings are read
+		// from environment variables.
 		ec.TenantID = os.Getenv("JAMF_TENANT")
 		ec.Username = os.Getenv("JAMF_USERNAME")
 		ec.Password = os.Getenv("JAMF_PASSWORD")
 		if v := os.Getenv("JAMF_PAGE_SIZE"); v != "" {
 			if n, err := strconv.Atoi(v); err == nil {
 				ec.PageSize = n
+			}
+		}
+		if v := os.Getenv("JAMF_IDSET_SHARDS"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil {
+				ec.IDSetShards = n
+			}
+		}
+		if v := os.Getenv("JAMF_TOKEN_GRACE_PERIOD"); v != "" {
+			if d, err := time.ParseDuration(v); err == nil {
+				ec.TokenGrace = d
 			}
 		}
 	}

--- a/receiver/entityanalyticsreceiver/jamf_test.go
+++ b/receiver/entityanalyticsreceiver/jamf_test.go
@@ -1,0 +1,60 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package entityanalyticsreceiver
+
+import (
+	"reflect"
+	"testing"
+
+	"go.opentelemetry.io/collector/confmap"
+
+	ecjamf "github.com/elastic/entcollect/provider/jamf"
+)
+
+// TestJamfProviderConfigRoundTrip verifies that every provider-owned field of
+// ecjamf.Config is represented in the jamfLocalConf mirror inside
+// jamfProvider. It does this in two ways:
+//
+//  1. Field-count assertion — ecjamf.Config currently has wantTotal fields.
+//     Two of them (SyncInterval, UpdateInterval) are owned by the receiver's
+//     top-level Config and are intentionally absent from jamfLocalConf.
+//     If the total changes, update jamfLocalConf and this test.
+//  2. Functional round-trip — all jamfLocalConf fields are set to non-default
+//     sentinel values via a confmap.Conf; jamfProvider must return no error,
+//     confirming that credentials and optional fields are wired through.
+func TestJamfProviderConfigRoundTrip(t *testing.T) {
+	const wantTotal = 8
+	if got := reflect.TypeOf(ecjamf.Config{}).NumField(); got != wantTotal {
+		t.Fatalf("ecjamf.Config has %d exported fields, want %d; "+
+			"update jamfLocalConf inside jamfProvider and this test", got, wantTotal)
+	}
+
+	cfg := confmap.NewFromStringMap(map[string]any{
+		"jamf_tenant":        "tenant.jamfcloud.com",
+		"jamf_username":      "user",
+		"jamf_password":      "pass",
+		"page_size":          50,
+		"idset_shards":       32,
+		"token_grace_period": "2m",
+	})
+
+	_, err := jamfProvider(cfg)
+	if err != nil {
+		t.Fatalf("jamfProvider returned unexpected error: %v", err)
+	}
+}

--- a/receiver/entityanalyticsreceiver/receiver_test.go
+++ b/receiver/entityanalyticsreceiver/receiver_test.go
@@ -221,7 +221,7 @@ func testConfig(provider string) *Config {
 	return &Config{
 		Provider:       provider,
 		StorageID:      "elasticsearch_storage",
-		SyncInterval:   time.Hour,
+		SyncInterval:   24 * time.Hour,
 		UpdateInterval: time.Hour,
 	}
 }


### PR DESCRIPTION
Register the entcollect Jamf provider under the "jamf" name so that the entity analytics receiver can use it. The registration mirrors the pattern established by the receiver added in #1153.

A local mapstructure-tagged struct (jamfLocalConf) is defined inside jamfProvider for the cfg != nil path, bridging confmap.Conf to ecjamf.Config. SyncInterval and UpdateInterval are intentionally absent from jamfLocalConf: they are owned by the receiver's top-level Config. When cfg is nil (the current default, since the receiver passes no provider sub-config), credentials are read from the JAMF_TENANT, JAMF_USERNAME, and JAMF_PASSWORD environment variables.

TestJamfProviderConfigRoundTrip guards against future drift: a field-count assertion on ecjamf.Config catches unhandled additions, and a functional round-trip through confmap.Conf confirms that the six provider-owned fields are unmarshalled and validated end-to-end.

For elastic/beats#49164