### PR TITLE
[connector/elasticapmconnector] make transaction name optional for APM aggregation

### DIFF
--- a/connector/elasticapmconnector/config.go
+++ b/connector/elasticapmconnector/config.go
@@ -316,7 +316,7 @@ func (cfg Config) signaltometricsConfig() *signaltometricsconfig.Config {
 
 	transactionAttributes := append([]signaltometricsconfig.Attribute{
 		{Key: "transaction.root"},
-		{Key: "transaction.name"},
+		{Key: "transaction.name", Optional: true},
 		{Key: "transaction.type"},
 		{Key: "transaction.result", Optional: true},
 		{Key: "event.outcome"},

--- a/connector/elasticapmconnector/config.go
+++ b/connector/elasticapmconnector/config.go
@@ -310,6 +310,8 @@ func (cfg Config) signaltometricsConfig() *signaltometricsconfig.Config {
 
 	serviceTransactionAttributes := append([]signaltometricsconfig.Attribute{
 		{Key: "transaction.root"},
+		// processor defaults empty transaction.type to "unknown":
+		// https://github.com/elastic/opentelemetry-collector-components/blob/cdd457b05388ca0e5090301a32292f887752911e/processor/elasticapmprocessor/internal/enrichments/span.go#L476
 		{Key: "transaction.type"},
 		{Key: "metricset.name", DefaultValue: "service_transaction"},
 	}, toSignalToMetricsAttributes(cfg.CustomSpanAttributes)...)
@@ -317,8 +319,12 @@ func (cfg Config) signaltometricsConfig() *signaltometricsconfig.Config {
 	transactionAttributes := append([]signaltometricsconfig.Attribute{
 		{Key: "transaction.root"},
 		{Key: "transaction.name", Optional: true},
+		// processor defaults empty transaction.type to "unknown":
+		// https://github.com/elastic/opentelemetry-collector-components/blob/cdd457b05388ca0e5090301a32292f887752911e/processor/elasticapmprocessor/internal/enrichments/span.go#L476
 		{Key: "transaction.type"},
 		{Key: "transaction.result", Optional: true},
+		// receiver defaults missing event.outcome to "unknown":
+		// https://github.com/elastic/opentelemetry-collector-components/blob/cdd457b05388ca0e5090301a32292f887752911e/receiver/elasticapmintakereceiver/internal/mappers/intakeV2ToDerivedFields.go#L125
 		{Key: "event.outcome"},
 		{Key: "metricset.name", DefaultValue: "transaction"},
 	}, toSignalToMetricsAttributes(cfg.CustomSpanAttributes)...)

--- a/connector/elasticapmconnector/connector_test.go
+++ b/connector/elasticapmconnector/connector_test.go
@@ -38,10 +38,8 @@ import (
 	"go.opentelemetry.io/collector/connector/connectortest"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumertest"
-	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
-	"go.opentelemetry.io/collector/pdata/ptrace"
 
 	"github.com/elastic/opentelemetry-collector-components/connector/elasticapmconnector/internal/metadata"
 )
@@ -141,6 +139,7 @@ func TestConnector_TracesToMetrics(t *testing.T) {
 		{name: "traces/transaction_metrics"},
 		{name: "traces/transaction_metrics_data_stream_namespace"},
 		{name: "traces/transaction_metrics_without_optional_attrs"},
+		{name: "traces/transaction_metrics_without_name"},
 		{name: "traces/transaction_metrics_custom_attrs"},
 		{name: "traces/transaction_metrics_no_overflow"},
 		{name: "traces/transaction_metrics_no_result"},
@@ -182,66 +181,6 @@ func TestConnector_TracesToMetrics(t *testing.T) {
 			compareAggregatedMetrics(t, expectedMetricsFile, allMetrics)
 		})
 	}
-}
-
-func TestConnector_TransactionMetricsWithoutName(t *testing.T) {
-	nextMetrics := &consumertest.MetricsSink{}
-	t2m := newTracesConnector(t, connectortest.NewNopSettings(metadata.Type), &Config{}, nextMetrics)
-
-	input := ptrace.NewTraces()
-	resourceSpans := input.ResourceSpans().AppendEmpty()
-	resourceAttrs := resourceSpans.Resource().Attributes()
-	resourceAttrs.PutStr("service.name", "nameless-transaction-service")
-	resourceAttrs.PutStr("deployment.environment", "qa")
-	resourceAttrs.PutStr("telemetry.sdk.language", "go")
-	resourceAttrs.PutStr("agent.name", "otlp/go")
-
-	span := resourceSpans.ScopeSpans().AppendEmpty().Spans().AppendEmpty()
-	span.SetName("fallback-span-name")
-	span.SetStartTimestamp(pcommon.Timestamp(1_581_452_772_000_000_321))
-	span.SetEndTimestamp(pcommon.Timestamp(1_581_452_783_000_000_789))
-	spanAttrs := span.Attributes()
-	spanAttrs.PutStr("processor.event", "transaction")
-	spanAttrs.PutBool("transaction.root", true)
-	spanAttrs.PutStr("transaction.type", "request")
-	spanAttrs.PutStr("event.outcome", "success")
-	spanAttrs.PutDouble("transaction.representative_count", 1.0)
-
-	require.NoError(t, t2m.ConsumeTraces(context.Background(), input))
-	require.NoError(t, t2m.Shutdown(context.Background()))
-
-	var foundNamelessTransactionMetric bool
-	for _, metrics := range nextMetrics.AllMetrics() {
-		rms := metrics.ResourceMetrics()
-		for i := 0; i < rms.Len(); i++ {
-			sms := rms.At(i).ScopeMetrics()
-			for j := 0; j < sms.Len(); j++ {
-				ms := sms.At(j).Metrics()
-				for k := 0; k < ms.Len(); k++ {
-					metric := ms.At(k)
-					if metric.Name() != "transaction.duration.histogram" || metric.Type() != pmetric.MetricTypeExponentialHistogram {
-						continue
-					}
-					dps := metric.ExponentialHistogram().DataPoints()
-					for l := 0; l < dps.Len(); l++ {
-						attrs := dps.At(l).Attributes()
-						dataset, ok := attrs.Get("data_stream.dataset")
-						if !ok || dataset.Str() != "transaction.1m" {
-							continue
-						}
-						metricset, ok := attrs.Get("metricset.name")
-						if !ok || metricset.Str() != "transaction" {
-							continue
-						}
-						_, hasTransactionName := attrs.Get("transaction.name")
-						assert.False(t, hasTransactionName)
-						foundNamelessTransactionMetric = true
-					}
-				}
-			}
-		}
-	}
-	assert.True(t, foundNamelessTransactionMetric)
 }
 
 func TestConnector_AggregationDirectory(t *testing.T) {

--- a/connector/elasticapmconnector/connector_test.go
+++ b/connector/elasticapmconnector/connector_test.go
@@ -38,8 +38,10 @@ import (
 	"go.opentelemetry.io/collector/connector/connectortest"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/ptrace"
 
 	"github.com/elastic/opentelemetry-collector-components/connector/elasticapmconnector/internal/metadata"
 )
@@ -180,6 +182,66 @@ func TestConnector_TracesToMetrics(t *testing.T) {
 			compareAggregatedMetrics(t, expectedMetricsFile, allMetrics)
 		})
 	}
+}
+
+func TestConnector_TransactionMetricsWithoutName(t *testing.T) {
+	nextMetrics := &consumertest.MetricsSink{}
+	t2m := newTracesConnector(t, connectortest.NewNopSettings(metadata.Type), &Config{}, nextMetrics)
+
+	input := ptrace.NewTraces()
+	resourceSpans := input.ResourceSpans().AppendEmpty()
+	resourceAttrs := resourceSpans.Resource().Attributes()
+	resourceAttrs.PutStr("service.name", "nameless-transaction-service")
+	resourceAttrs.PutStr("deployment.environment", "qa")
+	resourceAttrs.PutStr("telemetry.sdk.language", "go")
+	resourceAttrs.PutStr("agent.name", "otlp/go")
+
+	span := resourceSpans.ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+	span.SetName("fallback-span-name")
+	span.SetStartTimestamp(pcommon.Timestamp(1_581_452_772_000_000_321))
+	span.SetEndTimestamp(pcommon.Timestamp(1_581_452_783_000_000_789))
+	spanAttrs := span.Attributes()
+	spanAttrs.PutStr("processor.event", "transaction")
+	spanAttrs.PutBool("transaction.root", true)
+	spanAttrs.PutStr("transaction.type", "request")
+	spanAttrs.PutStr("event.outcome", "success")
+	spanAttrs.PutDouble("transaction.representative_count", 1.0)
+
+	require.NoError(t, t2m.ConsumeTraces(context.Background(), input))
+	require.NoError(t, t2m.Shutdown(context.Background()))
+
+	var foundNamelessTransactionMetric bool
+	for _, metrics := range nextMetrics.AllMetrics() {
+		rms := metrics.ResourceMetrics()
+		for i := 0; i < rms.Len(); i++ {
+			sms := rms.At(i).ScopeMetrics()
+			for j := 0; j < sms.Len(); j++ {
+				ms := sms.At(j).Metrics()
+				for k := 0; k < ms.Len(); k++ {
+					metric := ms.At(k)
+					if metric.Name() != "transaction.duration.histogram" || metric.Type() != pmetric.MetricTypeExponentialHistogram {
+						continue
+					}
+					dps := metric.ExponentialHistogram().DataPoints()
+					for l := 0; l < dps.Len(); l++ {
+						attrs := dps.At(l).Attributes()
+						dataset, ok := attrs.Get("data_stream.dataset")
+						if !ok || dataset.Str() != "transaction.1m" {
+							continue
+						}
+						metricset, ok := attrs.Get("metricset.name")
+						if !ok || metricset.Str() != "transaction" {
+							continue
+						}
+						_, hasTransactionName := attrs.Get("transaction.name")
+						assert.False(t, hasTransactionName)
+						foundNamelessTransactionMetric = true
+					}
+				}
+			}
+		}
+	}
+	assert.True(t, foundNamelessTransactionMetric)
 }
 
 func TestConnector_AggregationDirectory(t *testing.T) {

--- a/connector/elasticapmconnector/testdata/traces/transaction_metrics_without_name/aggregated_metrics.yaml
+++ b/connector/elasticapmconnector/testdata/traces/transaction_metrics_without_name/aggregated_metrics.yaml
@@ -1,0 +1,751 @@
+resourceMetrics:
+  - resource:
+      attributes:
+        - key: agent.name
+          value:
+            stringValue: otlp/go
+        - key: deployment.environment
+          value:
+            stringValue: qa
+        - key: service.name
+          value:
+            stringValue: foo
+        - key: telemetry.sdk.language
+          value:
+            stringValue: go
+    scopeMetrics:
+      - metrics:
+          - description: Success count as a metric for service transaction
+            histogram:
+              aggregationTemporality: 1
+              dataPoints:
+                - attributes:
+                    - key: data_stream.dataset
+                      value:
+                        stringValue: service_transaction.1m
+                    - key: elasticsearch.mapping.hints
+                      value:
+                        arrayValue:
+                          values:
+                            - stringValue: aggregate_metric_double
+                    - key: metricset.interval
+                      value:
+                        stringValue: 1m
+                    - key: metricset.name
+                      value:
+                        stringValue: service_transaction
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                    - key: transaction.root
+                      value:
+                        boolValue: true
+                    - key: transaction.type
+                      value:
+                        stringValue: request
+                  bucketCounts:
+                    - "1"
+                    - "0"
+                  count: "1"
+                  explicitBounds:
+                    - 1
+                  sum: 1
+                  timeUnixNano: "1000000"
+                - attributes:
+                    - key: data_stream.dataset
+                      value:
+                        stringValue: transaction.1m
+                    - key: elasticsearch.mapping.hints
+                      value:
+                        arrayValue:
+                          values:
+                            - stringValue: aggregate_metric_double
+                    - key: event.outcome
+                      value:
+                        stringValue: success
+                    - key: metricset.interval
+                      value:
+                        stringValue: 1m
+                    - key: metricset.name
+                      value:
+                        stringValue: transaction
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                    - key: transaction.root
+                      value:
+                        boolValue: true
+                    - key: transaction.type
+                      value:
+                        stringValue: request
+                  bucketCounts:
+                    - "1"
+                    - "0"
+                  count: "1"
+                  explicitBounds:
+                    - 1
+                  sum: 1
+                  timeUnixNano: "1000000"
+            name: event.success_count
+            unit: us
+          - description: Success count as a metric for service transaction
+            histogram:
+              aggregationTemporality: 1
+              dataPoints:
+                - attributes:
+                    - key: data_stream.dataset
+                      value:
+                        stringValue: service_transaction.10m
+                    - key: elasticsearch.mapping.hints
+                      value:
+                        arrayValue:
+                          values:
+                            - stringValue: aggregate_metric_double
+                    - key: metricset.interval
+                      value:
+                        stringValue: 10m
+                    - key: metricset.name
+                      value:
+                        stringValue: service_transaction
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                    - key: transaction.root
+                      value:
+                        boolValue: true
+                    - key: transaction.type
+                      value:
+                        stringValue: request
+                  bucketCounts:
+                    - "1"
+                    - "0"
+                  count: "1"
+                  explicitBounds:
+                    - 1
+                  sum: 1
+                  timeUnixNano: "1000000"
+                - attributes:
+                    - key: data_stream.dataset
+                      value:
+                        stringValue: transaction.10m
+                    - key: elasticsearch.mapping.hints
+                      value:
+                        arrayValue:
+                          values:
+                            - stringValue: aggregate_metric_double
+                    - key: event.outcome
+                      value:
+                        stringValue: success
+                    - key: metricset.interval
+                      value:
+                        stringValue: 10m
+                    - key: metricset.name
+                      value:
+                        stringValue: transaction
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                    - key: transaction.root
+                      value:
+                        boolValue: true
+                    - key: transaction.type
+                      value:
+                        stringValue: request
+                  bucketCounts:
+                    - "1"
+                    - "0"
+                  count: "1"
+                  explicitBounds:
+                    - 1
+                  sum: 1
+                  timeUnixNano: "1000000"
+            name: event.success_count
+            unit: us
+          - description: Success count as a metric for service transaction
+            histogram:
+              aggregationTemporality: 1
+              dataPoints:
+                - attributes:
+                    - key: data_stream.dataset
+                      value:
+                        stringValue: service_transaction.60m
+                    - key: elasticsearch.mapping.hints
+                      value:
+                        arrayValue:
+                          values:
+                            - stringValue: aggregate_metric_double
+                    - key: metricset.interval
+                      value:
+                        stringValue: 60m
+                    - key: metricset.name
+                      value:
+                        stringValue: service_transaction
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                    - key: transaction.root
+                      value:
+                        boolValue: true
+                    - key: transaction.type
+                      value:
+                        stringValue: request
+                  bucketCounts:
+                    - "1"
+                    - "0"
+                  count: "1"
+                  explicitBounds:
+                    - 1
+                  sum: 1
+                  timeUnixNano: "1000000"
+                - attributes:
+                    - key: data_stream.dataset
+                      value:
+                        stringValue: transaction.60m
+                    - key: elasticsearch.mapping.hints
+                      value:
+                        arrayValue:
+                          values:
+                            - stringValue: aggregate_metric_double
+                    - key: event.outcome
+                      value:
+                        stringValue: success
+                    - key: metricset.interval
+                      value:
+                        stringValue: 60m
+                    - key: metricset.name
+                      value:
+                        stringValue: transaction
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                    - key: transaction.root
+                      value:
+                        boolValue: true
+                    - key: transaction.type
+                      value:
+                        stringValue: request
+                  bucketCounts:
+                    - "1"
+                    - "0"
+                  count: "1"
+                  explicitBounds:
+                    - 1
+                  sum: 1
+                  timeUnixNano: "1000000"
+            name: event.success_count
+            unit: us
+          - name: service_summary
+            sum:
+              aggregationTemporality: 1
+              dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: data_stream.dataset
+                      value:
+                        stringValue: service_summary.1m
+                    - key: metricset.interval
+                      value:
+                        stringValue: 1m
+                    - key: metricset.name
+                      value:
+                        stringValue: service_summary
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                  timeUnixNano: "1000000"
+          - name: service_summary
+            sum:
+              aggregationTemporality: 1
+              dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: data_stream.dataset
+                      value:
+                        stringValue: service_summary.10m
+                    - key: metricset.interval
+                      value:
+                        stringValue: 10m
+                    - key: metricset.name
+                      value:
+                        stringValue: service_summary
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                  timeUnixNano: "1000000"
+          - name: service_summary
+            sum:
+              aggregationTemporality: 1
+              dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: data_stream.dataset
+                      value:
+                        stringValue: service_summary.60m
+                    - key: metricset.interval
+                      value:
+                        stringValue: 60m
+                    - key: metricset.name
+                      value:
+                        stringValue: service_summary
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                  timeUnixNano: "1000000"
+          - description: APM service transaction aggregated metrics as histogram
+            exponentialHistogram:
+              aggregationTemporality: 1
+              dataPoints:
+                - attributes:
+                    - key: data_stream.dataset
+                      value:
+                        stringValue: service_transaction.1m
+                    - key: elasticsearch.mapping.hints
+                      value:
+                        arrayValue:
+                          values:
+                            - stringValue: _doc_count
+                    - key: metricset.interval
+                      value:
+                        stringValue: 1m
+                    - key: metricset.name
+                      value:
+                        stringValue: service_transaction
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                    - key: transaction.root
+                      value:
+                        boolValue: true
+                    - key: transaction.type
+                      value:
+                        stringValue: request
+                  count: "1"
+                  max: 1.1e+07
+                  min: 1.1e+07
+                  negative: {}
+                  positive:
+                    bucketCounts:
+                      - "1"
+                    offset: 2.4527241e+07
+                  scale: 20
+                  sum: 1.1e+07
+                  timeUnixNano: "1000000"
+                - attributes:
+                    - key: data_stream.dataset
+                      value:
+                        stringValue: transaction.1m
+                    - key: elasticsearch.mapping.hints
+                      value:
+                        arrayValue:
+                          values:
+                            - stringValue: _doc_count
+                    - key: event.outcome
+                      value:
+                        stringValue: success
+                    - key: metricset.interval
+                      value:
+                        stringValue: 1m
+                    - key: metricset.name
+                      value:
+                        stringValue: transaction
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                    - key: transaction.root
+                      value:
+                        boolValue: true
+                    - key: transaction.type
+                      value:
+                        stringValue: request
+                  count: "1"
+                  max: 1.1e+07
+                  min: 1.1e+07
+                  negative: {}
+                  positive:
+                    bucketCounts:
+                      - "1"
+                    offset: 2.4527241e+07
+                  scale: 20
+                  sum: 1.1e+07
+                  timeUnixNano: "1000000"
+            name: transaction.duration.histogram
+            unit: us
+          - description: APM service transaction aggregated metrics as histogram
+            exponentialHistogram:
+              aggregationTemporality: 1
+              dataPoints:
+                - attributes:
+                    - key: data_stream.dataset
+                      value:
+                        stringValue: service_transaction.10m
+                    - key: elasticsearch.mapping.hints
+                      value:
+                        arrayValue:
+                          values:
+                            - stringValue: _doc_count
+                    - key: metricset.interval
+                      value:
+                        stringValue: 10m
+                    - key: metricset.name
+                      value:
+                        stringValue: service_transaction
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                    - key: transaction.root
+                      value:
+                        boolValue: true
+                    - key: transaction.type
+                      value:
+                        stringValue: request
+                  count: "1"
+                  max: 1.1e+07
+                  min: 1.1e+07
+                  negative: {}
+                  positive:
+                    bucketCounts:
+                      - "1"
+                    offset: 2.4527241e+07
+                  scale: 20
+                  sum: 1.1e+07
+                  timeUnixNano: "1000000"
+                - attributes:
+                    - key: data_stream.dataset
+                      value:
+                        stringValue: transaction.10m
+                    - key: elasticsearch.mapping.hints
+                      value:
+                        arrayValue:
+                          values:
+                            - stringValue: _doc_count
+                    - key: event.outcome
+                      value:
+                        stringValue: success
+                    - key: metricset.interval
+                      value:
+                        stringValue: 10m
+                    - key: metricset.name
+                      value:
+                        stringValue: transaction
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                    - key: transaction.root
+                      value:
+                        boolValue: true
+                    - key: transaction.type
+                      value:
+                        stringValue: request
+                  count: "1"
+                  max: 1.1e+07
+                  min: 1.1e+07
+                  negative: {}
+                  positive:
+                    bucketCounts:
+                      - "1"
+                    offset: 2.4527241e+07
+                  scale: 20
+                  sum: 1.1e+07
+                  timeUnixNano: "1000000"
+            name: transaction.duration.histogram
+            unit: us
+          - description: APM service transaction aggregated metrics as histogram
+            exponentialHistogram:
+              aggregationTemporality: 1
+              dataPoints:
+                - attributes:
+                    - key: data_stream.dataset
+                      value:
+                        stringValue: service_transaction.60m
+                    - key: elasticsearch.mapping.hints
+                      value:
+                        arrayValue:
+                          values:
+                            - stringValue: _doc_count
+                    - key: metricset.interval
+                      value:
+                        stringValue: 60m
+                    - key: metricset.name
+                      value:
+                        stringValue: service_transaction
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                    - key: transaction.root
+                      value:
+                        boolValue: true
+                    - key: transaction.type
+                      value:
+                        stringValue: request
+                  count: "1"
+                  max: 1.1e+07
+                  min: 1.1e+07
+                  negative: {}
+                  positive:
+                    bucketCounts:
+                      - "1"
+                    offset: 2.4527241e+07
+                  scale: 20
+                  sum: 1.1e+07
+                  timeUnixNano: "1000000"
+                - attributes:
+                    - key: data_stream.dataset
+                      value:
+                        stringValue: transaction.60m
+                    - key: elasticsearch.mapping.hints
+                      value:
+                        arrayValue:
+                          values:
+                            - stringValue: _doc_count
+                    - key: event.outcome
+                      value:
+                        stringValue: success
+                    - key: metricset.interval
+                      value:
+                        stringValue: 60m
+                    - key: metricset.name
+                      value:
+                        stringValue: transaction
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                    - key: transaction.root
+                      value:
+                        boolValue: true
+                    - key: transaction.type
+                      value:
+                        stringValue: request
+                  count: "1"
+                  max: 1.1e+07
+                  min: 1.1e+07
+                  negative: {}
+                  positive:
+                    bucketCounts:
+                      - "1"
+                    offset: 2.4527241e+07
+                  scale: 20
+                  sum: 1.1e+07
+                  timeUnixNano: "1000000"
+            name: transaction.duration.histogram
+            unit: us
+          - description: APM service transaction aggregated metrics as summary
+            histogram:
+              aggregationTemporality: 1
+              dataPoints:
+                - attributes:
+                    - key: data_stream.dataset
+                      value:
+                        stringValue: service_transaction.1m
+                    - key: elasticsearch.mapping.hints
+                      value:
+                        arrayValue:
+                          values:
+                            - stringValue: aggregate_metric_double
+                    - key: metricset.interval
+                      value:
+                        stringValue: 1m
+                    - key: metricset.name
+                      value:
+                        stringValue: service_transaction
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                    - key: transaction.root
+                      value:
+                        boolValue: true
+                    - key: transaction.type
+                      value:
+                        stringValue: request
+                  bucketCounts:
+                    - "0"
+                    - "1"
+                  count: "1"
+                  explicitBounds:
+                    - 1
+                  sum: 1.1e+07
+                  timeUnixNano: "1000000"
+                - attributes:
+                    - key: data_stream.dataset
+                      value:
+                        stringValue: transaction.1m
+                    - key: elasticsearch.mapping.hints
+                      value:
+                        arrayValue:
+                          values:
+                            - stringValue: aggregate_metric_double
+                    - key: event.outcome
+                      value:
+                        stringValue: success
+                    - key: metricset.interval
+                      value:
+                        stringValue: 1m
+                    - key: metricset.name
+                      value:
+                        stringValue: transaction
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                    - key: transaction.root
+                      value:
+                        boolValue: true
+                    - key: transaction.type
+                      value:
+                        stringValue: request
+                  bucketCounts:
+                    - "0"
+                    - "1"
+                  count: "1"
+                  explicitBounds:
+                    - 1
+                  sum: 1.1e+07
+                  timeUnixNano: "1000000"
+            name: transaction.duration.summary
+            unit: us
+          - description: APM service transaction aggregated metrics as summary
+            histogram:
+              aggregationTemporality: 1
+              dataPoints:
+                - attributes:
+                    - key: data_stream.dataset
+                      value:
+                        stringValue: service_transaction.10m
+                    - key: elasticsearch.mapping.hints
+                      value:
+                        arrayValue:
+                          values:
+                            - stringValue: aggregate_metric_double
+                    - key: metricset.interval
+                      value:
+                        stringValue: 10m
+                    - key: metricset.name
+                      value:
+                        stringValue: service_transaction
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                    - key: transaction.root
+                      value:
+                        boolValue: true
+                    - key: transaction.type
+                      value:
+                        stringValue: request
+                  bucketCounts:
+                    - "0"
+                    - "1"
+                  count: "1"
+                  explicitBounds:
+                    - 1
+                  sum: 1.1e+07
+                  timeUnixNano: "1000000"
+                - attributes:
+                    - key: data_stream.dataset
+                      value:
+                        stringValue: transaction.10m
+                    - key: elasticsearch.mapping.hints
+                      value:
+                        arrayValue:
+                          values:
+                            - stringValue: aggregate_metric_double
+                    - key: event.outcome
+                      value:
+                        stringValue: success
+                    - key: metricset.interval
+                      value:
+                        stringValue: 10m
+                    - key: metricset.name
+                      value:
+                        stringValue: transaction
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                    - key: transaction.root
+                      value:
+                        boolValue: true
+                    - key: transaction.type
+                      value:
+                        stringValue: request
+                  bucketCounts:
+                    - "0"
+                    - "1"
+                  count: "1"
+                  explicitBounds:
+                    - 1
+                  sum: 1.1e+07
+                  timeUnixNano: "1000000"
+            name: transaction.duration.summary
+            unit: us
+          - description: APM service transaction aggregated metrics as summary
+            histogram:
+              aggregationTemporality: 1
+              dataPoints:
+                - attributes:
+                    - key: data_stream.dataset
+                      value:
+                        stringValue: service_transaction.60m
+                    - key: elasticsearch.mapping.hints
+                      value:
+                        arrayValue:
+                          values:
+                            - stringValue: aggregate_metric_double
+                    - key: metricset.interval
+                      value:
+                        stringValue: 60m
+                    - key: metricset.name
+                      value:
+                        stringValue: service_transaction
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                    - key: transaction.root
+                      value:
+                        boolValue: true
+                    - key: transaction.type
+                      value:
+                        stringValue: request
+                  bucketCounts:
+                    - "0"
+                    - "1"
+                  count: "1"
+                  explicitBounds:
+                    - 1
+                  sum: 1.1e+07
+                  timeUnixNano: "1000000"
+                - attributes:
+                    - key: data_stream.dataset
+                      value:
+                        stringValue: transaction.60m
+                    - key: elasticsearch.mapping.hints
+                      value:
+                        arrayValue:
+                          values:
+                            - stringValue: aggregate_metric_double
+                    - key: event.outcome
+                      value:
+                        stringValue: success
+                    - key: metricset.interval
+                      value:
+                        stringValue: 60m
+                    - key: metricset.name
+                      value:
+                        stringValue: transaction
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                    - key: transaction.root
+                      value:
+                        boolValue: true
+                    - key: transaction.type
+                      value:
+                        stringValue: request
+                  bucketCounts:
+                    - "0"
+                    - "1"
+                  count: "1"
+                  explicitBounds:
+                    - 1
+                  sum: 1.1e+07
+                  timeUnixNano: "1000000"
+            name: transaction.duration.summary
+            unit: us
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/signaltometricsconnector

--- a/connector/elasticapmconnector/testdata/traces/transaction_metrics_without_name/config.yaml
+++ b/connector/elasticapmconnector/testdata/traces/transaction_metrics_without_name/config.yaml
@@ -1,0 +1,1 @@
+elasticapm: {}

--- a/connector/elasticapmconnector/testdata/traces/transaction_metrics_without_name/input.yaml
+++ b/connector/elasticapmconnector/testdata/traces/transaction_metrics_without_name/input.yaml
@@ -34,4 +34,6 @@ resourceSpans:
                   doubleValue: 1.0
             startTimeUnixNano: "1581452772000000321"
             endTimeUnixNano: "1581452783000000789"
+            # Because this test feeds traces straight into the connector, it bypasses the receiver/processor enrichment
+            # that would normally copy/derive transaction.name from the span name, so this input effectively has no transaction.name.
             name: http-span

--- a/connector/elasticapmconnector/testdata/traces/transaction_metrics_without_name/input.yaml
+++ b/connector/elasticapmconnector/testdata/traces/transaction_metrics_without_name/input.yaml
@@ -1,0 +1,37 @@
+resourceSpans:
+  - resource:
+      attributes:
+        - key: service.name
+          value:
+            stringValue: foo
+        - key: deployment.environment
+          value:
+            stringValue: qa
+        - key: telemetry.sdk.language
+          value:
+            stringValue: go
+        - key: agent.name
+          value:
+            stringValue: otlp/go
+    scopeSpans:
+      - scope: {}
+        spans:
+          - attributes:
+              - key: processor.event
+                value:
+                  stringValue: "transaction"
+              - key: transaction.root
+                value:
+                  boolValue: true
+              - key: transaction.type
+                value:
+                  stringValue: request
+              - key: event.outcome
+                value:
+                  stringValue: success
+              - key: transaction.representative_count
+                value:
+                  doubleValue: 1.0
+            startTimeUnixNano: "1581452772000000321"
+            endTimeUnixNano: "1581452783000000789"
+            name: http-span


### PR DESCRIPTION
  ## Summary
  - Make `transaction.name` optional for `elasticapmconnector` transaction-level aggregation.
  - Add a regression test confirming `metrics-apm.transaction.1m` is emitted when an incoming transaction has no `transaction.name`.
  ## Why
  currently skipping `transaction.1m` aggregation when `transaction.name` is missing, because `transaction.name` is configured as a required signal-to-metrics attribute. Legacy APM intake/APM Server does not require `transaction.name` for transaction aggregation; it groups nameless transactions with an 
  empty/missing transaction name.

  ## Testing
  - `go test ./... -count=1` from `connector/elasticapmconnector`