### PR TITLE
[processor/elasticapmprocessor] map span.composite.count to elasticsearch.doc_count

### DIFF
--- a/processor/elasticapmprocessor/internal/enrichments/config/config.go
+++ b/processor/elasticapmprocessor/internal/enrichments/config/config.go
@@ -100,6 +100,11 @@ type ElasticSpanConfig struct {
 	UserAgent           AttributeConfig `mapstructure:"user_agent"`
 	RemoveMessaging     AttributeConfig `mapstructure:"remove_messaging"`
 	MessageQueueName    AttributeConfig `mapstructure:"message_queue_name"`
+	// CompositeDocCount controls whether elasticsearch.doc_count is set
+	// to span.composite.count on composite spans. This enables the
+	// Elasticsearch exporter to write the correct _doc_count field for
+	// pre-aggregated composite span metrics.
+	CompositeDocCount AttributeConfig `mapstructure:"composite_doc_count"`
 }
 
 // SpanEventConfig configures enrichment attributes for the span events.
@@ -202,6 +207,7 @@ func Enabled() Config {
 			UserAgent:           AttributeConfig{Enabled: true},
 			RemoveMessaging:     AttributeConfig{Enabled: true},
 			MessageQueueName:    AttributeConfig{Enabled: true},
+			CompositeDocCount:   AttributeConfig{Enabled: true},
 		},
 		SpanEvent: SpanEventConfig{
 			TimestampUs:        AttributeConfig{Enabled: true},

--- a/processor/elasticapmprocessor/internal/enrichments/span.go
+++ b/processor/elasticapmprocessor/internal/enrichments/span.go
@@ -427,6 +427,9 @@ func (s *spanEnrichmentContext) enrichSpan(
 	if cfg.RemoveMessaging.Enabled {
 		s.removeMessagingAttrs(span)
 	}
+	if cfg.CompositeDocCount.Enabled {
+		s.setCompositeDocCount(span)
+	}
 
 	// The transaction type should not be updated if it was originally provided (s.transactionType is not empty)
 	// Prior enrichment logic may have set this value by using `s.getTxnType()`, in this
@@ -571,6 +574,15 @@ func (s *spanEnrichmentContext) setMessageQueue(span ptrace.Span) {
 // This creates results in elastic and semconv attribute mapping that is specific to messaging spans
 // that is not consistent for all span types (http, grpc, db, etc.).
 // This is another reason the attributes are deleted here to avoid special handling at export time.
+// setCompositeDocCount propagates span.composite.count to
+// elasticsearch.doc_count so the Elasticsearch exporter can write the
+// correct _doc_count field for pre-aggregated composite span metrics.
+func (s *spanEnrichmentContext) setCompositeDocCount(span ptrace.Span) {
+	if v, ok := span.Attributes().Get("span.composite.count"); ok {
+		span.Attributes().PutInt("elasticsearch.doc_count", v.Int())
+	}
+}
+
 func (s *spanEnrichmentContext) removeMessagingAttrs(span ptrace.Span) {
 	if s.isMessaging {
 		span.Attributes().Remove("message_bus.destination")

--- a/processor/elasticapmprocessor/internal/enrichments/span_test.go
+++ b/processor/elasticapmprocessor/internal/enrichments/span_test.go
@@ -2699,6 +2699,64 @@ func TestElasticSpanEnrich(t *testing.T) {
 				elasticattr.ServiceTargetName:       "",
 			},
 		},
+		{
+			name: "composite_span_sets_elasticsearch_doc_count",
+			input: func() ptrace.Span {
+				span := getElasticSpan()
+				span.Attributes().PutInt(elasticattr.SpanCompositeCount, 5)
+				return span
+			}(),
+			config: config.Enabled().Span,
+			enrichedAttrs: map[string]any{
+				"elasticsearch.doc_count":             int64(5),
+				elasticattr.TimestampUs:               startTs.AsTime().UnixMicro(),
+				elasticattr.ProcessorEvent:            "span",
+				elasticattr.SpanRepresentativeCount:   float64(1),
+				elasticattr.SpanType:                  "unknown",
+				elasticattr.SpanDurationUs:             expectedDuration.Microseconds(),
+				elasticattr.EventOutcome:               outcomeSuccess,
+				elasticattr.SuccessCount:               int64(1),
+			},
+		},
+		{
+			name: "non_composite_span_does_not_set_elasticsearch_doc_count",
+			input: func() ptrace.Span {
+				span := getElasticSpan()
+				return span
+			}(),
+			config: config.Enabled().Span,
+			enrichedAttrs: map[string]any{
+				elasticattr.TimestampUs:             startTs.AsTime().UnixMicro(),
+				elasticattr.ProcessorEvent:          "span",
+				elasticattr.SpanRepresentativeCount: float64(1),
+				elasticattr.SpanType:                "unknown",
+				elasticattr.SpanDurationUs:          expectedDuration.Microseconds(),
+				elasticattr.EventOutcome:            outcomeSuccess,
+				elasticattr.SuccessCount:            int64(1),
+			},
+		},
+		{
+			name: "composite_span_doc_count_disabled",
+			input: func() ptrace.Span {
+				span := getElasticSpan()
+				span.Attributes().PutInt(elasticattr.SpanCompositeCount, 5)
+				return span
+			}(),
+			config: func() config.ElasticSpanConfig {
+				cfg := config.Enabled().Span
+				cfg.CompositeDocCount.Enabled = false
+				return cfg
+			}(),
+			enrichedAttrs: map[string]any{
+				elasticattr.TimestampUs:             startTs.AsTime().UnixMicro(),
+				elasticattr.ProcessorEvent:          "span",
+				elasticattr.SpanRepresentativeCount: float64(1),
+				elasticattr.SpanType:                "unknown",
+				elasticattr.SpanDurationUs:          expectedDuration.Microseconds(),
+				elasticattr.EventOutcome:            outcomeSuccess,
+				elasticattr.SuccessCount:            int64(1),
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			expectedSpan := ptrace.NewSpan()


### PR DESCRIPTION
This pr will simply translate/ map the value of the `span.composite.count` to `elasticsearch.doc_count`. This will be used by the exporter to set the `_doc_count` attribute for composite spans.

This PR will be used in conjunction with:
- exporter change: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/48109
- elasticapmconnector change: https://github.com/elastic/opentelemetry-collector-components/pull/1197