### PR TITLE
[connector/elasticapm]Use adjusted_count for service destn response time

### DIFF
--- a/connector/elasticapmconnector/config.go
+++ b/connector/elasticapmconnector/config.go
@@ -403,7 +403,9 @@ func (cfg Config) signaltometricsConfig() *signaltometricsconfig.Config {
 			Histogram: configoptional.Some(transactionDurationSummaryHistogram),
 		}, {
 			// For composite spans, the response time sum is the composite
-			// duration (total of all compressed sub-spans).
+			// duration (total of all compressed sub-spans), scaled by the
+			// sampling weight so the aggregate represents the unsampled
+			// population (matches apm-server's setSpanMetrics behaviour).
 			Name:                      "span.destination.service.response_time.sum.us",
 			Description:               "APM span destination metrics",
 			IncludeResourceAttributes: spanDestinationResourceAttributes,
@@ -413,10 +415,11 @@ func (cfg Config) signaltometricsConfig() *signaltometricsconfig.Config {
 			},
 			Unit: "us",
 			Sum: configoptional.Some(signaltometricsconfig.Sum{
-				Value: `Double(attributes["span.composite.sum.us"])`,
+				Value: `Double(attributes["span.composite.sum.us"]) * Double(AdjustedCount())`,
 			}),
 		}, {
-			// For non-composite spans, use the span wall-clock duration.
+			// For non-composite spans, use the span wall-clock duration
+			// scaled by the sampling weight.
 			Name:                      "span.destination.service.response_time.sum.us",
 			Description:               "APM span destination metrics",
 			IncludeResourceAttributes: spanDestinationResourceAttributes,
@@ -426,11 +429,11 @@ func (cfg Config) signaltometricsConfig() *signaltometricsconfig.Config {
 			},
 			Unit: "us",
 			Sum: configoptional.Some(signaltometricsconfig.Sum{
-				Value: "Double(Microseconds(end_time - start_time))",
+				Value: "Double(Microseconds(end_time - start_time)) * Double(AdjustedCount())",
 			}),
 		}, {
 			// For composite spans, the count is the number of compressed
-			// operations.
+			// operations scaled by the sampling weight.
 			Name:                      "span.destination.service.response_time.count",
 			Description:               "APM span destination metrics",
 			IncludeResourceAttributes: spanDestinationResourceAttributes,
@@ -439,7 +442,7 @@ func (cfg Config) signaltometricsConfig() *signaltometricsconfig.Config {
 				`attributes["span.composite.count"] != nil`,
 			},
 			Sum: configoptional.Some(signaltometricsconfig.Sum{
-				Value: `Int(attributes["span.composite.count"])`,
+				Value: `Int(attributes["span.composite.count"]) * Int(AdjustedCount())`,
 			}),
 		}, {
 			// For non-composite spans, count is the sampling weight.

--- a/connector/elasticapmconnector/config.go
+++ b/connector/elasticapmconnector/config.go
@@ -227,6 +227,11 @@ func (cfg Config) lsmConfig() *lsmconfig.Config {
 	return lsmConfig
 }
 
+// signaltometricsConfig configures signal_to_metrics connector to produce
+// elastic APM metric aggregations. The aggregations produced for service
+// destination metric does NOT include _doc_count field as it is not used
+// by the UI. See https://github.com/elastic/hosted-otel-collector/issues/3009
+// for more details.
 func (cfg Config) signaltometricsConfig() *signaltometricsconfig.Config {
 	// commonResourceAttributes are resource attributes included in
 	// all aggregated metrics.
@@ -404,7 +409,7 @@ func (cfg Config) signaltometricsConfig() *signaltometricsconfig.Config {
 		}, {
 			// For composite spans, the response time sum is the composite
 			// duration (total of all compressed sub-spans), scaled by the
-			// sampling weight so the aggregate represents the unsampled
+			// adjusted count so the aggregate represents the unsampled
 			// population (matches apm-server's setSpanMetrics behaviour).
 			Name:                      "span.destination.service.response_time.sum.us",
 			Description:               "APM span destination metrics",
@@ -419,7 +424,7 @@ func (cfg Config) signaltometricsConfig() *signaltometricsconfig.Config {
 			}),
 		}, {
 			// For non-composite spans, use the span wall-clock duration
-			// scaled by the sampling weight.
+			// scaled by the adjusted count.
 			Name:                      "span.destination.service.response_time.sum.us",
 			Description:               "APM span destination metrics",
 			IncludeResourceAttributes: spanDestinationResourceAttributes,
@@ -433,7 +438,7 @@ func (cfg Config) signaltometricsConfig() *signaltometricsconfig.Config {
 			}),
 		}, {
 			// For composite spans, the count is the number of compressed
-			// operations scaled by the sampling weight.
+			// operations scaled by the adjusted count.
 			Name:                      "span.destination.service.response_time.count",
 			Description:               "APM span destination metrics",
 			IncludeResourceAttributes: spanDestinationResourceAttributes,
@@ -445,7 +450,7 @@ func (cfg Config) signaltometricsConfig() *signaltometricsconfig.Config {
 				Value: `Int(attributes["span.composite.count"]) * Int(AdjustedCount())`,
 			}),
 		}, {
-			// For non-composite spans, count is the sampling weight.
+			// For non-composite spans, count is the adjusted count.
 			Name:                      "span.destination.service.response_time.count",
 			Description:               "APM span destination metrics",
 			IncludeResourceAttributes: spanDestinationResourceAttributes,

--- a/connector/elasticapmconnector/testdata/traces/span_metrics/aggregated_metrics.yaml
+++ b/connector/elasticapmconnector/testdata/traces/span_metrics/aggregated_metrics.yaml
@@ -182,7 +182,7 @@ resourceMetrics:
             sum:
               aggregationTemporality: 1
               dataPoints:
-                - asDouble: 500000
+                - asDouble: 1e+06
                   attributes:
                     - key: data_stream.dataset
                       value:
@@ -218,7 +218,7 @@ resourceMetrics:
             sum:
               aggregationTemporality: 1
               dataPoints:
-                - asDouble: 500000
+                - asDouble: 1e+06
                   attributes:
                     - key: data_stream.dataset
                       value:
@@ -254,7 +254,7 @@ resourceMetrics:
             sum:
               aggregationTemporality: 1
               dataPoints:
-                - asDouble: 500000
+                - asDouble: 1e+06
                   attributes:
                     - key: data_stream.dataset
                       value:

--- a/connector/elasticapmconnector/testdata/traces/span_metrics_custom_attrs/aggregated_metrics.yaml
+++ b/connector/elasticapmconnector/testdata/traces/span_metrics_custom_attrs/aggregated_metrics.yaml
@@ -194,7 +194,7 @@ resourceMetrics:
             sum:
               aggregationTemporality: 1
               dataPoints:
-                - asDouble: 500000
+                - asDouble: 1e+06
                   attributes:
                     - key: data_stream.dataset
                       value:
@@ -233,7 +233,7 @@ resourceMetrics:
             sum:
               aggregationTemporality: 1
               dataPoints:
-                - asDouble: 500000
+                - asDouble: 1e+06
                   attributes:
                     - key: data_stream.dataset
                       value:
@@ -272,7 +272,7 @@ resourceMetrics:
             sum:
               aggregationTemporality: 1
               dataPoints:
-                - asDouble: 500000
+                - asDouble: 1e+06
                   attributes:
                     - key: data_stream.dataset
                       value:

--- a/connector/elasticapmconnector/testdata/traces/span_metrics_no_overflow/aggregated_metrics.yaml
+++ b/connector/elasticapmconnector/testdata/traces/span_metrics_no_overflow/aggregated_metrics.yaml
@@ -182,7 +182,7 @@ resourceMetrics:
             sum:
               aggregationTemporality: 1
               dataPoints:
-                - asDouble: 500000
+                - asDouble: 1e+06
                   attributes:
                     - key: data_stream.dataset
                       value:
@@ -218,7 +218,7 @@ resourceMetrics:
             sum:
               aggregationTemporality: 1
               dataPoints:
-                - asDouble: 500000
+                - asDouble: 1e+06
                   attributes:
                     - key: data_stream.dataset
                       value:
@@ -254,7 +254,7 @@ resourceMetrics:
             sum:
               aggregationTemporality: 1
               dataPoints:
-                - asDouble: 500000
+                - asDouble: 1e+06
                   attributes:
                     - key: data_stream.dataset
                       value:


### PR DESCRIPTION
The PR fixes the missing `adjusted_count` based scaling of the service destination metrics as per APM logic ([ref](https://github.com/elastic/apm-aggregation/blob/13d584260c7bc536224878fa1f390b9d5edfb96c/aggregators/converter.go#L553-L560))

Closes: https://github.com/elastic/opentelemetry-collector-components/issues/1158 