### PR TITLE
[connector/elasticapm]Fix overcounting of success count

### DIFF
--- a/connector/elasticapmconnector/config.go
+++ b/connector/elasticapmconnector/config.go
@@ -480,8 +480,10 @@ func (cfg Config) signaltometricsConfig() *signaltometricsconfig.Config {
 			Unit: "us",
 			Histogram: configoptional.Some(signaltometricsconfig.Histogram{
 				Buckets: []float64{1},
-				Count:   "Int(AdjustedCount())",
-				Value:   "Int(AdjustedCount())",
+				// Value=1 marks one success; Count=AdjustedCount weights it by
+				// the sampling factor. Aggregator sum = value*count = AdjustedCount.
+				Count: "Int(AdjustedCount())",
+				Value: "1",
 			}),
 		}, {
 			Name:                      "event.success_count",
@@ -514,8 +516,10 @@ func (cfg Config) signaltometricsConfig() *signaltometricsconfig.Config {
 			Unit: "us",
 			Histogram: configoptional.Some(signaltometricsconfig.Histogram{
 				Buckets: []float64{1},
-				Count:   "Int(AdjustedCount())",
-				Value:   "Int(AdjustedCount())",
+				// Value=1 marks one success; Count=AdjustedCount weights it by
+				// the sampling factor. Aggregator sum = value*count = AdjustedCount.
+				Count: "Int(AdjustedCount())",
+				Value: "1",
 			}),
 		}, {
 			Name:                      "event.success_count",

--- a/connector/elasticapmconnector/connector_test.go
+++ b/connector/elasticapmconnector/connector_test.go
@@ -142,6 +142,7 @@ func TestConnector_TracesToMetrics(t *testing.T) {
 		{name: "traces/transaction_metrics_custom_attrs"},
 		{name: "traces/transaction_metrics_no_overflow"},
 		{name: "traces/transaction_metrics_no_result"},
+		{name: "traces/transaction_metrics_sampled"},
 		{name: "traces/span_metrics"},
 		{name: "traces/span_metrics_custom_attrs"},
 		{name: "traces/span_metrics_no_overflow"},

--- a/connector/elasticapmconnector/testdata/traces/transaction_metrics_sampled/aggregated_metrics.yaml
+++ b/connector/elasticapmconnector/testdata/traces/transaction_metrics_sampled/aggregated_metrics.yaml
@@ -1,0 +1,1258 @@
+resourceMetrics:
+  - resource:
+      attributes:
+        - key: agent.name
+          value:
+            stringValue: otlp/go
+        - key: deployment.environment
+          value:
+            stringValue: qa
+        - key: service.name
+          value:
+            stringValue: foo
+        - key: telemetry.sdk.language
+          value:
+            stringValue: go
+    scopeMetrics:
+      - metrics:
+          - description: Success count as a metric for service transaction
+            histogram:
+              aggregationTemporality: 1
+              dataPoints:
+                - attributes:
+                    - key: data_stream.dataset
+                      value:
+                        stringValue: service_transaction.1m
+                    - key: elasticsearch.mapping.hints
+                      value:
+                        arrayValue:
+                          values:
+                            - stringValue: aggregate_metric_double
+                    - key: metricset.interval
+                      value:
+                        stringValue: 1m
+                    - key: metricset.name
+                      value:
+                        stringValue: service_transaction
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                    - key: transaction.root
+                      value:
+                        boolValue: true
+                    - key: transaction.type
+                      value:
+                        stringValue: request
+                  bucketCounts:
+                    - "4"
+                    - "0"
+                  count: "4"
+                  explicitBounds:
+                    - 1
+                  sum: 2
+                  timeUnixNano: "1000000"
+            name: event.success_count
+            unit: us
+          - description: Success count as a metric for service transaction
+            histogram:
+              aggregationTemporality: 1
+              dataPoints:
+                - attributes:
+                    - key: data_stream.dataset
+                      value:
+                        stringValue: service_transaction.10m
+                    - key: elasticsearch.mapping.hints
+                      value:
+                        arrayValue:
+                          values:
+                            - stringValue: aggregate_metric_double
+                    - key: metricset.interval
+                      value:
+                        stringValue: 10m
+                    - key: metricset.name
+                      value:
+                        stringValue: service_transaction
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                    - key: transaction.root
+                      value:
+                        boolValue: true
+                    - key: transaction.type
+                      value:
+                        stringValue: request
+                  bucketCounts:
+                    - "4"
+                    - "0"
+                  count: "4"
+                  explicitBounds:
+                    - 1
+                  sum: 2
+                  timeUnixNano: "1000000"
+            name: event.success_count
+            unit: us
+          - description: Success count as a metric for service transaction
+            histogram:
+              aggregationTemporality: 1
+              dataPoints:
+                - attributes:
+                    - key: data_stream.dataset
+                      value:
+                        stringValue: service_transaction.60m
+                    - key: elasticsearch.mapping.hints
+                      value:
+                        arrayValue:
+                          values:
+                            - stringValue: aggregate_metric_double
+                    - key: metricset.interval
+                      value:
+                        stringValue: 60m
+                    - key: metricset.name
+                      value:
+                        stringValue: service_transaction
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                    - key: transaction.root
+                      value:
+                        boolValue: true
+                    - key: transaction.type
+                      value:
+                        stringValue: request
+                  bucketCounts:
+                    - "4"
+                    - "0"
+                  count: "4"
+                  explicitBounds:
+                    - 1
+                  sum: 2
+                  timeUnixNano: "1000000"
+            name: event.success_count
+            unit: us
+          - name: service_summary
+            sum:
+              aggregationTemporality: 1
+              dataPoints:
+                - asInt: "4"
+                  attributes:
+                    - key: data_stream.dataset
+                      value:
+                        stringValue: service_summary.1m
+                    - key: metricset.interval
+                      value:
+                        stringValue: 1m
+                    - key: metricset.name
+                      value:
+                        stringValue: service_summary
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                  timeUnixNano: "1000000"
+          - name: service_summary
+            sum:
+              aggregationTemporality: 1
+              dataPoints:
+                - asInt: "4"
+                  attributes:
+                    - key: data_stream.dataset
+                      value:
+                        stringValue: service_summary.10m
+                    - key: metricset.interval
+                      value:
+                        stringValue: 10m
+                    - key: metricset.name
+                      value:
+                        stringValue: service_summary
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                  timeUnixNano: "1000000"
+          - name: service_summary
+            sum:
+              aggregationTemporality: 1
+              dataPoints:
+                - asInt: "4"
+                  attributes:
+                    - key: data_stream.dataset
+                      value:
+                        stringValue: service_summary.60m
+                    - key: metricset.interval
+                      value:
+                        stringValue: 60m
+                    - key: metricset.name
+                      value:
+                        stringValue: service_summary
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                  timeUnixNano: "1000000"
+          - description: APM service transaction aggregated metrics as histogram
+            exponentialHistogram:
+              aggregationTemporality: 1
+              dataPoints:
+                - attributes:
+                    - key: data_stream.dataset
+                      value:
+                        stringValue: service_transaction.1m
+                    - key: elasticsearch.mapping.hints
+                      value:
+                        arrayValue:
+                          values:
+                            - stringValue: _doc_count
+                    - key: metricset.interval
+                      value:
+                        stringValue: 1m
+                    - key: metricset.name
+                      value:
+                        stringValue: service_transaction
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                    - key: transaction.root
+                      value:
+                        boolValue: true
+                    - key: transaction.type
+                      value:
+                        stringValue: request
+                  count: "4"
+                  max: 1.1e+07
+                  min: 1.1e+07
+                  negative: {}
+                  positive:
+                    bucketCounts:
+                      - "4"
+                    offset: 2.4527241e+07
+                  scale: 20
+                  sum: 4.4e+07
+                  timeUnixNano: "1000000"
+            name: transaction.duration.histogram
+            unit: us
+          - description: APM service transaction aggregated metrics as histogram
+            exponentialHistogram:
+              aggregationTemporality: 1
+              dataPoints:
+                - attributes:
+                    - key: data_stream.dataset
+                      value:
+                        stringValue: service_transaction.10m
+                    - key: elasticsearch.mapping.hints
+                      value:
+                        arrayValue:
+                          values:
+                            - stringValue: _doc_count
+                    - key: metricset.interval
+                      value:
+                        stringValue: 10m
+                    - key: metricset.name
+                      value:
+                        stringValue: service_transaction
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                    - key: transaction.root
+                      value:
+                        boolValue: true
+                    - key: transaction.type
+                      value:
+                        stringValue: request
+                  count: "4"
+                  max: 1.1e+07
+                  min: 1.1e+07
+                  negative: {}
+                  positive:
+                    bucketCounts:
+                      - "4"
+                    offset: 2.4527241e+07
+                  scale: 20
+                  sum: 4.4e+07
+                  timeUnixNano: "1000000"
+            name: transaction.duration.histogram
+            unit: us
+          - description: APM service transaction aggregated metrics as histogram
+            exponentialHistogram:
+              aggregationTemporality: 1
+              dataPoints:
+                - attributes:
+                    - key: data_stream.dataset
+                      value:
+                        stringValue: service_transaction.60m
+                    - key: elasticsearch.mapping.hints
+                      value:
+                        arrayValue:
+                          values:
+                            - stringValue: _doc_count
+                    - key: metricset.interval
+                      value:
+                        stringValue: 60m
+                    - key: metricset.name
+                      value:
+                        stringValue: service_transaction
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                    - key: transaction.root
+                      value:
+                        boolValue: true
+                    - key: transaction.type
+                      value:
+                        stringValue: request
+                  count: "4"
+                  max: 1.1e+07
+                  min: 1.1e+07
+                  negative: {}
+                  positive:
+                    bucketCounts:
+                      - "4"
+                    offset: 2.4527241e+07
+                  scale: 20
+                  sum: 4.4e+07
+                  timeUnixNano: "1000000"
+            name: transaction.duration.histogram
+            unit: us
+          - description: APM service transaction aggregated metrics as summary
+            histogram:
+              aggregationTemporality: 1
+              dataPoints:
+                - attributes:
+                    - key: data_stream.dataset
+                      value:
+                        stringValue: service_transaction.1m
+                    - key: elasticsearch.mapping.hints
+                      value:
+                        arrayValue:
+                          values:
+                            - stringValue: aggregate_metric_double
+                    - key: metricset.interval
+                      value:
+                        stringValue: 1m
+                    - key: metricset.name
+                      value:
+                        stringValue: service_transaction
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                    - key: transaction.root
+                      value:
+                        boolValue: true
+                    - key: transaction.type
+                      value:
+                        stringValue: request
+                  bucketCounts:
+                    - "0"
+                    - "4"
+                  count: "4"
+                  explicitBounds:
+                    - 1
+                  sum: 4.4e+07
+                  timeUnixNano: "1000000"
+            name: transaction.duration.summary
+            unit: us
+          - description: APM service transaction aggregated metrics as summary
+            histogram:
+              aggregationTemporality: 1
+              dataPoints:
+                - attributes:
+                    - key: data_stream.dataset
+                      value:
+                        stringValue: service_transaction.10m
+                    - key: elasticsearch.mapping.hints
+                      value:
+                        arrayValue:
+                          values:
+                            - stringValue: aggregate_metric_double
+                    - key: metricset.interval
+                      value:
+                        stringValue: 10m
+                    - key: metricset.name
+                      value:
+                        stringValue: service_transaction
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                    - key: transaction.root
+                      value:
+                        boolValue: true
+                    - key: transaction.type
+                      value:
+                        stringValue: request
+                  bucketCounts:
+                    - "0"
+                    - "4"
+                  count: "4"
+                  explicitBounds:
+                    - 1
+                  sum: 4.4e+07
+                  timeUnixNano: "1000000"
+            name: transaction.duration.summary
+            unit: us
+          - description: APM service transaction aggregated metrics as summary
+            histogram:
+              aggregationTemporality: 1
+              dataPoints:
+                - attributes:
+                    - key: data_stream.dataset
+                      value:
+                        stringValue: service_transaction.60m
+                    - key: elasticsearch.mapping.hints
+                      value:
+                        arrayValue:
+                          values:
+                            - stringValue: aggregate_metric_double
+                    - key: metricset.interval
+                      value:
+                        stringValue: 60m
+                    - key: metricset.name
+                      value:
+                        stringValue: service_transaction
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                    - key: transaction.root
+                      value:
+                        boolValue: true
+                    - key: transaction.type
+                      value:
+                        stringValue: request
+                  bucketCounts:
+                    - "0"
+                    - "4"
+                  count: "4"
+                  explicitBounds:
+                    - 1
+                  sum: 4.4e+07
+                  timeUnixNano: "1000000"
+            name: transaction.duration.summary
+            unit: us
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/signaltometricsconnector
+  - resource:
+      attributes:
+        - key: agent.name
+          value:
+            stringValue: otlp/go
+        - key: deployment.environment
+          value:
+            stringValue: qa
+        - key: host.name
+          value:
+            stringValue: camponotus_leonardi
+        - key: service.name
+          value:
+            stringValue: foo
+        - key: telemetry.sdk.language
+          value:
+            stringValue: go
+    scopeMetrics:
+      - metrics:
+          - description: APM transaction aggregated metrics as histogram
+            exponentialHistogram:
+              aggregationTemporality: 1
+              dataPoints:
+                - attributes:
+                    - key: data_stream.dataset
+                      value:
+                        stringValue: transaction.1m
+                    - key: elasticsearch.mapping.hints
+                      value:
+                        arrayValue:
+                          values:
+                            - stringValue: _doc_count
+                    - key: event.outcome
+                      value:
+                        stringValue: failure
+                    - key: metricset.interval
+                      value:
+                        stringValue: 1m
+                    - key: metricset.name
+                      value:
+                        stringValue: transaction
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                    - key: transaction.name
+                      value:
+                        stringValue: http-span
+                    - key: transaction.result
+                      value:
+                        stringValue: HTTP 5xx
+                    - key: transaction.root
+                      value:
+                        boolValue: true
+                    - key: transaction.type
+                      value:
+                        stringValue: request
+                  count: "2"
+                  max: 1.1e+07
+                  min: 1.1e+07
+                  negative: {}
+                  positive:
+                    bucketCounts:
+                      - "2"
+                    offset: 2.4527241e+07
+                  scale: 20
+                  sum: 2.2e+07
+                  timeUnixNano: "1000000"
+                - attributes:
+                    - key: data_stream.dataset
+                      value:
+                        stringValue: transaction.1m
+                    - key: elasticsearch.mapping.hints
+                      value:
+                        arrayValue:
+                          values:
+                            - stringValue: _doc_count
+                    - key: event.outcome
+                      value:
+                        stringValue: success
+                    - key: metricset.interval
+                      value:
+                        stringValue: 1m
+                    - key: metricset.name
+                      value:
+                        stringValue: transaction
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                    - key: transaction.name
+                      value:
+                        stringValue: http-span
+                    - key: transaction.result
+                      value:
+                        stringValue: HTTP 2xx
+                    - key: transaction.root
+                      value:
+                        boolValue: true
+                    - key: transaction.type
+                      value:
+                        stringValue: request
+                  count: "2"
+                  max: 1.1e+07
+                  min: 1.1e+07
+                  negative: {}
+                  positive:
+                    bucketCounts:
+                      - "2"
+                    offset: 2.4527241e+07
+                  scale: 20
+                  sum: 2.2e+07
+                  timeUnixNano: "1000000"
+            name: transaction.duration.histogram
+            unit: us
+          - description: APM transaction aggregated metrics as summary
+            histogram:
+              aggregationTemporality: 1
+              dataPoints:
+                - attributes:
+                    - key: data_stream.dataset
+                      value:
+                        stringValue: transaction.1m
+                    - key: elasticsearch.mapping.hints
+                      value:
+                        arrayValue:
+                          values:
+                            - stringValue: aggregate_metric_double
+                    - key: event.outcome
+                      value:
+                        stringValue: failure
+                    - key: metricset.interval
+                      value:
+                        stringValue: 1m
+                    - key: metricset.name
+                      value:
+                        stringValue: transaction
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                    - key: transaction.name
+                      value:
+                        stringValue: http-span
+                    - key: transaction.result
+                      value:
+                        stringValue: HTTP 5xx
+                    - key: transaction.root
+                      value:
+                        boolValue: true
+                    - key: transaction.type
+                      value:
+                        stringValue: request
+                  bucketCounts:
+                    - "0"
+                    - "2"
+                  count: "2"
+                  explicitBounds:
+                    - 1
+                  sum: 2.2e+07
+                  timeUnixNano: "1000000"
+                - attributes:
+                    - key: data_stream.dataset
+                      value:
+                        stringValue: transaction.1m
+                    - key: elasticsearch.mapping.hints
+                      value:
+                        arrayValue:
+                          values:
+                            - stringValue: aggregate_metric_double
+                    - key: event.outcome
+                      value:
+                        stringValue: success
+                    - key: metricset.interval
+                      value:
+                        stringValue: 1m
+                    - key: metricset.name
+                      value:
+                        stringValue: transaction
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                    - key: transaction.name
+                      value:
+                        stringValue: http-span
+                    - key: transaction.result
+                      value:
+                        stringValue: HTTP 2xx
+                    - key: transaction.root
+                      value:
+                        boolValue: true
+                    - key: transaction.type
+                      value:
+                        stringValue: request
+                  bucketCounts:
+                    - "0"
+                    - "2"
+                  count: "2"
+                  explicitBounds:
+                    - 1
+                  sum: 2.2e+07
+                  timeUnixNano: "1000000"
+            name: transaction.duration.summary
+            unit: us
+          - description: Success count as a metric for transaction
+            histogram:
+              aggregationTemporality: 1
+              dataPoints:
+                - attributes:
+                    - key: data_stream.dataset
+                      value:
+                        stringValue: transaction.1m
+                    - key: elasticsearch.mapping.hints
+                      value:
+                        arrayValue:
+                          values:
+                            - stringValue: aggregate_metric_double
+                    - key: event.outcome
+                      value:
+                        stringValue: failure
+                    - key: metricset.interval
+                      value:
+                        stringValue: 1m
+                    - key: metricset.name
+                      value:
+                        stringValue: transaction
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                    - key: transaction.name
+                      value:
+                        stringValue: http-span
+                    - key: transaction.result
+                      value:
+                        stringValue: HTTP 5xx
+                    - key: transaction.root
+                      value:
+                        boolValue: true
+                    - key: transaction.type
+                      value:
+                        stringValue: request
+                  bucketCounts:
+                    - "2"
+                    - "0"
+                  count: "2"
+                  explicitBounds:
+                    - 0
+                  sum: 0
+                  timeUnixNano: "1000000"
+                - attributes:
+                    - key: data_stream.dataset
+                      value:
+                        stringValue: transaction.1m
+                    - key: elasticsearch.mapping.hints
+                      value:
+                        arrayValue:
+                          values:
+                            - stringValue: aggregate_metric_double
+                    - key: event.outcome
+                      value:
+                        stringValue: success
+                    - key: metricset.interval
+                      value:
+                        stringValue: 1m
+                    - key: metricset.name
+                      value:
+                        stringValue: transaction
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                    - key: transaction.name
+                      value:
+                        stringValue: http-span
+                    - key: transaction.result
+                      value:
+                        stringValue: HTTP 2xx
+                    - key: transaction.root
+                      value:
+                        boolValue: true
+                    - key: transaction.type
+                      value:
+                        stringValue: request
+                  bucketCounts:
+                    - "2"
+                    - "0"
+                  count: "2"
+                  explicitBounds:
+                    - 1
+                  sum: 2
+                  timeUnixNano: "1000000"
+            name: event.success_count
+            unit: us
+          - description: APM transaction aggregated metrics as histogram
+            exponentialHistogram:
+              aggregationTemporality: 1
+              dataPoints:
+                - attributes:
+                    - key: data_stream.dataset
+                      value:
+                        stringValue: transaction.10m
+                    - key: elasticsearch.mapping.hints
+                      value:
+                        arrayValue:
+                          values:
+                            - stringValue: _doc_count
+                    - key: event.outcome
+                      value:
+                        stringValue: failure
+                    - key: metricset.interval
+                      value:
+                        stringValue: 10m
+                    - key: metricset.name
+                      value:
+                        stringValue: transaction
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                    - key: transaction.name
+                      value:
+                        stringValue: http-span
+                    - key: transaction.result
+                      value:
+                        stringValue: HTTP 5xx
+                    - key: transaction.root
+                      value:
+                        boolValue: true
+                    - key: transaction.type
+                      value:
+                        stringValue: request
+                  count: "2"
+                  max: 1.1e+07
+                  min: 1.1e+07
+                  negative: {}
+                  positive:
+                    bucketCounts:
+                      - "2"
+                    offset: 2.4527241e+07
+                  scale: 20
+                  sum: 2.2e+07
+                  timeUnixNano: "1000000"
+                - attributes:
+                    - key: data_stream.dataset
+                      value:
+                        stringValue: transaction.10m
+                    - key: elasticsearch.mapping.hints
+                      value:
+                        arrayValue:
+                          values:
+                            - stringValue: _doc_count
+                    - key: event.outcome
+                      value:
+                        stringValue: success
+                    - key: metricset.interval
+                      value:
+                        stringValue: 10m
+                    - key: metricset.name
+                      value:
+                        stringValue: transaction
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                    - key: transaction.name
+                      value:
+                        stringValue: http-span
+                    - key: transaction.result
+                      value:
+                        stringValue: HTTP 2xx
+                    - key: transaction.root
+                      value:
+                        boolValue: true
+                    - key: transaction.type
+                      value:
+                        stringValue: request
+                  count: "2"
+                  max: 1.1e+07
+                  min: 1.1e+07
+                  negative: {}
+                  positive:
+                    bucketCounts:
+                      - "2"
+                    offset: 2.4527241e+07
+                  scale: 20
+                  sum: 2.2e+07
+                  timeUnixNano: "1000000"
+            name: transaction.duration.histogram
+            unit: us
+          - description: APM transaction aggregated metrics as summary
+            histogram:
+              aggregationTemporality: 1
+              dataPoints:
+                - attributes:
+                    - key: data_stream.dataset
+                      value:
+                        stringValue: transaction.10m
+                    - key: elasticsearch.mapping.hints
+                      value:
+                        arrayValue:
+                          values:
+                            - stringValue: aggregate_metric_double
+                    - key: event.outcome
+                      value:
+                        stringValue: failure
+                    - key: metricset.interval
+                      value:
+                        stringValue: 10m
+                    - key: metricset.name
+                      value:
+                        stringValue: transaction
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                    - key: transaction.name
+                      value:
+                        stringValue: http-span
+                    - key: transaction.result
+                      value:
+                        stringValue: HTTP 5xx
+                    - key: transaction.root
+                      value:
+                        boolValue: true
+                    - key: transaction.type
+                      value:
+                        stringValue: request
+                  bucketCounts:
+                    - "0"
+                    - "2"
+                  count: "2"
+                  explicitBounds:
+                    - 1
+                  sum: 2.2e+07
+                  timeUnixNano: "1000000"
+                - attributes:
+                    - key: data_stream.dataset
+                      value:
+                        stringValue: transaction.10m
+                    - key: elasticsearch.mapping.hints
+                      value:
+                        arrayValue:
+                          values:
+                            - stringValue: aggregate_metric_double
+                    - key: event.outcome
+                      value:
+                        stringValue: success
+                    - key: metricset.interval
+                      value:
+                        stringValue: 10m
+                    - key: metricset.name
+                      value:
+                        stringValue: transaction
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                    - key: transaction.name
+                      value:
+                        stringValue: http-span
+                    - key: transaction.result
+                      value:
+                        stringValue: HTTP 2xx
+                    - key: transaction.root
+                      value:
+                        boolValue: true
+                    - key: transaction.type
+                      value:
+                        stringValue: request
+                  bucketCounts:
+                    - "0"
+                    - "2"
+                  count: "2"
+                  explicitBounds:
+                    - 1
+                  sum: 2.2e+07
+                  timeUnixNano: "1000000"
+            name: transaction.duration.summary
+            unit: us
+          - description: Success count as a metric for transaction
+            histogram:
+              aggregationTemporality: 1
+              dataPoints:
+                - attributes:
+                    - key: data_stream.dataset
+                      value:
+                        stringValue: transaction.10m
+                    - key: elasticsearch.mapping.hints
+                      value:
+                        arrayValue:
+                          values:
+                            - stringValue: aggregate_metric_double
+                    - key: event.outcome
+                      value:
+                        stringValue: failure
+                    - key: metricset.interval
+                      value:
+                        stringValue: 10m
+                    - key: metricset.name
+                      value:
+                        stringValue: transaction
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                    - key: transaction.name
+                      value:
+                        stringValue: http-span
+                    - key: transaction.result
+                      value:
+                        stringValue: HTTP 5xx
+                    - key: transaction.root
+                      value:
+                        boolValue: true
+                    - key: transaction.type
+                      value:
+                        stringValue: request
+                  bucketCounts:
+                    - "2"
+                    - "0"
+                  count: "2"
+                  explicitBounds:
+                    - 0
+                  sum: 0
+                  timeUnixNano: "1000000"
+                - attributes:
+                    - key: data_stream.dataset
+                      value:
+                        stringValue: transaction.10m
+                    - key: elasticsearch.mapping.hints
+                      value:
+                        arrayValue:
+                          values:
+                            - stringValue: aggregate_metric_double
+                    - key: event.outcome
+                      value:
+                        stringValue: success
+                    - key: metricset.interval
+                      value:
+                        stringValue: 10m
+                    - key: metricset.name
+                      value:
+                        stringValue: transaction
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                    - key: transaction.name
+                      value:
+                        stringValue: http-span
+                    - key: transaction.result
+                      value:
+                        stringValue: HTTP 2xx
+                    - key: transaction.root
+                      value:
+                        boolValue: true
+                    - key: transaction.type
+                      value:
+                        stringValue: request
+                  bucketCounts:
+                    - "2"
+                    - "0"
+                  count: "2"
+                  explicitBounds:
+                    - 1
+                  sum: 2
+                  timeUnixNano: "1000000"
+            name: event.success_count
+            unit: us
+          - description: APM transaction aggregated metrics as histogram
+            exponentialHistogram:
+              aggregationTemporality: 1
+              dataPoints:
+                - attributes:
+                    - key: data_stream.dataset
+                      value:
+                        stringValue: transaction.60m
+                    - key: elasticsearch.mapping.hints
+                      value:
+                        arrayValue:
+                          values:
+                            - stringValue: _doc_count
+                    - key: event.outcome
+                      value:
+                        stringValue: failure
+                    - key: metricset.interval
+                      value:
+                        stringValue: 60m
+                    - key: metricset.name
+                      value:
+                        stringValue: transaction
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                    - key: transaction.name
+                      value:
+                        stringValue: http-span
+                    - key: transaction.result
+                      value:
+                        stringValue: HTTP 5xx
+                    - key: transaction.root
+                      value:
+                        boolValue: true
+                    - key: transaction.type
+                      value:
+                        stringValue: request
+                  count: "2"
+                  max: 1.1e+07
+                  min: 1.1e+07
+                  negative: {}
+                  positive:
+                    bucketCounts:
+                      - "2"
+                    offset: 2.4527241e+07
+                  scale: 20
+                  sum: 2.2e+07
+                  timeUnixNano: "1000000"
+                - attributes:
+                    - key: data_stream.dataset
+                      value:
+                        stringValue: transaction.60m
+                    - key: elasticsearch.mapping.hints
+                      value:
+                        arrayValue:
+                          values:
+                            - stringValue: _doc_count
+                    - key: event.outcome
+                      value:
+                        stringValue: success
+                    - key: metricset.interval
+                      value:
+                        stringValue: 60m
+                    - key: metricset.name
+                      value:
+                        stringValue: transaction
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                    - key: transaction.name
+                      value:
+                        stringValue: http-span
+                    - key: transaction.result
+                      value:
+                        stringValue: HTTP 2xx
+                    - key: transaction.root
+                      value:
+                        boolValue: true
+                    - key: transaction.type
+                      value:
+                        stringValue: request
+                  count: "2"
+                  max: 1.1e+07
+                  min: 1.1e+07
+                  negative: {}
+                  positive:
+                    bucketCounts:
+                      - "2"
+                    offset: 2.4527241e+07
+                  scale: 20
+                  sum: 2.2e+07
+                  timeUnixNano: "1000000"
+            name: transaction.duration.histogram
+            unit: us
+          - description: APM transaction aggregated metrics as summary
+            histogram:
+              aggregationTemporality: 1
+              dataPoints:
+                - attributes:
+                    - key: data_stream.dataset
+                      value:
+                        stringValue: transaction.60m
+                    - key: elasticsearch.mapping.hints
+                      value:
+                        arrayValue:
+                          values:
+                            - stringValue: aggregate_metric_double
+                    - key: event.outcome
+                      value:
+                        stringValue: failure
+                    - key: metricset.interval
+                      value:
+                        stringValue: 60m
+                    - key: metricset.name
+                      value:
+                        stringValue: transaction
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                    - key: transaction.name
+                      value:
+                        stringValue: http-span
+                    - key: transaction.result
+                      value:
+                        stringValue: HTTP 5xx
+                    - key: transaction.root
+                      value:
+                        boolValue: true
+                    - key: transaction.type
+                      value:
+                        stringValue: request
+                  bucketCounts:
+                    - "0"
+                    - "2"
+                  count: "2"
+                  explicitBounds:
+                    - 1
+                  sum: 2.2e+07
+                  timeUnixNano: "1000000"
+                - attributes:
+                    - key: data_stream.dataset
+                      value:
+                        stringValue: transaction.60m
+                    - key: elasticsearch.mapping.hints
+                      value:
+                        arrayValue:
+                          values:
+                            - stringValue: aggregate_metric_double
+                    - key: event.outcome
+                      value:
+                        stringValue: success
+                    - key: metricset.interval
+                      value:
+                        stringValue: 60m
+                    - key: metricset.name
+                      value:
+                        stringValue: transaction
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                    - key: transaction.name
+                      value:
+                        stringValue: http-span
+                    - key: transaction.result
+                      value:
+                        stringValue: HTTP 2xx
+                    - key: transaction.root
+                      value:
+                        boolValue: true
+                    - key: transaction.type
+                      value:
+                        stringValue: request
+                  bucketCounts:
+                    - "0"
+                    - "2"
+                  count: "2"
+                  explicitBounds:
+                    - 1
+                  sum: 2.2e+07
+                  timeUnixNano: "1000000"
+            name: transaction.duration.summary
+            unit: us
+          - description: Success count as a metric for transaction
+            histogram:
+              aggregationTemporality: 1
+              dataPoints:
+                - attributes:
+                    - key: data_stream.dataset
+                      value:
+                        stringValue: transaction.60m
+                    - key: elasticsearch.mapping.hints
+                      value:
+                        arrayValue:
+                          values:
+                            - stringValue: aggregate_metric_double
+                    - key: event.outcome
+                      value:
+                        stringValue: failure
+                    - key: metricset.interval
+                      value:
+                        stringValue: 60m
+                    - key: metricset.name
+                      value:
+                        stringValue: transaction
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                    - key: transaction.name
+                      value:
+                        stringValue: http-span
+                    - key: transaction.result
+                      value:
+                        stringValue: HTTP 5xx
+                    - key: transaction.root
+                      value:
+                        boolValue: true
+                    - key: transaction.type
+                      value:
+                        stringValue: request
+                  bucketCounts:
+                    - "2"
+                    - "0"
+                  count: "2"
+                  explicitBounds:
+                    - 0
+                  sum: 0
+                  timeUnixNano: "1000000"
+                - attributes:
+                    - key: data_stream.dataset
+                      value:
+                        stringValue: transaction.60m
+                    - key: elasticsearch.mapping.hints
+                      value:
+                        arrayValue:
+                          values:
+                            - stringValue: aggregate_metric_double
+                    - key: event.outcome
+                      value:
+                        stringValue: success
+                    - key: metricset.interval
+                      value:
+                        stringValue: 60m
+                    - key: metricset.name
+                      value:
+                        stringValue: transaction
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                    - key: transaction.name
+                      value:
+                        stringValue: http-span
+                    - key: transaction.result
+                      value:
+                        stringValue: HTTP 2xx
+                    - key: transaction.root
+                      value:
+                        boolValue: true
+                    - key: transaction.type
+                      value:
+                        stringValue: request
+                  bucketCounts:
+                    - "2"
+                    - "0"
+                  count: "2"
+                  explicitBounds:
+                    - 1
+                  sum: 2
+                  timeUnixNano: "1000000"
+            name: event.success_count
+            unit: us
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/signaltometricsconnector

--- a/connector/elasticapmconnector/testdata/traces/transaction_metrics_sampled/config.yaml
+++ b/connector/elasticapmconnector/testdata/traces/transaction_metrics_sampled/config.yaml
@@ -1,0 +1,1 @@
+elasticapm: {}

--- a/connector/elasticapmconnector/testdata/traces/transaction_metrics_sampled/input.yaml
+++ b/connector/elasticapmconnector/testdata/traces/transaction_metrics_sampled/input.yaml
@@ -1,0 +1,91 @@
+resourceSpans:
+  - resource:
+      attributes:
+        - key: service.name
+          value:
+            stringValue: foo
+        - key: deployment.environment
+          value:
+            stringValue: qa
+        - key: telemetry.sdk.language
+          value:
+            stringValue: go
+        - key: agent.name
+          value:
+            stringValue: otlp/go
+        - key: host.name
+          value:
+            stringValue: camponotus_leonardi
+    scopeSpans:
+      - scope: {}
+        spans:
+          # success transaction sampled at 50% (ot=th:8 -> AdjustedCount=2).
+          # MIS reference: event.success_count sum contribution = repCount = 2
+          # Pre-fix MOTEL bug: sum contribution = repCount * Value = 2 * 2 = 4
+          - attributes:
+              - key: timestamp.us
+                value:
+                  intValue: 1581452772000000
+              - key: transaction.sampled
+                value:
+                  boolValue: true
+              - key: transaction.name
+                value:
+                  stringValue: "http-span"
+              - key: processor.event
+                value:
+                  stringValue: "transaction"
+              - key: transaction.duration.us
+                value:
+                  intValue: 11000000
+              - key: transaction.type
+                value:
+                  stringValue: request
+              - key: transaction.result
+                value:
+                  stringValue: "HTTP 2xx"
+              - key: event.outcome
+                value:
+                  stringValue: success
+              - key: event.success_count
+                value:
+                  intValue: 1
+            startTimeUnixNano: "1581452772000000321"
+            endTimeUnixNano: "1581452783000000789"
+            name: th-value-8 # represents 2 sampled successes
+            traceState: "ot=th:8"
+
+          # failure transaction sampled at 50% (ot=th:8 -> AdjustedCount=2).
+          # MIS reference: count = repCount = 2, sum = 0
+          - attributes:
+              - key: timestamp.us
+                value:
+                  intValue: 1581452772000000
+              - key: transaction.sampled
+                value:
+                  boolValue: true
+              - key: transaction.name
+                value:
+                  stringValue: "http-span"
+              - key: processor.event
+                value:
+                  stringValue: "transaction"
+              - key: transaction.duration.us
+                value:
+                  intValue: 11000000
+              - key: transaction.type
+                value:
+                  stringValue: request
+              - key: transaction.result
+                value:
+                  stringValue: "HTTP 5xx"
+              - key: event.outcome
+                value:
+                  stringValue: failure
+              - key: event.success_count
+                value:
+                  intValue: 0
+            startTimeUnixNano: "1581452772000000321"
+            endTimeUnixNano: "1581452783000000789"
+            name: th-value-8 # represents 2 sampled failures
+            traceState: "ot=th:8"


### PR DESCRIPTION
Fixes the overcounting reported in https://github.com/elastic/opentelemetry-collector-components/issues/1209 and adds a test case to capture the count issue.

Closes: https://github.com/elastic/opentelemetry-collector-components/issues/1209