### PR TITLE
receiver/entityanalyticsreceiver: make sync loop self-healing after failed full sync

### DIFF
--- a/receiver/entityanalyticsreceiver/receiver.go
+++ b/receiver/entityanalyticsreceiver/receiver.go
@@ -102,31 +102,44 @@ func (r *entityAnalyticsReceiver) Shutdown(_ context.Context) error {
 	return nil
 }
 
+// run drives the sync loop with a single ticker at UpdateInterval.
+// At each tick, a full sync is performed if the last successful full
+// sync is older than SyncInterval (or has never happened); otherwise
+// an incremental sync runs. This is self-healing: a failed full sync
+// leaves lastFullSyncAt at its zero value, so every subsequent tick
+// retries a full sync until one succeeds. Note that under persistent
+// full-sync failure, retries occur at UpdateInterval cadence, not at
+// SyncInterval.
 func (r *entityAnalyticsReceiver) run(ctx context.Context, store entcollect.Store, provider entcollect.Provider, log *slog.Logger) {
 	defer r.wg.Done()
 
 	pub := newPublisher(r.consumer, r.cfg.Provider, metadata.ScopeName, r.buildVersion)
 
-	r.doSync(ctx, store, provider, pub, log, true)
+	var lastFullSyncAt time.Time
+	if r.doSync(ctx, store, provider, pub, log, true) {
+		lastFullSyncAt = time.Now()
+	}
 
-	fullTicker := time.NewTicker(r.cfg.SyncInterval)
-	defer fullTicker.Stop()
-	incrTicker := time.NewTicker(r.cfg.UpdateInterval)
-	defer incrTicker.Stop()
+	ticker := time.NewTicker(r.cfg.UpdateInterval)
+	defer ticker.Stop()
 
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case <-fullTicker.C:
-			r.doSync(ctx, store, provider, pub, log, true)
-		case <-incrTicker.C:
-			r.doSync(ctx, store, provider, pub, log, false)
+		case <-ticker.C:
+			full := lastFullSyncAt.IsZero() || time.Since(lastFullSyncAt) >= r.cfg.SyncInterval
+			if r.doSync(ctx, store, provider, pub, log, full) && full {
+				lastFullSyncAt = time.Now()
+			}
 		}
 	}
 }
 
