### PR TITLE
[Extension][beats_encoding] feat: Introduce mappings feature

### DIFF
--- a/extension/beatsencodingextension/README.md
+++ b/extension/beatsencodingextension/README.md
@@ -6,15 +6,20 @@ Each extracted record is stored as a raw string under the `message` body map key
 
 ## Configuration
 
-| Field | Type | Default | Description |
-|---|---|---|---|
-| `format` | string | `json` | Input format: `json` or `text`. |
-| `unwrap` | []string | _(empty)_ | Sequence of JSON object keys to traverse to reach the target array (e.g., `["records"]` or `["data", "items"]`). Only used with `json` format. |
-| `data_stream.dataset` | string | _(required)_ | Data stream dataset (e.g., `azure.activitylogs`). |
-| `data_stream.namespace` | string | `default` | Data stream namespace. |
-| `input_type` | string | _(empty)_ | Sets the `input.type` field in the log record body (e.g., `aws-s3`, `azure-eventhub`). |
-| `tags` | []string | _(empty)_ | List of strings appended to the `tags` field in the log record body (e.g., `["forwarded", "aws-cloudtrail"]`). |
-| `fields` | map[string]any | _(empty)_ | Key-value pairs added to every log record body (e.g., `{environment: production}`). |
+| Field                   | Type           | Default      | Description                                                                                                                                    |
+|-------------------------|----------------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------|
+| `format`                | string         | `json`       | Input format: `json` or `text`.                                                                                                                |
+| `unwrap`                | []string       | _(empty)_    | Sequence of JSON object keys to traverse to reach the target array (e.g., `["records"]` or `["data", "items"]`). Only used with `json` format. |
+| `mappings`              | []object       | _(empty)_    | Field extraction rules for JSON array elements (see below). Only used with `json` format and `unwrap`.                                         |
+| `mappings.source`       | string         | _(required)_ | JSON key to read from the decoded object.                                                                                                      |
+| `mappings.destination`  | string         | _(required)_ | Key to write in the log body map.                                                                                                              |
+| `mappings.type`         | string         | _(required)_ | OTel value type: `String` or `Integer`.                                                                                                        |
+| `mappings.multiplier`   | int            | `0`          | Scales numeric values before storing (Integer only). `0` means no scaling.                                                                     |
+| `data_stream.dataset`   | string         | _(required)_ | Data stream dataset (e.g., `azure.activitylogs`).                                                                                              |
+| `data_stream.namespace` | string         | `default`    | Data stream namespace.                                                                                                                         |
+| `input_type`            | string         | _(empty)_    | Sets the `input.type` field in the log record body (e.g., `aws-s3`, `azure-eventhub`).                                                         |
+| `tags`                  | []string       | _(empty)_    | List of strings appended to the `tags` field in the log record body (e.g., `["forwarded", "aws-cloudtrail"]`).                                 |
+| `fields`                | map[string]any | _(empty)_    | Key-value pairs added to every log record body (e.g., `{environment: production}`).                                                            |
 
 ### Formats
 
