### PR TITLE
receiver/entityanalyticsreceiver: register azure-ad provider

### DIFF
--- a/receiver/entityanalyticsreceiver/README.md
+++ b/receiver/entityanalyticsreceiver/README.md
@@ -73,5 +73,4 @@ are registered:
 - `jamf` — Jamf Pro device inventory
 - `activedirectory` — Microsoft Active Directory (users, devices, groups via LDAP)
 - `okta` — Okta (users, devices, groups with bulk-fetch enrichment)
-
-Further providers (EntraID) will be added in subsequent work.
+- `azure-ad` — Microsoft Entra ID (users, devices, groups via Graph API delta queries)

--- a/receiver/entityanalyticsreceiver/entraid.go
+++ b/receiver/entityanalyticsreceiver/entraid.go
@@ -1,0 +1,121 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package entityanalyticsreceiver // import "github.com/elastic/opentelemetry-collector-components/receiver/entityanalyticsreceiver"
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"go.opentelemetry.io/collector/config/configopaque"
+	"go.opentelemetry.io/collector/confmap"
+
+	"github.com/elastic/entcollect"
+	ecentraid "github.com/elastic/entcollect/provider/entraid"
+)
+
+func init() {
+	Register("azure-ad", entraidProvider)
+}
+
+func entraidProvider(cfg *confmap.Conf) (entcollect.Provider, error) {
+	ec := ecentraid.DefaultConfig()
+	if cfg != nil {
+		// entraidLocalConf mirrors ecentraid.Config with mapstructure
+		// tags for confmap.Conf Unmarshal. SyncInterval and
+		// UpdateInterval are owned by the receiver's top-level Config
+		// and are intentionally absent here. If ecentraid.Config gains
+		// a new field, add it here too; TestEntraidProviderConfigRoundTrip
+		// will catch any drift.
+		type entraidLocalConf struct {
+			TenantID     configopaque.String `mapstructure:"tenant_id"`
+			ClientID     configopaque.String `mapstructure:"client_id"`
+			ClientSecret configopaque.String `mapstructure:"client_secret"`
+
+			LoginEndpoint string   `mapstructure:"login_endpoint"`
+			LoginScopes   []string `mapstructure:"login_scopes"`
+			APIEndpoint   string   `mapstructure:"api_endpoint"`
+
+			Dataset    string   `mapstructure:"dataset"`
+			EnrichWith []string `mapstructure:"enrich_with"`
+
+			SelectUsers   []string `mapstructure:"select_users"`
+			SelectGroups  []string `mapstructure:"select_groups"`
+			SelectDevices []string `mapstructure:"select_devices"`
+		}
+
+		lc := entraidLocalConf{
+			LoginEndpoint: ec.LoginEndpoint,
+			LoginScopes:   ec.LoginScopes,
+			APIEndpoint:   ec.APIEndpoint,
+			Dataset:       ec.Dataset,
+			EnrichWith:    ec.EnrichWith,
+			SelectUsers:   ec.SelectUsers,
+			SelectGroups:  ec.SelectGroups,
+			SelectDevices: ec.SelectDevices,
+		}
+		err := cfg.Unmarshal(&lc)
+		if err != nil {
+			return nil, fmt.Errorf("azure-ad: unmarshal config: %w", err)
+		}
+		ec.TenantID = string(lc.TenantID)
+		ec.ClientID = string(lc.ClientID)
+		ec.ClientSecret = string(lc.ClientSecret)
+		ec.LoginEndpoint = lc.LoginEndpoint
+		ec.LoginScopes = lc.LoginScopes
+		ec.APIEndpoint = lc.APIEndpoint
+		ec.Dataset = lc.Dataset
+		ec.EnrichWith = lc.EnrichWith
+		ec.SelectUsers = lc.SelectUsers
+		ec.SelectGroups = lc.SelectGroups
+		ec.SelectDevices = lc.SelectDevices
+	} else {
+		ec.TenantID = os.Getenv("ENTRAID_TENANT_ID")
+		ec.ClientID = os.Getenv("ENTRAID_CLIENT_ID")
+		ec.ClientSecret = os.Getenv("ENTRAID_CLIENT_SECRET")
+		if v := os.Getenv("ENTRAID_LOGIN_ENDPOINT"); v != "" {
+			ec.LoginEndpoint = v
+		}
+		if v := os.Getenv("ENTRAID_LOGIN_SCOPES"); v != "" {
+			ec.LoginScopes = strings.Split(v, ",")
+		}
+		if v := os.Getenv("ENTRAID_API_ENDPOINT"); v != "" {
+			ec.APIEndpoint = v
+		}
+		if v := os.Getenv("ENTRAID_DATASET"); v != "" {
+			ec.Dataset = v
+		}
+		if v := os.Getenv("ENTRAID_ENRICH_WITH"); v != "" {
+			ec.EnrichWith = strings.Split(v, ",")
+		}
+		if v := os.Getenv("ENTRAID_SELECT_USERS"); v != "" {
+			ec.SelectUsers = strings.Split(v, ",")
+		}
+		if v := os.Getenv("ENTRAID_SELECT_GROUPS"); v != "" {
+			ec.SelectGroups = strings.Split(v, ",")
+		}
+		if v := os.Getenv("ENTRAID_SELECT_DEVICES"); v != "" {
+			ec.SelectDevices = strings.Split(v, ",")
+		}
+	}
+	err := ec.Validate()
+	if err != nil {
+		return nil, err
+	}
+	return ecentraid.New(ec), nil
+}

