### PR TITLE
[receiver/akamaisiemreceiver] - Version bump for initial release

### DIFF
--- a/distributions/elastic-components/manifest.yaml
+++ b/distributions/elastic-components/manifest.yaml
@@ -40,7 +40,7 @@ receivers:
   - gomod: github.com/elastic/opentelemetry-collector-components/receiver/loadgenreceiver v0.46.0
   - gomod: github.com/elastic/opentelemetry-collector-components/receiver/elasticapmintakereceiver v0.46.0
   - gomod: github.com/elastic/opentelemetry-collector-components/receiver/entityanalyticsreceiver v0.0.0
-  - gomod: github.com/elastic/opentelemetry-collector-components/receiver/akamaisiemreceiver v0.0.0
+  - gomod: github.com/elastic/opentelemetry-collector-components/receiver/akamaisiemreceiver v0.1.0
 
 processors:
   - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.151.0


### PR DESCRIPTION
Incremented version to v0.1.0 for initial git release with tag `receiver/akamaisiemreceiver/v0.1.0`