@@ -90,3 +95,40 @@ extensions:
 service:
   extensions: [beats_encoding/text]
 ```
+
+#### JSON with field mappings
+
+Extract specific fields from each array element instead of storing the entire JSON as `message`:
+
+```yaml
+extensions:
+  beats_encoding/mapped:
+    format: json
+    unwrap:
+      - data
+      - items
+    data_stream:
+      dataset: custom
+    input_type: aws-s3
+    mappings:
+      - source: log
+        destination: message
+        type: String
+      - source: timestamp
+        destination: "@timestamp"
+        type: Integer
+        multiplier: 1000  # seconds → millis
+
+service:
+  extensions: [beats_encoding/mapped]
+```
+
+Given input:
+```json
+{"data": {"items": [{"id": 1, "log": "hello", "timestamp": 1779463864}]}}
+```
+
+The resulting log body will contain:
+- `message`: `"hello"`
+- `@timestamp`: `1779463864000`
+

--- a/extension/beatsencodingextension/config.go
+++ b/extension/beatsencodingextension/config.go
@@ -24,6 +24,9 @@ import (
 // Format defines how the incoming raw bytes should be interpreted.
 type Format string
 
+// FieldType defines the supported OTel pcommon value types for field mappings.
+type FieldType string
+
 const (
 	// FormatJSON indicates the input is a JSON document that may contain
 	// wrapped records (use Unwrap to extract them).
@@ -32,6 +35,12 @@ const (
 	// FormatText indicates the input is newline-delimited text where
 	// each line becomes a separate log record.
 	FormatText Format = "text"
+
+	// FieldTypeString maps to pcommon.Map.PutStr.
+	FieldTypeString FieldType = "String"
+
+	// FieldTypeInteger maps to pcommon.Map.PutInt.
+	FieldTypeInteger FieldType = "Integer"
 )
 
 // DataStreamConfig defines the data stream routing attributes.
@@ -69,8 +78,30 @@ type Config struct {
 	// inject custom metadata (e.g., environment, team) into each event.
 	Fields map[string]any `mapstructure:"fields,omitempty"`
 
+	// Mappings defines which JSON keys to extract from each decoded JSON
+	// element and how to store them in the log record body.
+	// Only used when Format is "json" and Unwrap is set.
+	Mappings []FieldMapping `mapstructure:"mappings,omitempty"`
+
 	// prevent unkeyed literal initialization
 	_ struct{}
+}
+
+// FieldMapping defines how a single JSON key is extracted and written
+// to the log record body.
+type FieldMapping struct {
+	// Source is the JSON key to read from the decoded object.
+	Source string `mapstructure:"source"`
+
+	// Destination is the key to write to in the log body map.
+	Destination string `mapstructure:"destination"`
+
+	// Type is the OTel pcommon value type: "String" or "Integer".
+	Type FieldType `mapstructure:"type"`
+
+	// Multiplier scales the numeric value before storing.
+	// Only applies to FieldTypeInteger. A value of 0 means no scaling.
+	Multiplier int64 `mapstructure:"multiplier,omitempty"`
 }
 
 func (c *Config) Validate() error {
@@ -90,6 +121,20 @@ func (c *Config) Validate() error {
 
 	if c.DataStream.Namespace == "" {
 		return fmt.Errorf("data_stream.namespace is required")
+	}
+
+	for i, m := range c.Mappings {
+		if m.Source == "" {
+			return fmt.Errorf("mappings[%d].source is required", i)
+		}
+		if m.Destination == "" {
+			return fmt.Errorf("mappings[%d].destination is required", i)
+		}
+		switch m.Type {
+		case FieldTypeString, FieldTypeInteger:
+		default:
+			return fmt.Errorf("mappings[%d].type %q is invalid: must be %q or %q", i, m.Type, FieldTypeString, FieldTypeInteger)
+		}
 	}
 
 	return nil

--- a/extension/beatsencodingextension/config_test.go
+++ b/extension/beatsencodingextension/config_test.go
@@ -109,6 +109,19 @@ func TestLoadConfig(t *testing.T) {
 			id:      component.NewIDWithName(metadata.Type, "missing_namespace"),
 			wantErr: "data_stream.namespace is required",
 		},
+		{
+			id: component.NewIDWithName(metadata.Type, "with_mappings"),
+			expected: func() *Config {
+				cfg := createDefaultConfig().(*Config)
+				cfg.Unwrap = []string{"records"}
+				cfg.DataStream.Dataset = "azure.events"
+				cfg.Mappings = []FieldMapping{
+					{Source: "message", Destination: "message", Type: FieldTypeString},
+					{Source: "eventTime", Destination: "@timestamp", Type: FieldTypeInteger, Multiplier: 1000000},
+				}
+				return cfg
+			}(),
+		},
 	}
 
 	for _, tt := range tests {

--- a/extension/beatsencodingextension/extension.go
+++ b/extension/beatsencodingextension/extension.go
@@ -44,6 +44,12 @@ var (
 	_ encoding.LogsDecoderExtension     = (*beatsEncodingExtension)(nil)
 )
 
+// MappedField pairs a FieldMapping with its extracted value.
+type MappedField struct {
+	Mapping FieldMapping
+	Value   any
+}
+
 type beatsEncodingExtension struct {
 	config *Config
 	logger *zap.Logger
@@ -112,7 +118,11 @@ func (e *beatsEncodingExtension) newLineDecoder(reader io.Reader, options ...enc
 			line, flush, err := scanner.ScanString()
 
 			if line != "" {
-				e.appendLogRecord(sl, now, eventCreated, line)
+				// Simply add to message as a string
+				data := []MappedField{{Mapping: FieldMapping{Type: FieldTypeString, Destination: "message"}, Value: line}}
+				if err := e.appendLogRecord(sl, now, eventCreated, data); err != nil {
+					return plog.NewLogs(), err
+				}
 			}
 
 			if errors.Is(err, io.EOF) {
@@ -180,7 +190,12 @@ func (e *beatsEncodingExtension) newSingleRecordDecoder(reader io.Reader, opts e
 		logs := plog.NewLogs()
 		sl := newScopeLogs(logs)
 		now := pcommon.NewTimestampFromTime(time.Now())
-		e.appendLogRecord(sl, now, now.AsTime().UTC().Format(time.RFC3339Nano), string(trimmed))
+
+		// Simply add to message as a string
+		data := []MappedField{{Mapping: FieldMapping{Type: FieldTypeString, Destination: "message"}, Value: string(trimmed)}}
+		if err := e.appendLogRecord(sl, now, now.AsTime().UTC().Format(time.RFC3339Nano), data); err != nil {
+			return plog.NewLogs(), err
+		}
 		return logs, nil
 	}
 
@@ -228,6 +243,9 @@ func (e *beatsEncodingExtension) newStreamingJSONDecoder(reader io.Reader, opts 
 		eventCreated := now.AsTime().UTC().Format(time.RFC3339Nano)
 
 		for dec.More() {
+			var n int64
+			var data []MappedField
+
 			var raw json.RawMessage
 			if err := dec.Decode(&raw); err != nil {
 				return logs, fmt.Errorf("decoding array element: %w", err)
@@ -238,10 +256,36 @@ func (e *beatsEncodingExtension) newStreamingJSONDecoder(reader io.Reader, opts 
 				continue
 			}
 
-			e.appendLogRecord(sl, now, eventCreated, string(trimmed))
+			n = int64(len(raw))
+
+			if len(e.config.Mappings) > 0 {
+				var asMap map[string]any
+				if err := json.Unmarshal(trimmed, &asMap); err != nil {
+					return logs, fmt.Errorf("decoding array element: %w", err)
+				}
+				if len(raw) == 0 {
+					continue
+				}
+				for _, m := range e.config.Mappings {
+					if val, ok := asMap[m.Source]; ok {
+						data = append(data, MappedField{Mapping: m, Value: val})
+					}
+				}
+			} else {
+				trimmed := bytes.TrimSpace(raw)
+				if len(trimmed) == 0 {
+					continue
+				}
+				data = []MappedField{{Mapping: FieldMapping{Type: FieldTypeString, Destination: "message"}, Value: string(trimmed)}}
+			}
+
+			if err := e.appendLogRecord(sl, now, eventCreated, data); err != nil {
+				return plog.NewLogs(), err
+			}
+
 			recordCount++
 			batchHelper.IncrementItems(1)
-			batchHelper.IncrementBytes(int64(len(raw)))
+			batchHelper.IncrementBytes(n)
 
 			if batchHelper.ShouldFlush() {
 				batchHelper.Reset()
@@ -382,14 +426,35 @@ func newScopeLogs(logs plog.Logs) plog.ScopeLogs {
 	return sl
 }
 
-func (e *beatsEncodingExtension) appendLogRecord(sl plog.ScopeLogs, ts pcommon.Timestamp, eventCreated string, record string) {
+func (e *beatsEncodingExtension) appendLogRecord(sl plog.ScopeLogs, ts pcommon.Timestamp, eventCreated string, data []MappedField) error {
 	lr := sl.LogRecords().AppendEmpty()
 	lr.SetTimestamp(ts)
 	lr.SetObservedTimestamp(ts)
 
 	body := lr.Body().SetEmptyMap()
-	body.EnsureCapacity(7) // we know we'll be adding at least 7 entries to the body
-	body.PutStr("message", record)
+	body.EnsureCapacity(7)
+
+	for _, d := range data {
+		switch d.Mapping.Type {
+		case FieldTypeString:
+			s, ok := d.Value.(string)
+			if !ok {
+				return fmt.Errorf("expected string field type, got %T", d.Value)
+			}
+			body.PutStr(d.Mapping.Destination, s)
+		case FieldTypeInteger:
+			f, ok := d.Value.(float64)
+			if !ok {
+				return fmt.Errorf("expected numeric field type, got %T", d.Value)
+			}
+			val := int64(f)
+			if d.Mapping.Multiplier != 0 {
+				val *= d.Mapping.Multiplier
+			}
+			body.PutInt(d.Mapping.Destination, val)
+		}
+	}
+
 	body.PutStr("event.created", eventCreated)
 
 	// The data_stream.* should be also set on the body as some
@@ -420,4 +485,6 @@ func (e *beatsEncodingExtension) appendLogRecord(sl plog.ScopeLogs, ts pcommon.T
 	attrs.PutStr("data_stream.type", "logs")
 	attrs.PutStr("data_stream.dataset", e.config.DataStream.Dataset)
 	attrs.PutStr("data_stream.namespace", e.config.DataStream.Namespace)
+
+	return nil
 }

--- a/extension/beatsencodingextension/extension.go
+++ b/extension/beatsencodingextension/extension.go
@@ -259,8 +259,12 @@ func (e *beatsEncodingExtension) newStreamingJSONDecoder(reader io.Reader, opts 
 			n = int64(len(raw))
 
 			if len(e.config.Mappings) > 0 {
+				// Use Number to preserve numeric types
+				numDec := json.NewDecoder(bytes.NewReader(raw))
+				numDec.UseNumber()
+
 				var asMap map[string]any
-				if err := json.Unmarshal(trimmed, &asMap); err != nil {
+				if err := numDec.Decode(&asMap); err != nil {
 					return logs, fmt.Errorf("decoding array element: %w", err)
 				}
 				if len(raw) == 0 {
@@ -272,10 +276,6 @@ func (e *beatsEncodingExtension) newStreamingJSONDecoder(reader io.Reader, opts 
 					}
 				}
 			} else {
-				trimmed := bytes.TrimSpace(raw)
-				if len(trimmed) == 0 {
-					continue
-				}
 				data = []MappedField{{Mapping: FieldMapping{Type: FieldTypeString, Destination: "message"}, Value: string(trimmed)}}
 			}
 
@@ -443,15 +443,19 @@ func (e *beatsEncodingExtension) appendLogRecord(sl plog.ScopeLogs, ts pcommon.T
 			}
 			body.PutStr(d.Mapping.Destination, s)
 		case FieldTypeInteger:
-			f, ok := d.Value.(float64)
+			num, ok := d.Value.(json.Number)
 			if !ok {
-				return fmt.Errorf("expected numeric field type, got %T", d.Value)
+				return fmt.Errorf("field %q: expected numeric (json.Number), got %T", d.Mapping.Destination, d.Value)
 			}
-			val := int64(f)
+			base, err := num.Int64()
+			if err != nil {
+				return fmt.Errorf("field %q: expected integer, got %q: %w", d.Mapping.Destination, num.String(), err)
+			}
+
 			if d.Mapping.Multiplier != 0 {
-				val *= d.Mapping.Multiplier
+				base *= d.Mapping.Multiplier
 			}
-			body.PutInt(d.Mapping.Destination, val)
+			body.PutInt(d.Mapping.Destination, base)
 		}
 	}
 

--- a/extension/beatsencodingextension/extension_test.go
+++ b/extension/beatsencodingextension/extension_test.go
@@ -153,9 +153,9 @@ func TestUnmarshalLogs(t *testing.T) {
 					},
 					{
 						Source:      "seconds",
-						Destination: "milliseconds",
+						Destination: "Nano",
 						Type:        "Integer",
-						Multiplier:  1000000,
+						Multiplier:  1000,
 					},
 				},
 				DataStream: DataStreamConfig{Dataset: "custom", Namespace: "default"},

--- a/extension/beatsencodingextension/extension_test.go
+++ b/extension/beatsencodingextension/extension_test.go
@@ -140,6 +140,31 @@ func TestUnmarshalLogs(t *testing.T) {
 			goldenFile: "aws_vpcflow_input_type_tags_expected.yaml",
 			wantLogs:   3,
 		},
+		{
+			name: "JSON handling with mappings",
+			config: Config{
+				Format: FormatJSON,
+				Unwrap: []string{"items"},
+				Mappings: []FieldMapping{
+					{
+						Source:      "log",
+						Destination: "message",
+						Type:        "String",
+					},
+					{
+						Source:      "seconds",
+						Destination: "milliseconds",
+						Type:        "Integer",
+						Multiplier:  1000000,
+					},
+				},
+				DataStream: DataStreamConfig{Dataset: "custom", Namespace: "default"},
+				InputType:  "aws-s3",
+			},
+			inputFile:  "json_nested_complex.json",
+			goldenFile: "json_nested_complex_expected.yaml",
+			wantLogs:   3,
+		},
 	}
 
 	for _, tt := range tests {

--- a/extension/beatsencodingextension/testdata/config.yaml
+++ b/extension/beatsencodingextension/testdata/config.yaml
@@ -45,7 +45,7 @@ beats_encoding/empty_fields:
   format: text
   data_stream:
     dataset: test
-  fields: {}
+  fields: { }
 
 beats_encoding/missing_dataset:
   format: json
@@ -54,3 +54,17 @@ beats_encoding/missing_namespace:
   data_stream:
     dataset: test
     namespace: ""
+
+beats_encoding/with_mappings:
+  unwrap:
+    - records
+  data_stream:
+    dataset: azure.events
+  mappings:
+    - source: message
+      destination: message
+      type: String
+    - source: eventTime
+      destination: "@timestamp"
+      type: Integer
+      multiplier: 1000000

--- a/extension/beatsencodingextension/testdata/json_nested_complex.json
+++ b/extension/beatsencodingextension/testdata/json_nested_complex.json
@@ -1,0 +1,22 @@
+{
+  "type": "complex",
+  "date": "1970-01-01T00:00:00Z",
+  "uuid": "123e4567-e89b-12d3-a456-426614174000",
+  "items": [
+    {
+      "id": 1,
+      "log": "log1",
+      "seconds": 10
+    },
+    {
+      "id": 2,
+      "log": "log2",
+      "seconds": 20
+    },
+    {
+      "id": 3,
+      "log": "log3",
+      "seconds": 30
+    }
+  ]
+}

--- a/extension/beatsencodingextension/testdata/json_nested_complex.json
+++ b/extension/beatsencodingextension/testdata/json_nested_complex.json
@@ -6,17 +6,17 @@
     {
       "id": 1,
       "log": "log1",
-      "seconds": 10
+      "seconds": 1779801400123456
     },
     {
       "id": 2,
       "log": "log2",
-      "seconds": 20
+      "seconds": 1779801500123456
     },
     {
       "id": 3,
       "log": "log3",
-      "seconds": 30
+      "seconds": 1779801600123456
     }
   ]
 }

--- a/extension/beatsencodingextension/testdata/json_nested_complex_expected.yaml
+++ b/extension/beatsencodingextension/testdata/json_nested_complex_expected.yaml
@@ -18,9 +18,9 @@ resourceLogs:
                   - key: message
                     value:
                       stringValue: log1
-                  - key: milliseconds
+                  - key: Nano
                     value:
-                      intValue: "10000000"
+                      intValue: "1779801400123456000"
                   - key: input.type
                     value:
                       stringValue: aws-s3
@@ -36,8 +36,8 @@ resourceLogs:
                   - key: event.dataset
                     value:
                       stringValue: custom
-            observedTimeUnixNano: "1779469455005671000"
-            timeUnixNano: "1779469455005671000"
+            observedTimeUnixNano: "1779817241863875000"
+            timeUnixNano: "1779817241863875000"
           - attributes:
               - key: data_stream.type
                 value:
@@ -54,9 +54,9 @@ resourceLogs:
                   - key: message
                     value:
                       stringValue: log2
-                  - key: milliseconds
+                  - key: Nano
                     value:
-                      intValue: "20000000"
+                      intValue: "1779801500123456000"
                   - key: input.type
                     value:
                       stringValue: aws-s3
@@ -72,8 +72,8 @@ resourceLogs:
                   - key: event.dataset
                     value:
                       stringValue: custom
-            observedTimeUnixNano: "1779469455005671000"
-            timeUnixNano: "1779469455005671000"
+            observedTimeUnixNano: "1779817241863875000"
+            timeUnixNano: "1779817241863875000"
           - attributes:
               - key: data_stream.type
                 value:
@@ -90,9 +90,9 @@ resourceLogs:
                   - key: message
                     value:
                       stringValue: log3
-                  - key: milliseconds
+                  - key: Nano
                     value:
-                      intValue: "30000000"
+                      intValue: "1779801600123456000"
                   - key: input.type
                     value:
                       stringValue: aws-s3
@@ -108,8 +108,8 @@ resourceLogs:
                   - key: event.dataset
                     value:
                       stringValue: custom
-            observedTimeUnixNano: "1779469455005671000"
-            timeUnixNano: "1779469455005671000"
+            observedTimeUnixNano: "1779817241863875000"
+            timeUnixNano: "1779817241863875000"
         scope:
           attributes:
             - key: elastic.mapping.mode

--- a/extension/beatsencodingextension/testdata/json_nested_complex_expected.yaml
+++ b/extension/beatsencodingextension/testdata/json_nested_complex_expected.yaml
@@ -1,0 +1,117 @@
+resourceLogs:
+  - resource: {}
+    scopeLogs:
+      - logRecords:
+          - attributes:
+              - key: data_stream.type
+                value:
+                  stringValue: logs
+              - key: data_stream.dataset
+                value:
+                  stringValue: custom
+              - key: data_stream.namespace
+                value:
+                  stringValue: default
+            body:
+              kvlistValue:
+                values:
+                  - key: message
+                    value:
+                      stringValue: log1
+                  - key: milliseconds
+                    value:
+                      intValue: "10000000"
+                  - key: input.type
+                    value:
+                      stringValue: aws-s3
+                  - key: data_stream.type
+                    value:
+                      stringValue: logs
+                  - key: data_stream.dataset
+                    value:
+                      stringValue: custom
+                  - key: data_stream.namespace
+                    value:
+                      stringValue: default
+                  - key: event.dataset
+                    value:
+                      stringValue: custom
+            observedTimeUnixNano: "1779469455005671000"
+            timeUnixNano: "1779469455005671000"
+          - attributes:
+              - key: data_stream.type
+                value:
+                  stringValue: logs
+              - key: data_stream.dataset
+                value:
+                  stringValue: custom
+              - key: data_stream.namespace
+                value:
+                  stringValue: default
+            body:
+              kvlistValue:
+                values:
+                  - key: message
+                    value:
+                      stringValue: log2
+                  - key: milliseconds
+                    value:
+                      intValue: "20000000"
+                  - key: input.type
+                    value:
+                      stringValue: aws-s3
+                  - key: data_stream.type
+                    value:
+                      stringValue: logs
+                  - key: data_stream.dataset
+                    value:
+                      stringValue: custom
+                  - key: data_stream.namespace
+                    value:
+                      stringValue: default
+                  - key: event.dataset
+                    value:
+                      stringValue: custom
+            observedTimeUnixNano: "1779469455005671000"
+            timeUnixNano: "1779469455005671000"
+          - attributes:
+              - key: data_stream.type
+                value:
+                  stringValue: logs
+              - key: data_stream.dataset
+                value:
+                  stringValue: custom
+              - key: data_stream.namespace
+                value:
+                  stringValue: default
+            body:
+              kvlistValue:
+                values:
+                  - key: message
+                    value:
+                      stringValue: log3
+                  - key: milliseconds
+                    value:
+                      intValue: "30000000"
+                  - key: input.type
+                    value:
+                      stringValue: aws-s3
+                  - key: data_stream.type
+                    value:
+                      stringValue: logs
+                  - key: data_stream.dataset
+                    value:
+                      stringValue: custom
+                  - key: data_stream.namespace
+                    value:
+                      stringValue: default
+                  - key: event.dataset
+                    value:
+                      stringValue: custom
+            observedTimeUnixNano: "1779469455005671000"
+            timeUnixNano: "1779469455005671000"
+        scope:
+          attributes:
+            - key: elastic.mapping.mode
+              value:
+                stringValue: bodymap


### PR DESCRIPTION
### Overview

This PR enhance the Beats Encoding extension by introducing `mappings` configuration.

Consider following config.yaml portion,

```yaml
extensions:
  beats_encoding/mapped:
    format: json
    unwrap:
      - data
      - items
    data_stream:
      dataset: custom
    input_type: aws-s3
    mappings:
      - source: log
        destination: message
        type: String
      - source: timestamp
        destination: "@timestamp"
        type: Integer
        multiplier: 1000  # seconds → millis
```

When processing following JSON,

```json
{"data": {"items": [{"id": 1, "log": "hello", "timestamp": 1779463864}]}}
```

Mappings will extract internal JSON entries as below,

```
- `message`: `"hello"`
- `@timestamp`: `1779463864000` // Scaler values with multiplier
```

