### PR TITLE
[connector/elasticapmconnector] add _doc_count mapping hint and forward elasticsearch.doc_count

### DIFF
--- a/connector/elasticapmconnector/config.go
+++ b/connector/elasticapmconnector/config.go
@@ -407,7 +407,16 @@ func (cfg Config) signaltometricsConfig() *signaltometricsconfig.Config {
 			Name:                      "span.destination.service.response_time.sum.us",
 			Description:               "APM span destination metrics",
 			IncludeResourceAttributes: spanDestinationResourceAttributes,
-			Attributes:                spanDestinationAttributes,
+			Attributes: append(slices.Clone(spanDestinationAttributes),
+				signaltometricsconfig.Attribute{
+					Key:          "elasticsearch.mapping.hints",
+					DefaultValue: []any{"_doc_count"},
+				},
+				signaltometricsconfig.Attribute{
+					Key:      "elasticsearch.doc_count",
+					Optional: true,
+				},
+			),
 			Conditions: []string{
 				`attributes["span.composite.sum.us"] != nil`,
 			},
@@ -420,7 +429,10 @@ func (cfg Config) signaltometricsConfig() *signaltometricsconfig.Config {
 			Name:                      "span.destination.service.response_time.sum.us",
 			Description:               "APM span destination metrics",
 			IncludeResourceAttributes: spanDestinationResourceAttributes,
-			Attributes:                spanDestinationAttributes,
+			Attributes: append(slices.Clone(spanDestinationAttributes), signaltometricsconfig.Attribute{
+				Key:          "elasticsearch.mapping.hints",
+				DefaultValue: []any{"_doc_count"},
+			}),
 			Conditions: []string{
 				`attributes["span.composite.sum.us"] == nil`,
 			},
@@ -434,7 +446,16 @@ func (cfg Config) signaltometricsConfig() *signaltometricsconfig.Config {
 			Name:                      "span.destination.service.response_time.count",
 			Description:               "APM span destination metrics",
 			IncludeResourceAttributes: spanDestinationResourceAttributes,
-			Attributes:                spanDestinationAttributes,
+			Attributes: append(slices.Clone(spanDestinationAttributes),
+				signaltometricsconfig.Attribute{
+					Key:          "elasticsearch.mapping.hints",
+					DefaultValue: []any{"_doc_count"},
+				},
+				signaltometricsconfig.Attribute{
+					Key:      "elasticsearch.doc_count",
+					Optional: true,
+				},
+			),
 			Conditions: []string{
 				`attributes["span.composite.count"] != nil`,
 			},
@@ -446,7 +467,10 @@ func (cfg Config) signaltometricsConfig() *signaltometricsconfig.Config {
 			Name:                      "span.destination.service.response_time.count",
 			Description:               "APM span destination metrics",
 			IncludeResourceAttributes: spanDestinationResourceAttributes,
-			Attributes:                spanDestinationAttributes,
+			Attributes: append(slices.Clone(spanDestinationAttributes), signaltometricsconfig.Attribute{
+				Key:          "elasticsearch.mapping.hints",
+				DefaultValue: []any{"_doc_count"},
+			}),
 			Conditions: []string{
 				`attributes["span.composite.count"] == nil`,
 			},

--- a/connector/elasticapmconnector/connector_test.go
+++ b/connector/elasticapmconnector/connector_test.go
@@ -143,6 +143,7 @@ func TestConnector_TracesToMetrics(t *testing.T) {
 		{name: "traces/transaction_metrics_no_overflow"},
 		{name: "traces/transaction_metrics_no_result"},
 		{name: "traces/span_metrics"},
+		{name: "traces/span_metrics_composite"},
 		{name: "traces/span_metrics_custom_attrs"},
 		{name: "traces/span_metrics_no_overflow"},
 		// output should show overflow

--- a/connector/elasticapmconnector/testdata/traces/span_metrics/aggregated_metrics.yaml
+++ b/connector/elasticapmconnector/testdata/traces/span_metrics/aggregated_metrics.yaml
@@ -82,6 +82,11 @@ resourceMetrics:
                     - key: data_stream.dataset
                       value:
                         stringValue: service_destination.1m
+                    - key: elasticsearch.mapping.hints
+                      value:
+                        arrayValue:
+                          values:
+                            - stringValue: _doc_count
                     - key: event.outcome
                       value:
                         stringValue: success
@@ -117,6 +122,11 @@ resourceMetrics:
                     - key: data_stream.dataset
                       value:
                         stringValue: service_destination.10m
+                    - key: elasticsearch.mapping.hints
+                      value:
+                        arrayValue:
+                          values:
+                            - stringValue: _doc_count
                     - key: event.outcome
                       value:
                         stringValue: success
@@ -152,6 +162,11 @@ resourceMetrics:
                     - key: data_stream.dataset
                       value:
                         stringValue: service_destination.60m
+                    - key: elasticsearch.mapping.hints
+                      value:
+                        arrayValue:
+                          values:
+                            - stringValue: _doc_count
                     - key: event.outcome
                       value:
                         stringValue: success
@@ -187,6 +202,11 @@ resourceMetrics:
                     - key: data_stream.dataset
                       value:
                         stringValue: service_destination.1m
+                    - key: elasticsearch.mapping.hints
+                      value:
+                        arrayValue:
+                          values:
+                            - stringValue: _doc_count
                     - key: event.outcome
                       value:
                         stringValue: success
@@ -223,6 +243,11 @@ resourceMetrics:
                     - key: data_stream.dataset
                       value:
                         stringValue: service_destination.10m
+                    - key: elasticsearch.mapping.hints
+                      value:
+                        arrayValue:
+                          values:
+                            - stringValue: _doc_count
                     - key: event.outcome
                       value:
                         stringValue: success
@@ -259,6 +284,11 @@ resourceMetrics:
                     - key: data_stream.dataset
                       value:
                         stringValue: service_destination.60m
+                    - key: elasticsearch.mapping.hints
+                      value:
+                        arrayValue:
+                          values:
+                            - stringValue: _doc_count
                     - key: event.outcome
                       value:
                         stringValue: success

--- a/connector/elasticapmconnector/testdata/traces/span_metrics_composite/aggregated_metrics.yaml
+++ b/connector/elasticapmconnector/testdata/traces/span_metrics_composite/aggregated_metrics.yaml
@@ -7,9 +7,6 @@ resourceMetrics:
         - key: deployment.environment
           value:
             stringValue: qa
-        - key: foo
-          value:
-            stringValue: bar
         - key: service.name
           value:
             stringValue: foo
@@ -22,7 +19,7 @@ resourceMetrics:
             sum:
               aggregationTemporality: 1
               dataPoints:
-                - asInt: "2"
+                - asInt: "1"
                   attributes:
                     - key: data_stream.dataset
                       value:
@@ -41,7 +38,7 @@ resourceMetrics:
             sum:
               aggregationTemporality: 1
               dataPoints:
-                - asInt: "2"
+                - asInt: "1"
                   attributes:
                     - key: data_stream.dataset
                       value:
@@ -60,7 +57,7 @@ resourceMetrics:
             sum:
               aggregationTemporality: 1
               dataPoints:
-                - asInt: "2"
+                - asInt: "1"
                   attributes:
                     - key: data_stream.dataset
                       value:
@@ -80,11 +77,14 @@ resourceMetrics:
             sum:
               aggregationTemporality: 1
               dataPoints:
-                - asInt: "2"
+                - asInt: "5"
                   attributes:
                     - key: data_stream.dataset
                       value:
                         stringValue: service_destination.1m
+                    - key: elasticsearch.doc_count
+                      value:
+                        intValue: "5"
                     - key: elasticsearch.mapping.hints
                       value:
                         arrayValue:
@@ -104,30 +104,30 @@ resourceMetrics:
                         stringValue: metric
                     - key: service.target.name
                       value:
-                        stringValue: main
+                        stringValue: api.example.com
                     - key: service.target.type
                       value:
-                        stringValue: mysql
+                        stringValue: http
                     - key: span.destination.service.resource
                       value:
-                        stringValue: mysql
-                    - key: span.foo
-                      value:
-                        stringValue: span.bar
+                        stringValue: api.example.com:443
                     - key: span.name
                       value:
-                        stringValue: th-value-8
+                        stringValue: GET api.example.com
                   timeUnixNano: "1000000"
           - description: APM span destination metrics
             name: span.destination.service.response_time.count
             sum:
               aggregationTemporality: 1
               dataPoints:
-                - asInt: "2"
+                - asInt: "5"
                   attributes:
                     - key: data_stream.dataset
                       value:
                         stringValue: service_destination.10m
+                    - key: elasticsearch.doc_count
+                      value:
+                        intValue: "5"
                     - key: elasticsearch.mapping.hints
                       value:
                         arrayValue:
@@ -147,30 +147,30 @@ resourceMetrics:
                         stringValue: metric
                     - key: service.target.name
                       value:
-                        stringValue: main
+                        stringValue: api.example.com
                     - key: service.target.type
                       value:
-                        stringValue: mysql
+                        stringValue: http
                     - key: span.destination.service.resource
                       value:
-                        stringValue: mysql
-                    - key: span.foo
-                      value:
-                        stringValue: span.bar
+                        stringValue: api.example.com:443
                     - key: span.name
                       value:
-                        stringValue: th-value-8
+                        stringValue: GET api.example.com
                   timeUnixNano: "1000000"
           - description: APM span destination metrics
             name: span.destination.service.response_time.count
             sum:
               aggregationTemporality: 1
               dataPoints:
-                - asInt: "2"
+                - asInt: "5"
                   attributes:
                     - key: data_stream.dataset
                       value:
                         stringValue: service_destination.60m
+                    - key: elasticsearch.doc_count
+                      value:
+                        intValue: "5"
                     - key: elasticsearch.mapping.hints
                       value:
                         arrayValue:
@@ -190,30 +190,30 @@ resourceMetrics:
                         stringValue: metric
                     - key: service.target.name
                       value:
-                        stringValue: main
+                        stringValue: api.example.com
                     - key: service.target.type
                       value:
-                        stringValue: mysql
+                        stringValue: http
                     - key: span.destination.service.resource
                       value:
-                        stringValue: mysql
-                    - key: span.foo
-                      value:
-                        stringValue: span.bar
+                        stringValue: api.example.com:443
                     - key: span.name
                       value:
-                        stringValue: th-value-8
+                        stringValue: GET api.example.com
                   timeUnixNano: "1000000"
           - description: APM span destination metrics
             name: span.destination.service.response_time.sum.us
             sum:
               aggregationTemporality: 1
               dataPoints:
-                - asDouble: 500000
+                - asDouble: 100000
                   attributes:
                     - key: data_stream.dataset
                       value:
                         stringValue: service_destination.1m
+                    - key: elasticsearch.doc_count
+                      value:
+                        intValue: "5"
                     - key: elasticsearch.mapping.hints
                       value:
                         arrayValue:
@@ -233,19 +233,16 @@ resourceMetrics:
                         stringValue: metric
                     - key: service.target.name
                       value:
-                        stringValue: main
+                        stringValue: api.example.com
                     - key: service.target.type
                       value:
-                        stringValue: mysql
+                        stringValue: http
                     - key: span.destination.service.resource
                       value:
-                        stringValue: mysql
-                    - key: span.foo
-                      value:
-                        stringValue: span.bar
+                        stringValue: api.example.com:443
                     - key: span.name
                       value:
-                        stringValue: th-value-8
+                        stringValue: GET api.example.com
                   timeUnixNano: "1000000"
             unit: us
           - description: APM span destination metrics
@@ -253,11 +250,14 @@ resourceMetrics:
             sum:
               aggregationTemporality: 1
               dataPoints:
-                - asDouble: 500000
+                - asDouble: 100000
                   attributes:
                     - key: data_stream.dataset
                       value:
                         stringValue: service_destination.10m
+                    - key: elasticsearch.doc_count
+                      value:
+                        intValue: "5"
                     - key: elasticsearch.mapping.hints
                       value:
                         arrayValue:
@@ -277,19 +277,16 @@ resourceMetrics:
                         stringValue: metric
                     - key: service.target.name
                       value:
-                        stringValue: main
+                        stringValue: api.example.com
                     - key: service.target.type
                       value:
-                        stringValue: mysql
+                        stringValue: http
                     - key: span.destination.service.resource
                       value:
-                        stringValue: mysql
-                    - key: span.foo
-                      value:
-                        stringValue: span.bar
+                        stringValue: api.example.com:443
                     - key: span.name
                       value:
-                        stringValue: th-value-8
+                        stringValue: GET api.example.com
                   timeUnixNano: "1000000"
             unit: us
           - description: APM span destination metrics
@@ -297,11 +294,14 @@ resourceMetrics:
             sum:
               aggregationTemporality: 1
               dataPoints:
-                - asDouble: 500000
+                - asDouble: 100000
                   attributes:
                     - key: data_stream.dataset
                       value:
                         stringValue: service_destination.60m
+                    - key: elasticsearch.doc_count
+                      value:
+                        intValue: "5"
                     - key: elasticsearch.mapping.hints
                       value:
                         arrayValue:
@@ -321,19 +321,16 @@ resourceMetrics:
                         stringValue: metric
                     - key: service.target.name
                       value:
-                        stringValue: main
+                        stringValue: api.example.com
                     - key: service.target.type
                       value:
-                        stringValue: mysql
+                        stringValue: http
                     - key: span.destination.service.resource
                       value:
-                        stringValue: mysql
-                    - key: span.foo
-                      value:
-                        stringValue: span.bar
+                        stringValue: api.example.com:443
                     - key: span.name
                       value:
-                        stringValue: th-value-8
+                        stringValue: GET api.example.com
                   timeUnixNano: "1000000"
             unit: us
         scope:

--- a/connector/elasticapmconnector/testdata/traces/span_metrics_composite/config.yaml
+++ b/connector/elasticapmconnector/testdata/traces/span_metrics_composite/config.yaml
@@ -1,0 +1,1 @@
+elasticapm: {}

--- a/connector/elasticapmconnector/testdata/traces/span_metrics_composite/input.yaml
+++ b/connector/elasticapmconnector/testdata/traces/span_metrics_composite/input.yaml
@@ -1,0 +1,62 @@
+resourceSpans:
+  - resource:
+      attributes:
+        - key: service.name
+          value:
+            stringValue: foo
+        - key: deployment.environment
+          value:
+            stringValue: qa
+        - key: telemetry.sdk.language
+          value:
+            stringValue: go
+        - key: agent.name
+          value:
+            stringValue: otlp/go
+        - key: agent.version
+          value:
+            stringValue: unknown
+    scopeSpans:
+      - scope: {}
+        spans:
+          - attributes:
+              - key: elasticsearch.doc_count
+                value:
+                  intValue: 5
+              - key: event.outcome
+                value:
+                  stringValue: success
+              - key: event.success_count
+                value:
+                  intValue: 1
+              - key: processor.event
+                value:
+                  stringValue: span
+              - key: service.target.name
+                value:
+                  stringValue: api.example.com
+              - key: service.target.type
+                value:
+                  stringValue: http
+              - key: span.composite.count
+                value:
+                  intValue: 5
+              - key: span.composite.sum.us
+                value:
+                  intValue: 100000
+              - key: span.destination.service.resource
+                value:
+                  stringValue: api.example.com:443
+              - key: span.representative_count
+                value:
+                  doubleValue: 1.0
+              - key: span.type
+                value:
+                  stringValue: external
+              - key: timestamp.us
+                value:
+                  intValue: 1581452772000000
+            endTimeUnixNano: "1581452772500000000"
+            name: GET api.example.com
+            parentSpanId: "bcff497b5a47310f"
+            startTimeUnixNano: "1581452772000000000"

--- a/connector/elasticapmconnector/testdata/traces/span_metrics_no_overflow/aggregated_metrics.yaml
+++ b/connector/elasticapmconnector/testdata/traces/span_metrics_no_overflow/aggregated_metrics.yaml
@@ -82,6 +82,11 @@ resourceMetrics:
                     - key: data_stream.dataset
                       value:
                         stringValue: service_destination.1m
+                    - key: elasticsearch.mapping.hints
+                      value:
+                        arrayValue:
+                          values:
+                            - stringValue: _doc_count
                     - key: event.outcome
                       value:
                         stringValue: success
@@ -117,6 +122,11 @@ resourceMetrics:
                     - key: data_stream.dataset
                       value:
                         stringValue: service_destination.10m
+                    - key: elasticsearch.mapping.hints
+                      value:
+                        arrayValue:
+                          values:
+                            - stringValue: _doc_count
                     - key: event.outcome
                       value:
                         stringValue: success
@@ -152,6 +162,11 @@ resourceMetrics:
                     - key: data_stream.dataset
                       value:
                         stringValue: service_destination.60m
+                    - key: elasticsearch.mapping.hints
+                      value:
+                        arrayValue:
+                          values:
+                            - stringValue: _doc_count
                     - key: event.outcome
                       value:
                         stringValue: success
@@ -187,6 +202,11 @@ resourceMetrics:
                     - key: data_stream.dataset
                       value:
                         stringValue: service_destination.1m
+                    - key: elasticsearch.mapping.hints
+                      value:
+                        arrayValue:
+                          values:
+                            - stringValue: _doc_count
                     - key: event.outcome
                       value:
                         stringValue: success
@@ -223,6 +243,11 @@ resourceMetrics:
                     - key: data_stream.dataset
                       value:
                         stringValue: service_destination.10m
+                    - key: elasticsearch.mapping.hints
+                      value:
+                        arrayValue:
+                          values:
+                            - stringValue: _doc_count
                     - key: event.outcome
                       value:
                         stringValue: success
@@ -259,6 +284,11 @@ resourceMetrics:
                     - key: data_stream.dataset
                       value:
                         stringValue: service_destination.60m
+                    - key: elasticsearch.mapping.hints
+                      value:
+                        arrayValue:
+                          values:
+                            - stringValue: _doc_count
                     - key: event.outcome
                       value:
                         stringValue: success

--- a/connector/elasticapmconnector/testdata/traces/span_metrics_overflow/aggregated_metrics.yaml
+++ b/connector/elasticapmconnector/testdata/traces/span_metrics_overflow/aggregated_metrics.yaml
@@ -28,10 +28,10 @@ resourceMetrics:
                     - key: metricset.interval
                       value:
                         stringValue: 1m
-                    - key: processor.event
+                    - key: overflow
                       value:
                         stringValue: metric
-                    - key: overflow
+                    - key: processor.event
                       value:
                         stringValue: metric
           - description: Overflow metric count due to metric limit
@@ -47,10 +47,10 @@ resourceMetrics:
                     - key: metricset.interval
                       value:
                         stringValue: 10m
-                    - key: processor.event
+                    - key: overflow
                       value:
                         stringValue: metric
-                    - key: overflow
+                    - key: processor.event
                       value:
                         stringValue: metric
           - description: Overflow metric count due to metric limit
@@ -66,10 +66,10 @@ resourceMetrics:
                     - key: metricset.interval
                       value:
                         stringValue: 60m
-                    - key: processor.event
+                    - key: overflow
                       value:
                         stringValue: metric
-                    - key: overflow
+                    - key: processor.event
                       value:
                         stringValue: metric
           - name: service_summary


### PR DESCRIPTION
This PR will enable us to `_doc_count` for spans events. The change sets the `_doc_count` mapping hint, and for composite spans it will also forward `span.composite.count` to `elasticsearch.doc_count` so that we can set the `_doc_count` correctly in the exporter.

This exporter PR: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/48109 shows how `elasticsearch.doc_count` will be used to set the composite span _doc_count correctly.