### PR TITLE
Update versions.yaml and codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@ internal/elasticattr                   @elastic/obs-ds-intake-services @elastic/
 loadgen                                @elastic/obs-ds-intake-services @elastic/obs-ds-hosted-services @elastic/ingest-otel-data
 receiver/loadgenreceiver               @elastic/obs-ds-intake-services @elastic/obs-ds-hosted-services @elastic/ingest-otel-data
 receiver/elasticapmintakereceiver      @elastic/obs-ds-intake-services @elastic/obs-ds-hosted-services @elastic/ingest-otel-data
-receiver/entityanalyticsreceiver       @elastic/security-service-integrations
+receiver/entityanalyticsreceiver       @elastic/security-service-integrations @elastic/ingest-otel-data
 processor/elasticinframetricsprocessor @elastic/obs-infraobs-integrations @elastic/ingest-otel-data
 processor/elasticapmprocessor          @elastic/obs-ds-intake-services @elastic/obs-ds-hosted-services @elastic/ingest-otel-data
 processor/elastictraceprocessor        @elastic/obs-ds-intake-services @elastic/obs-ds-hosted-services @elastic/ingest-otel-data

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,6 +1,6 @@
 module-sets:
   edot-base:
-    version: v0.46.0
+    version: v0.47.0
     modules:
       - github.com/elastic/opentelemetry-collector-components/receiver/elasticapmintakereceiver
       - github.com/elastic/opentelemetry-collector-components/receiver/loadgenreceiver
@@ -24,10 +24,13 @@ excluded-modules:
   - github.com/elastic/opentelemetry-collector-components/internal/tools
   - github.com/elastic/opentelemetry-collector-components/internal/sharedcomponent
   - github.com/elastic/opentelemetry-collector-components/internal/testutil
+  - github.com/elastic/opentelemetry-collector-components/internal/versionscheck
   - github.com/elastic/opentelemetry-collector-components/pkg/integrations
   - github.com/elastic/opentelemetry-collector-components/receiver/integrationreceiver
+  - github.com/elastic/opentelemetry-collector-components/receiver/prometheusremotewritev1receiver/correctnesstests
   - github.com/elastic/opentelemetry-collector-components/extension/fileintegrationextension
   - github.com/elastic/opentelemetry-collector-components/extension/configintegrationextension
   - github.com/elastic/opentelemetry-collector-components/processor/integrationprocessor
   - github.com/elastic/opentelemetry-collector-components/processor/partitioningprocessor
   - github.com/elastic/opentelemetry-collector-components/loadgen
+  - github.com/elastic/opentelemetry-collector-components/receiver/entityanalyticsreceiver


### PR DESCRIPTION
Adapting files according to the release process.

### CODEOWNERS
- Adding `elastic/ingest-otel-data` to `receiver/entityanalyticsreceiver`: we added `elastic/ingest-otel-data` for all modules because this team is primarily responsible for releasing this repo and keeping upstream OTel dependencies in sync - for this, with each upstream update we bump the dependency in `go.mod` files in each module resulting changes in `go.mod` and `go.sum` in all modules. In order to be able to do this as a single team we added this team in https://github.com/elastic/opentelemetry-collector-components/pull/1020 - this PR just keeps this in sync. If we ever need to do more than just bumping up the version, we always ping the real code owner of the module


### versions.yaml
- Bumping version, as usual
- Plus I found some new modules and added those as well, otherwise `make push-tags` fails with those modules missing. 