--- a/receiver/entityanalyticsreceiver/entraid_test.go
+++ b/receiver/entityanalyticsreceiver/entraid_test.go
@@ -1,0 +1,67 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package entityanalyticsreceiver
+
+import (
+	"reflect"
+	"testing"
+
+	"go.opentelemetry.io/collector/confmap"
+
+	ecentraid "github.com/elastic/entcollect/provider/entraid"
+)
+
+// TestEntraidProviderConfigRoundTrip verifies that every provider-owned field
+// of ecentraid.Config is represented in the entraidLocalConf mirror inside
+// entraidProvider.
+//
+//  1. Field-count assertion — ecentraid.Config currently has wantTotal
+//     fields. Two of them (SyncInterval, UpdateInterval) are owned by the
+//     receiver's top-level Config and are intentionally absent from
+//     entraidLocalConf. If the total changes, update entraidLocalConf
+//     and this test.
+//  2. Functional round-trip — all entraidLocalConf fields are set to
+//     non-default sentinel values via a confmap.Conf; entraidProvider
+//     must return no error, confirming that credentials and optional
+//     fields are wired through.
+func TestEntraidProviderConfigRoundTrip(t *testing.T) {
+	const wantTotal = 13
+	if got := reflect.TypeOf(ecentraid.Config{}).NumField(); got != wantTotal {
+		t.Fatalf("ecentraid.Config has %d exported fields, want %d; "+
+			"update entraidLocalConf inside entraidProvider and this test", got, wantTotal)
+	}
+
+	cfg := confmap.NewFromStringMap(map[string]any{
+		"tenant_id":      "test-tenant",
+		"client_id":      "test-client",
+		"client_secret":  "test-secret",
+		"login_endpoint": "https://login.example.com",
+		"login_scopes":   []string{"https://graph.example.com/.default"},
+		"api_endpoint":   "https://graph.example.com/v1.0",
+		"dataset":        "users",
+		"enrich_with":    []string{"mfa"},
+		"select_users":   []string{"displayName", "mail"},
+		"select_groups":  []string{"displayName"},
+		"select_devices": []string{"displayName", "operatingSystem"},
+	})
+
+	_, err := entraidProvider(cfg)
+	if err != nil {
+		t.Fatalf("entraidProvider returned unexpected error: %v", err)
+	}
+}

--- a/receiver/entityanalyticsreceiver/go.mod
+++ b/receiver/entityanalyticsreceiver/go.mod
@@ -3,7 +3,7 @@ module github.com/elastic/opentelemetry-collector-components/receiver/entityanal
 go 1.25.0
 
 require (
-	github.com/elastic/entcollect v0.0.0-20260514013106-6d4034497b3d
+	github.com/elastic/entcollect v0.0.0-20260525234839-d7d7a2bf1510
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/component v1.58.0
 	go.opentelemetry.io/collector/component/componenttest v0.152.0

--- a/receiver/entityanalyticsreceiver/go.sum
+++ b/receiver/entityanalyticsreceiver/go.sum
@@ -7,8 +7,8 @@ github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/elastic/entcollect v0.0.0-20260514013106-6d4034497b3d h1:eKAtaQ8G4w9j3LctyOaSoYXnxfSGAcnix8y81esjtJs=
-github.com/elastic/entcollect v0.0.0-20260514013106-6d4034497b3d/go.mod h1:geO9V37Ibo+caL/8JpeqUE5ZJd8jzHjvOcEvAGEaZgI=
+github.com/elastic/entcollect v0.0.0-20260525234839-d7d7a2bf1510 h1:UOtItuwg13cYHSHaK6iIMaBlw9hWIFPWb/xVbYYBnK8=
+github.com/elastic/entcollect v0.0.0-20260525234839-d7d7a2bf1510/go.mod h1:geO9V37Ibo+caL/8JpeqUE5ZJd8jzHjvOcEvAGEaZgI=
 github.com/fatih/color v1.17.0 h1:GlRw1BRJxkpqUCBKzKOw098ed57fEsKeNjpTe3cSjK4=
 github.com/fatih/color v1.17.0/go.mod h1:YZ7TlrGPkiz6ku9fK3TLD/pl3CpsiFyu8N92HLgmosI=
 github.com/foxboron/go-tpm-keyfiles v0.0.0-20250903184740-5d135037bd4d h1:EdO/NMMuCZfxhdzTZLuKAciQSnI2DV+Ppg8+vAYrnqA=


### PR DESCRIPTION
Add the EntraID (Azure AD) provider to the entity analytics receiver. The provider maps either confmap config or ENTRAID_* environment variables to the entcollect ecentraid.Config and registers under the "azure-ad" name to match the Filebeat provider.

A field-count guard in TestEntraidProviderConfigRoundTrip detects config drift between the local mirror struct and ecentraid.Config.

For elastic/beats#49161
Depends elastic/entcollect#9

Assisted-By: Cursor