-func (r *entityAnalyticsReceiver) doSync(ctx context.Context, store entcollect.Store, provider entcollect.Provider, pub entcollect.Publisher, log *slog.Logger, full bool) {
+// doSync runs one sync (full or incremental) and commits the buffer
+// on success. It returns true if both the sync and the commit
+// succeeded, false otherwise.
+func (r *entityAnalyticsReceiver) doSync(ctx context.Context, store entcollect.Store, provider entcollect.Provider, pub entcollect.Publisher, log *slog.Logger, full bool) bool {
 	kind := "full"
 	if !full {
 		kind = "incremental"
@@ -143,11 +156,12 @@ func (r *entityAnalyticsReceiver) doSync(ctx context.Context, store entcollect.S
 	if err != nil {
 		buf.Discard()
 		r.logger.Error("sync failed", zap.String("kind", kind), zap.Error(err))
-		return
+		return false
 	}
 	if err := buf.Commit(); err != nil {
 		r.logger.Error("committing sync state", zap.String("kind", kind), zap.Error(err))
-		return
+		return false
 	}
 	r.logger.Info("sync complete", zap.String("kind", kind))
+	return true
 }

--- a/receiver/entityanalyticsreceiver/receiver_test.go
+++ b/receiver/entityanalyticsreceiver/receiver_test.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sync"
 	"testing"
 	"time"
 
@@ -166,6 +167,36 @@ func TestCommitFailureAfterSuccessfulSync(t *testing.T) {
 
 	assert.Equal(t, 3, sink.LogRecordCount(), "docs should have been consumed despite commit failure")
 	assert.Empty(t, base.data, "store should be empty — commit could not persist state")
+}
+
+// TestSelfHealingAfterFailedFullSync verifies that when the initial
+// full sync fails, the next tick retries a full sync rather than
+// silently calling IncrementalSync against unestablished state.
+func TestSelfHealingAfterFailedFullSync(t *testing.T) {
+	const name = "test_selfheal"
+
+	prov := &recordingProvider{failFullN: 1}
+	Register(name, func(_ *confmap.Conf) (entcollect.Provider, error) { return prov, nil })
+	t.Cleanup(func() { unregister(name) })
+
+	cfg := &Config{
+		Provider:       name,
+		StorageID:      "elasticsearch_storage",
+		SyncInterval:   10 * time.Millisecond,
+		UpdateInterval: 10 * time.Millisecond,
+	}
+	rcvr := newReceiver(nopSettings(), cfg, &consumertest.LogsSink{})
+	require.NoError(t, rcvr.Start(context.Background(), testHost(name, newMemoryStore())))
+	t.Cleanup(func() { require.NoError(t, rcvr.Shutdown(context.Background())) })
+
+	require.Eventually(t, func() bool {
+		return prov.callCount() >= 2
+	}, 5*time.Second, 5*time.Millisecond)
+
+	calls := prov.calls()
+	require.GreaterOrEqual(t, len(calls), 2)
+	assert.Equal(t, "full", calls[0], "first call must be full")
+	assert.Equal(t, "full", calls[1], "second call must also be full because the first full sync failed")
 }
 
 func TestShutdownCancelsSync(t *testing.T) {
@@ -385,3 +416,44 @@ type notRegistryExtension struct{}
 
 func (n *notRegistryExtension) Start(context.Context, component.Host) error { return nil }
 func (n *notRegistryExtension) Shutdown(context.Context) error              { return nil }
+
+// recordingProvider records the kind of each sync call ("full" or
+// "incremental") and fails the first failFullN full sync calls.
+type recordingProvider struct {
+	mu         sync.Mutex
+	callsLog   []string
+	fullErrors int
+	failFullN  int
+}
+
+func (p *recordingProvider) FullSync(context.Context, entcollect.Store, entcollect.Publisher, *slog.Logger) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.callsLog = append(p.callsLog, "full")
+	if p.fullErrors < p.failFullN {
+		p.fullErrors++
+		return errors.New("full sync failed")
+	}
+	return nil
+}
+
+func (p *recordingProvider) IncrementalSync(context.Context, entcollect.Store, entcollect.Publisher, *slog.Logger) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.callsLog = append(p.callsLog, "incremental")
+	return nil
+}
+
+func (p *recordingProvider) callCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.callsLog)
+}
+
+func (p *recordingProvider) calls() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]string, len(p.callsLog))
+	copy(out, p.callsLog)
+	return out
+}


### PR DESCRIPTION
The previous loop used two independent tickers — one at SyncInterval that always called FullSync, and one at UpdateInterval that always called IncrementalSync. If the initial full sync (or any later full sync) failed, every incremental tick between then and the next full ticker fire called IncrementalSync against state that was never established. For providers with true incremental mode this would emit wrong or missing data for up to one full SyncInterval.

Drive the loop from a single ticker at UpdateInterval and track lastFullSyncAt in memory. At each tick perform a full sync if the last successful full sync is older than SyncInterval (or has never happened); otherwise perform an incremental sync. A failed full sync leaves lastFullSyncAt at its zero value, so every subsequent tick retries a full sync until one succeeds.

Note that under persistent full-sync failure, retries occur at UpdateInterval cadence rather than SyncInterval. Net API call frequency during an outage is unchanged from the previous design, which was also calling the API every UpdateInterval (just via incorrect IncrementalSync calls).

In-memory tracking is sufficient because run() unconditionally performs an immediate full sync at startup, closing any gap across restarts.

ref: https://github.com/elastic/opentelemetry-collector-components/pull/1192#pullrequestreview-4210978284