### PR TITLE
Improve telemetry of the ratelimit processor

### DIFF
--- a/processor/ratelimitprocessor/README.md
+++ b/processor/ratelimitprocessor/README.md
@@ -52,8 +52,10 @@ processors:
 | `otelcol_ratelimit.request_size` | Histogram | Size (bytes) of the request. Only recorded when `strategy: bytes`. Labelled with `decision` and `reason`. |
 | `otelcol_ratelimit.concurrent_requests` | UpDownCounter | Number of requests currently being processed (in-flight). Labelled by metadata keys only. |
 | `otelcol_ratelimit.delay_duration` | Histogram | Time (seconds) a request spent waiting due to rate limiting. Only recorded when `throttle_behavior: delay` and a delay actually occurred (`decision: delayed`). Labelled with `decision` and `reason`. |
-| `otelcol_ratelimit.tokens_after` | Gauge | Token bucket level after this request was served. Negative values indicate the bucket is in debt. Labelled by metadata keys and `limit_threshold`. |
-| `otelcol_ratelimit.tokens_before` | Gauge | Token bucket level when the request arrived, before any tokens were consumed. Negative means the bucket was already in deficit on arrival (sustained throttling). Labelled by metadata keys and `limit_threshold`. |
+| `otelcol_ratelimit.tokens_after` | Gauge | Token bucket level after this request was served. Negative values indicate the bucket is in debt. Only emitted for `throttle_behavior: delay`. Labelled by metadata keys and `limit_threshold`. |
+| `otelcol_ratelimit.tokens_before` | Gauge | Token bucket level when the request arrived, before any tokens were consumed. Negative means the bucket was already in deficit on arrival (sustained throttling). Only emitted for `throttle_behavior: delay`. Labelled by metadata keys and `limit_threshold`. |
+
+`tokens_before` and `tokens_after` answer different questions: `tokens_before` shows whether the bucket was already in deficit when the request arrived — a negative value is a reliable signal of sustained overload rather than a transient burst. `tokens_after` shows how deep in debt the bucket is after serving the request, reflecting committed future debt from the reservation. Together they give a before→after trajectory that neither metric provides on its own.
 
 #### Attributes
 
@@ -73,4 +75,4 @@ processors:
 | `under_limit` | Bucket had enough tokens; request accepted immediately. |
 | `over_limit` | Bucket was empty or in deficit. Applies to `delayed`, `throttled`, and `cancelled` decisions. |
 
-**`limit_threshold`** — the configured token refill rate (tokens/second) for the key. Appears on `otelcol_ratelimit.tokens_after` and `otelcol_ratelimit.tokens_before`.
+**`limit_threshold`** — the configured token refill rate (tokens/second) for the key. Appears on `otelcol_ratelimit.tokens_after` and `otelcol_ratelimit.tokens_before` (delay mode only).

--- a/processor/ratelimitprocessor/README.md
+++ b/processor/ratelimitprocessor/README.md
@@ -52,11 +52,12 @@ processors:
 | `otelcol_ratelimit.request_size` | Histogram | Size (bytes) of the request. Only recorded when `strategy: bytes`. Labelled with `decision` and `reason`. |
 | `otelcol_ratelimit.concurrent_requests` | UpDownCounter | Number of requests currently being processed (in-flight). Labelled by metadata keys only. |
 | `otelcol_ratelimit.delay_duration` | Histogram | Time (seconds) a request spent waiting due to rate limiting. Only recorded when `throttle_behavior: delay` and a delay actually occurred (`decision: delayed`). Labelled with `decision` and `reason`. |
-| `otelcol_ratelimit.tokens` | Gauge | Current token level in the rate limiter bucket. Negative values mean the bucket is in debt (active throttling). Labelled by metadata keys and `limit_threshold`. |
+| `otelcol_ratelimit.tokens_after` | Gauge | Token bucket level after this request was served. Negative values indicate the bucket is in debt. Labelled by metadata keys and `limit_threshold`. |
+| `otelcol_ratelimit.tokens_before` | Gauge | Token bucket level when the request arrived, before any tokens were consumed. Negative means the bucket was already in deficit on arrival (sustained throttling). Labelled by metadata keys and `limit_threshold`. |
 
 #### Attributes
 
-**`decision`** — the outcome of the rate limit check:
+**`ratelimit_decision`** — the outcome of the rate limit check:
 
 | Value | Meaning |
 |-------|---------|
@@ -72,4 +73,4 @@ processors:
 | `under_limit` | Bucket had enough tokens; request accepted immediately. |
 | `over_limit` | Bucket was empty or in deficit. Applies to `delayed`, `throttled`, and `cancelled` decisions. |
 
-**`limit_threshold`** — the configured token refill rate (tokens/second) for the key. Appears only on `otelcol_ratelimit.tokens`.
+**`limit_threshold`** — the configured token refill rate (tokens/second) for the key. Appears on `otelcol_ratelimit.tokens_after` and `otelcol_ratelimit.tokens_before`.

--- a/processor/ratelimitprocessor/README.md
+++ b/processor/ratelimitprocessor/README.md
@@ -73,17 +73,3 @@ processors:
 | `over_limit` | Bucket was empty or in deficit. Applies to `delayed`, `throttled`, and `cancelled` decisions. |
 
 **`limit_threshold`** — the configured token refill rate (tokens/second) for the key. Appears only on `otelcol_ratelimit.tokens`.
-
-#### Example: what to look for
-
-**Is any tenant being rate-limited?**
-Query `otelcol_ratelimit.requests` filtered to `decision != "accepted"`. A non-zero count for `decision="throttled"` means requests are being dropped. A count for `decision="delayed"` means they are being queued.
-
-**How long are delayed requests waiting?**
-`otelcol_ratelimit.delay_duration` shows the distribution of wait times. P99 above a few hundred milliseconds may indicate the rate is set too low relative to incoming traffic.
-
-**Is the bucket currently in debt?**
-`otelcol_ratelimit.tokens` going negative means the processor is actively throttling. How negative it is reflects how far behind the bucket is.
-
-**Are clients timing out while waiting?**
-`otelcol_ratelimit.requests` filtered to `decision="cancelled"` shows requests that started waiting (delay mode) but whose client gave up before the wait completed.

--- a/processor/ratelimitprocessor/README.md
+++ b/processor/ratelimitprocessor/README.md
@@ -43,14 +43,47 @@ processors:
 ```
 ### Telemetry and metrics
 
-The processor emits attributes on relevant metrics to aid debugging and monitoring:
+#### Metrics
 
-* `decision`
-* `reason`
+| Metric | Type | Description |
+|--------|------|-------------|
+| `otelcol_ratelimit.requests` | Counter | Total number of rate-limiting decisions made. Labelled with `decision` and `reason`. |
+| `otelcol_ratelimit.request_duration` | Histogram | Time (seconds) to evaluate the rate limit check itself. Labelled by metadata keys only. |
+| `otelcol_ratelimit.request_size` | Histogram | Size (bytes) of the request. Only recorded when `strategy: bytes`. Labelled with `decision` and `reason`. |
+| `otelcol_ratelimit.concurrent_requests` | UpDownCounter | Number of requests currently being processed (in-flight). Labelled by metadata keys only. |
+| `otelcol_ratelimit.delay_duration` | Histogram | Time (seconds) a request spent waiting due to rate limiting. Only recorded when `throttle_behavior: delay` and a delay actually occurred (`decision: delayed`). Labelled with `decision` and `reason`. |
+| `otelcol_ratelimit.tokens` | Gauge | Current token level in the rate limiter bucket. Negative values mean the bucket is in debt (active throttling). Labelled by metadata keys and `limit_threshold`. |
 
-Metrics exposed by the processor include:
+#### Attributes
 
-* `otelcol_ratelimit.requests` — total number of rate limiting requests
-* `otelcol_ratelimit.request_duration` — histogram of request processing duration (seconds)
-* `otelcol_ratelimit.request_size` — histogram of bytes per request (only when strategy is `bytes`)
-* `otelcol_ratelimit.concurrent_requests` — current number of in-flight requests
+**`decision`** — the outcome of the rate limit check:
+
+| Value | Meaning |
+|-------|---------|
+| `accepted` | Request passed immediately; tokens were available. |
+| `delayed` | Request was held for a short wait while the bucket refilled (`throttle_behavior: delay`). No error is returned. |
+| `throttled` | Request was rejected because the bucket was empty (`throttle_behavior: error`). An error is returned to the sender. |
+| `cancelled` | Request was waiting for the bucket to refill but the client cancelled the context before the wait completed. The cancellation error is propagated back. |
+
+**`reason`** — the rate-limiting state that produced the decision:
+
+| Value | Meaning |
+|-------|---------|
+| `under_limit` | Bucket had enough tokens; request accepted immediately. |
+| `over_limit` | Bucket was empty or in deficit. Applies to `delayed`, `throttled`, and `cancelled` decisions. |
+
+**`limit_threshold`** — the configured token refill rate (tokens/second) for the key. Appears only on `otelcol_ratelimit.tokens`.
+
+#### Example: what to look for
+
+**Is any tenant being rate-limited?**
+Query `otelcol_ratelimit.requests` filtered to `decision != "accepted"`. A non-zero count for `decision="throttled"` means requests are being dropped. A count for `decision="delayed"` means they are being queued.
+
+**How long are delayed requests waiting?**
+`otelcol_ratelimit.delay_duration` shows the distribution of wait times. P99 above a few hundred milliseconds may indicate the rate is set too low relative to incoming traffic.
+
+**Is the bucket currently in debt?**
+`otelcol_ratelimit.tokens` going negative means the processor is actively throttling. How negative it is reflects how far behind the bucket is.
+
+**Are clients timing out while waiting?**
+`otelcol_ratelimit.requests` filtered to `decision="cancelled"` shows requests that started waiting (delay mode) but whose client gave up before the wait completed.

--- a/processor/ratelimitprocessor/documentation.md
+++ b/processor/ratelimitprocessor/documentation.md
@@ -53,9 +53,17 @@ Number of rate-limiting requests
 | decision | rate limit decision | Any Str | - |
 | reason | rate limit reason | Any Str | - |
 
-### otelcol_ratelimit.tokens
+### otelcol_ratelimit.tokens_after
 
-Current token level in the rate limiter bucket per key. Negative values indicate active throttling.
+Token bucket level after this request was served. Negative values indicate the bucket is in debt.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {tokens} | Gauge | Double | Development |
+
+### otelcol_ratelimit.tokens_before
+
+Token bucket level at the moment a request arrived, before any tokens were consumed. Negative values mean the bucket was already in deficit on arrival (sustained throttling).
 
 | Unit | Metric Type | Value Type | Stability |
 | ---- | ----------- | ---------- | --------- |

--- a/processor/ratelimitprocessor/documentation.md
+++ b/processor/ratelimitprocessor/documentation.md
@@ -55,7 +55,7 @@ Number of rate-limiting requests
 
 ### otelcol_ratelimit.tokens_after
 
-Token bucket level after this request was served. Negative values indicate the bucket is in debt.
+Token bucket level after this request was served. Negative values indicate the bucket is in debt. Only emitted for throttle_behavior=delay.
 
 | Unit | Metric Type | Value Type | Stability |
 | ---- | ----------- | ---------- | --------- |
@@ -63,7 +63,7 @@ Token bucket level after this request was served. Negative values indicate the b
 
 ### otelcol_ratelimit.tokens_before
 
-Token bucket level at the moment a request arrived, before any tokens were consumed. Negative values mean the bucket was already in deficit on arrival (sustained throttling).
+Token bucket level at the moment a request arrived, before any tokens were consumed. Negative values mean the bucket was already in deficit on arrival (sustained throttling). Only emitted for throttle_behavior=delay.
 
 | Unit | Metric Type | Value Type | Stability |
 | ---- | ----------- | ---------- | --------- |

--- a/processor/ratelimitprocessor/documentation.md
+++ b/processor/ratelimitprocessor/documentation.md
@@ -14,6 +14,14 @@ Number of in-flight requests at any given time
 | ---- | ----------- | ---------- | --------- | --------- |
 | {requests} | Sum | Int | false | Development |
 
+### otelcol_ratelimit.delay_duration
+
+Time (in seconds) a request spent waiting due to rate limiting. Only recorded when a delay occurs.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {seconds} | Histogram | Double | Development |
+
 ### otelcol_ratelimit.request_duration
 
 Time(in seconds) taken to process a rate limit request
@@ -44,3 +52,11 @@ Number of rate-limiting requests
 | ---- | ----------- | ------ | ------------------- |
 | decision | rate limit decision | Any Str | - |
 | reason | rate limit reason | Any Str | - |
+
+### otelcol_ratelimit.tokens
+
+Current token level in the rate limiter bucket per key. Negative values indicate active throttling.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {tokens} | Gauge | Double | Development |

--- a/processor/ratelimitprocessor/internal/metadata/generated_telemetry.go
+++ b/processor/ratelimitprocessor/internal/metadata/generated_telemetry.go
@@ -48,7 +48,8 @@ type TelemetryBuilder struct {
 	RatelimitRequestDuration    metric.Float64Histogram
 	RatelimitRequestSize        metric.Int64Histogram
 	RatelimitRequests           metric.Int64Counter
-	RatelimitTokens             metric.Float64Gauge
+	RatelimitTokensAfter        metric.Float64Gauge
+	RatelimitTokensBefore       metric.Float64Gauge
 }
 
 // TelemetryBuilderOption applies changes to default builder.
@@ -113,9 +114,15 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 		metric.WithUnit("{requests}"),
 	)
 	errs = errors.Join(errs, err)
-	builder.RatelimitTokens, err = builder.meter.Float64Gauge(
-		"otelcol_ratelimit.tokens",
-		metric.WithDescription("Current token level in the rate limiter bucket per key. Negative values indicate active throttling. [Development]"),
+	builder.RatelimitTokensAfter, err = builder.meter.Float64Gauge(
+		"otelcol_ratelimit.tokens_after",
+		metric.WithDescription("Token bucket level after this request was served. Negative values indicate the bucket is in debt. [Development]"),
+		metric.WithUnit("{tokens}"),
+	)
+	errs = errors.Join(errs, err)
+	builder.RatelimitTokensBefore, err = builder.meter.Float64Gauge(
+		"otelcol_ratelimit.tokens_before",
+		metric.WithDescription("Token bucket level at the moment a request arrived, before any tokens were consumed. Negative values mean the bucket was already in deficit on arrival (sustained throttling). [Development]"),
 		metric.WithUnit("{tokens}"),
 	)
 	errs = errors.Join(errs, err)

--- a/processor/ratelimitprocessor/internal/metadata/generated_telemetry.go
+++ b/processor/ratelimitprocessor/internal/metadata/generated_telemetry.go
@@ -44,9 +44,11 @@ type TelemetryBuilder struct {
 	mu                          sync.Mutex
 	registrations               []metric.Registration
 	RatelimitConcurrentRequests metric.Int64UpDownCounter
+	RatelimitDelayDuration      metric.Float64Histogram
 	RatelimitRequestDuration    metric.Float64Histogram
 	RatelimitRequestSize        metric.Int64Histogram
 	RatelimitRequests           metric.Int64Counter
+	RatelimitTokens             metric.Float64Gauge
 }
 
 // TelemetryBuilderOption applies changes to default builder.
@@ -84,6 +86,13 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 		metric.WithUnit("{requests}"),
 	)
 	errs = errors.Join(errs, err)
+	builder.RatelimitDelayDuration, err = builder.meter.Float64Histogram(
+		"otelcol_ratelimit.delay_duration",
+		metric.WithDescription("Time (in seconds) a request spent waiting due to rate limiting. Only recorded when a delay occurs. [Development]"),
+		metric.WithUnit("{seconds}"),
+		metric.WithExplicitBucketBoundaries([]float64{0.0001, 0.0005, 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.5, 1, 5, 10, 30}...),
+	)
+	errs = errors.Join(errs, err)
 	builder.RatelimitRequestDuration, err = builder.meter.Float64Histogram(
 		"otelcol_ratelimit.request_duration",
 		metric.WithDescription("Time(in seconds) taken to process a rate limit request [Development]"),
@@ -102,6 +111,12 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 		"otelcol_ratelimit.requests",
 		metric.WithDescription("Number of rate-limiting requests [Development]"),
 		metric.WithUnit("{requests}"),
+	)
+	errs = errors.Join(errs, err)
+	builder.RatelimitTokens, err = builder.meter.Float64Gauge(
+		"otelcol_ratelimit.tokens",
+		metric.WithDescription("Current token level in the rate limiter bucket per key. Negative values indicate active throttling. [Development]"),
+		metric.WithUnit("{tokens}"),
 	)
 	errs = errors.Join(errs, err)
 	return &builder, errs

--- a/processor/ratelimitprocessor/internal/metadata/generated_telemetry.go
+++ b/processor/ratelimitprocessor/internal/metadata/generated_telemetry.go
@@ -116,13 +116,13 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 	errs = errors.Join(errs, err)
 	builder.RatelimitTokensAfter, err = builder.meter.Float64Gauge(
 		"otelcol_ratelimit.tokens_after",
-		metric.WithDescription("Token bucket level after this request was served. Negative values indicate the bucket is in debt. [Development]"),
+		metric.WithDescription("Token bucket level after this request was served. Negative values indicate the bucket is in debt. Only emitted for throttle_behavior=delay. [Development]"),
 		metric.WithUnit("{tokens}"),
 	)
 	errs = errors.Join(errs, err)
 	builder.RatelimitTokensBefore, err = builder.meter.Float64Gauge(
 		"otelcol_ratelimit.tokens_before",
-		metric.WithDescription("Token bucket level at the moment a request arrived, before any tokens were consumed. Negative values mean the bucket was already in deficit on arrival (sustained throttling). [Development]"),
+		metric.WithDescription("Token bucket level at the moment a request arrived, before any tokens were consumed. Negative values mean the bucket was already in deficit on arrival (sustained throttling). Only emitted for throttle_behavior=delay. [Development]"),
 		metric.WithUnit("{tokens}"),
 	)
 	errs = errors.Join(errs, err)

--- a/processor/ratelimitprocessor/internal/metadatatest/generated_telemetrytest.go
+++ b/processor/ratelimitprocessor/internal/metadatatest/generated_telemetrytest.go
@@ -54,6 +54,21 @@ func AssertEqualRatelimitConcurrentRequests(t *testing.T, tt *componenttest.Tele
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
+func AssertEqualRatelimitDelayDuration(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.HistogramDataPoint[float64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol_ratelimit.delay_duration",
+		Description: "Time (in seconds) a request spent waiting due to rate limiting. Only recorded when a delay occurs. [Development]",
+		Unit:        "{seconds}",
+		Data: metricdata.Histogram[float64]{
+			Temporality: metricdata.CumulativeTemporality,
+			DataPoints:  dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol_ratelimit.delay_duration")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}
+
 func AssertEqualRatelimitRequestDuration(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.HistogramDataPoint[float64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_ratelimit.request_duration",
@@ -96,6 +111,20 @@ func AssertEqualRatelimitRequests(t *testing.T, tt *componenttest.Telemetry, dps
 		},
 	}
 	got, err := tt.GetMetric("otelcol_ratelimit.requests")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}
+
+func AssertEqualRatelimitTokens(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[float64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol_ratelimit.tokens",
+		Description: "Current token level in the rate limiter bucket per key. Negative values indicate active throttling. [Development]",
+		Unit:        "{tokens}",
+		Data: metricdata.Gauge[float64]{
+			DataPoints: dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol_ratelimit.tokens")
 	require.NoError(t, err)
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }

--- a/processor/ratelimitprocessor/internal/metadatatest/generated_telemetrytest.go
+++ b/processor/ratelimitprocessor/internal/metadatatest/generated_telemetrytest.go
@@ -118,7 +118,7 @@ func AssertEqualRatelimitRequests(t *testing.T, tt *componenttest.Telemetry, dps
 func AssertEqualRatelimitTokensAfter(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[float64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_ratelimit.tokens_after",
-		Description: "Token bucket level after this request was served. Negative values indicate the bucket is in debt. [Development]",
+		Description: "Token bucket level after this request was served. Negative values indicate the bucket is in debt. Only emitted for throttle_behavior=delay. [Development]",
 		Unit:        "{tokens}",
 		Data: metricdata.Gauge[float64]{
 			DataPoints: dps,
@@ -132,7 +132,7 @@ func AssertEqualRatelimitTokensAfter(t *testing.T, tt *componenttest.Telemetry, 
 func AssertEqualRatelimitTokensBefore(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[float64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_ratelimit.tokens_before",
-		Description: "Token bucket level at the moment a request arrived, before any tokens were consumed. Negative values mean the bucket was already in deficit on arrival (sustained throttling). [Development]",
+		Description: "Token bucket level at the moment a request arrived, before any tokens were consumed. Negative values mean the bucket was already in deficit on arrival (sustained throttling). Only emitted for throttle_behavior=delay. [Development]",
 		Unit:        "{tokens}",
 		Data: metricdata.Gauge[float64]{
 			DataPoints: dps,

--- a/processor/ratelimitprocessor/internal/metadatatest/generated_telemetrytest.go
+++ b/processor/ratelimitprocessor/internal/metadatatest/generated_telemetrytest.go
@@ -115,16 +115,30 @@ func AssertEqualRatelimitRequests(t *testing.T, tt *componenttest.Telemetry, dps
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
-func AssertEqualRatelimitTokens(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[float64], opts ...metricdatatest.Option) {
+func AssertEqualRatelimitTokensAfter(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[float64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
-		Name:        "otelcol_ratelimit.tokens",
-		Description: "Current token level in the rate limiter bucket per key. Negative values indicate active throttling. [Development]",
+		Name:        "otelcol_ratelimit.tokens_after",
+		Description: "Token bucket level after this request was served. Negative values indicate the bucket is in debt. [Development]",
 		Unit:        "{tokens}",
 		Data: metricdata.Gauge[float64]{
 			DataPoints: dps,
 		},
 	}
-	got, err := tt.GetMetric("otelcol_ratelimit.tokens")
+	got, err := tt.GetMetric("otelcol_ratelimit.tokens_after")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}
+
+func AssertEqualRatelimitTokensBefore(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[float64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol_ratelimit.tokens_before",
+		Description: "Token bucket level at the moment a request arrived, before any tokens were consumed. Negative values mean the bucket was already in deficit on arrival (sustained throttling). [Development]",
+		Unit:        "{tokens}",
+		Data: metricdata.Gauge[float64]{
+			DataPoints: dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol_ratelimit.tokens_before")
 	require.NoError(t, err)
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }

--- a/processor/ratelimitprocessor/internal/metadatatest/generated_telemetrytest_test.go
+++ b/processor/ratelimitprocessor/internal/metadatatest/generated_telemetrytest_test.go
@@ -37,11 +37,16 @@ func TestSetupTelemetry(t *testing.T) {
 	require.NoError(t, err)
 	defer tb.Shutdown()
 	tb.RatelimitConcurrentRequests.Add(context.Background(), 1)
+	tb.RatelimitDelayDuration.Record(context.Background(), 1)
 	tb.RatelimitRequestDuration.Record(context.Background(), 1)
 	tb.RatelimitRequestSize.Record(context.Background(), 1)
 	tb.RatelimitRequests.Add(context.Background(), 1)
+	tb.RatelimitTokens.Record(context.Background(), 1)
 	AssertEqualRatelimitConcurrentRequests(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
+		metricdatatest.IgnoreTimestamp())
+	AssertEqualRatelimitDelayDuration(t, testTel,
+		[]metricdata.HistogramDataPoint[float64]{{}}, metricdatatest.IgnoreValue(),
 		metricdatatest.IgnoreTimestamp())
 	AssertEqualRatelimitRequestDuration(t, testTel,
 		[]metricdata.HistogramDataPoint[float64]{{}}, metricdatatest.IgnoreValue(),
@@ -51,6 +56,9 @@ func TestSetupTelemetry(t *testing.T) {
 		metricdatatest.IgnoreTimestamp())
 	AssertEqualRatelimitRequests(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
+		metricdatatest.IgnoreTimestamp())
+	AssertEqualRatelimitTokens(t, testTel,
+		[]metricdata.DataPoint[float64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
 
 	require.NoError(t, testTel.Shutdown(context.Background()))

--- a/processor/ratelimitprocessor/internal/metadatatest/generated_telemetrytest_test.go
+++ b/processor/ratelimitprocessor/internal/metadatatest/generated_telemetrytest_test.go
@@ -41,7 +41,8 @@ func TestSetupTelemetry(t *testing.T) {
 	tb.RatelimitRequestDuration.Record(context.Background(), 1)
 	tb.RatelimitRequestSize.Record(context.Background(), 1)
 	tb.RatelimitRequests.Add(context.Background(), 1)
-	tb.RatelimitTokens.Record(context.Background(), 1)
+	tb.RatelimitTokensAfter.Record(context.Background(), 1)
+	tb.RatelimitTokensBefore.Record(context.Background(), 1)
 	AssertEqualRatelimitConcurrentRequests(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
@@ -57,7 +58,10 @@ func TestSetupTelemetry(t *testing.T) {
 	AssertEqualRatelimitRequests(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
-	AssertEqualRatelimitTokens(t, testTel,
+	AssertEqualRatelimitTokensAfter(t, testTel,
+		[]metricdata.DataPoint[float64]{{Value: 1}},
+		metricdatatest.IgnoreTimestamp())
+	AssertEqualRatelimitTokensBefore(t, testTel,
 		[]metricdata.DataPoint[float64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
 

--- a/processor/ratelimitprocessor/internal/telemetry/attributes.go
+++ b/processor/ratelimitprocessor/internal/telemetry/attributes.go
@@ -31,6 +31,7 @@ const (
 	limitThresholdKey = "limit_threshold"
 
 	StatusUnderLimit Reason = "under_limit"
+	StatusOverLimit  Reason = "over_limit"
 
 	RequestErr Reason = "request_error"
 )

--- a/processor/ratelimitprocessor/local.go
+++ b/processor/ratelimitprocessor/local.go
@@ -77,13 +77,20 @@ func (r *localRateLimiter) RateLimit(ctx context.Context, hits int) (RateLimitRe
 	})
 	state := v.(*keyState)
 
+	// preTokens is the bucket level before this request consumes anything.
+	// PreTokens < 0 means the bucket was already in deficit on arrival —
+	// a reliable signal for genuine sustained throttling (vs. a transient
+	// batching spike that clears before the next request).
+	preTokens := state.limiter.Tokens()
+
 	// makeResult captures the current token level and config for telemetry.
 	makeResult := func(decision Decision, delay time.Duration) RateLimitResult {
 		return RateLimitResult{
-			Decision:   decision,
-			Delay:      delay,
-			Tokens:     state.limiter.Tokens(),
-			ConfigRate: float64(cfg.Rate),
+			Decision:     decision,
+			Delay:        delay,
+			TokensBefore: preTokens,
+			TokensAfter:  state.limiter.Tokens(),
+			ConfigRate:   float64(cfg.Rate),
 		}
 	}
 

--- a/processor/ratelimitprocessor/local.go
+++ b/processor/ratelimitprocessor/local.go
@@ -77,50 +77,45 @@ func (r *localRateLimiter) RateLimit(ctx context.Context, hits int) (RateLimitRe
 	})
 	state := v.(*keyState)
 
-	// preTokens is the bucket level before this request consumes anything.
-	// PreTokens < 0 means the bucket was already in deficit on arrival —
-	// a reliable signal for genuine sustained throttling (vs. a transient
-	// batching spike that clears before the next request).
-	preTokens := state.limiter.Tokens()
-
-	// makeResult captures the current token level and config for telemetry.
-	makeResult := func(decision Decision, delay time.Duration) RateLimitResult {
+	makeResult := func(decision Decision, delay time.Duration, tokensBefore, tokensAfter float64, emitTokenMetrics bool) RateLimitResult {
 		return RateLimitResult{
-			Decision:     decision,
-			Delay:        delay,
-			TokensBefore: preTokens,
-			TokensAfter:  state.limiter.Tokens(),
-			ConfigRate:   float64(cfg.Rate),
+			Decision:         decision,
+			Delay:            delay,
+			TokensBefore:     tokensBefore,
+			TokensAfter:      tokensAfter,
+			ConfigRate:       float64(cfg.Rate),
+			EmitTokenMetrics: emitTokenMetrics,
 		}
 	}
 
 	switch cfg.ThrottleBehavior {
 	case ThrottleBehaviorError:
 		if ok := state.limiter.AllowN(time.Now(), hits); !ok {
-			return makeResult(DecisionThrottled, 0), errorWithDetails(errTooManyRequests, cfg)
+			return makeResult(DecisionThrottled, 0, 0, 0, false), errorWithDetails(errTooManyRequests, cfg)
 		}
-		return makeResult(DecisionAccepted, 0), nil
+		return makeResult(DecisionAccepted, 0, 0, 0, false), nil
 
 	case ThrottleBehaviorDelay:
-		reservations, delay, err := reserveAll(state, hits)
+		reservations, delay, tokensBefore, tokensAfter, err := reserveAll(state, hits)
 		if err != nil {
-			return makeResult(DecisionThrottled, 0), errorWithDetails(err, cfg)
+			return makeResult(DecisionThrottled, 0, tokensBefore, tokensAfter, true), errorWithDetails(err, cfg)
 		}
 		if delay <= 0 {
-			return makeResult(DecisionAccepted, 0), nil
+			return makeResult(DecisionAccepted, 0, tokensBefore, tokensAfter, true), nil
 		}
 		timer := time.NewTimer(delay)
 		defer timer.Stop()
 		select {
 		case <-ctx.Done():
 			cancelReservations(reservations)
-			return makeResult(DecisionCancelled, 0), ctx.Err()
+			// tokensAfter reflects peak debt at reservation time, before cancellation.
+			return makeResult(DecisionCancelled, 0, tokensBefore, tokensAfter, true), ctx.Err()
 		case <-timer.C:
-			return makeResult(DecisionDelayed, delay), nil
+			return makeResult(DecisionDelayed, delay, tokensBefore, tokensAfter, true), nil
 		}
 	}
 
-	return makeResult(DecisionAccepted, 0), nil
+	return makeResult(DecisionAccepted, 0, 0, 0, false), nil
 }
 
 // reserveAll books all chunks for one caller atomically under
@@ -135,15 +130,19 @@ func (r *localRateLimiter) RateLimit(ctx context.Context, hits int) (RateLimitRe
 // never hold more than burst tokens). All chunks are booked at the same
 // timestamp, so the last reservation carries the largest deficit and
 // therefore the cumulative delay for the whole batch.
-func reserveAll(state *keyState, hits int) ([]*rate.Reservation, time.Duration, error) {
+func reserveAll(state *keyState, hits int) ([]*rate.Reservation, time.Duration, float64, float64, error) {
 	// Empty batches (hits <= 0) consume nothing and have no delay.
 	if hits <= 0 {
-		return nil, 0, nil
+		return nil, 0, 0, 0, nil
 	}
 	state.reserveLock.Lock()
 	defer state.reserveLock.Unlock()
 
 	limiter := state.limiter
+	// Both tokensBefore and tokensAfter are captured inside the lock so they are
+	// consistent with each other: no other caller sharing this key can consume
+	// tokens between the two reads or between either read and the ReserveN calls.
+	tokensBefore := limiter.Tokens()
 	burst := limiter.Burst()
 	now := time.Now()
 	reservations := make([]*rate.Reservation, 0, (hits+burst-1)/burst)
@@ -158,12 +157,12 @@ func reserveAll(state *keyState, hits int) ([]*rate.Reservation, time.Duration, 
 			// math.MaxInt64 nanoseconds. Cancel anything we already
 			// booked so we don't leak tokens.
 			cancelReservations(reservations)
-			return nil, 0, errTooManyRequests
+			return nil, 0, tokensBefore, limiter.Tokens(), errTooManyRequests
 		}
 		reservations = append(reservations, lr)
 		remaining -= n
 	}
-	return reservations, reservations[len(reservations)-1].Delay(), nil
+	return reservations, reservations[len(reservations)-1].Delay(), tokensBefore, limiter.Tokens(), nil
 }
 
 // cancelReservations releases tokens reserved by reserveAll. Reservations

--- a/processor/ratelimitprocessor/local.go
+++ b/processor/ratelimitprocessor/local.go
@@ -65,43 +65,55 @@ func (r *localRateLimiter) Shutdown(_ context.Context) error {
 	return nil
 }
 
-func (r *localRateLimiter) RateLimit(ctx context.Context, hits int) error {
-	metadata := client.FromContext(ctx).Metadata
+func (r *localRateLimiter) RateLimit(ctx context.Context, hits int) (RateLimitResult, error) {
+	clientMetadata := client.FromContext(ctx).Metadata
 	// Each (shared) processor gets its own rate limiter,
 	// so it's enough to use client metadata-based unique key.
-	key := getUniqueKey(metadata, r.cfg.MetadataKeys)
-	cfg := resolveRateLimit(r.cfg, metadata)
+	key := getUniqueKey(clientMetadata, r.cfg.MetadataKeys)
+	cfg := resolveRateLimit(r.cfg, clientMetadata)
 
 	v, _ := r.limiters.LoadOrStore(key, &keyState{
 		limiter: rate.NewLimiter(rate.Limit(cfg.Rate), cfg.Burst),
 	})
 	state := v.(*keyState)
-	limiter := state.limiter
+
+	// makeResult captures the current token level and config for telemetry.
+	makeResult := func(decision Decision, delay time.Duration) RateLimitResult {
+		return RateLimitResult{
+			Decision:   decision,
+			Delay:      delay,
+			Tokens:     state.limiter.Tokens(),
+			ConfigRate: float64(cfg.Rate),
+		}
+	}
 
 	switch cfg.ThrottleBehavior {
 	case ThrottleBehaviorError:
-		if ok := limiter.AllowN(time.Now(), hits); !ok {
-			return errorWithDetails(errTooManyRequests, cfg)
+		if ok := state.limiter.AllowN(time.Now(), hits); !ok {
+			return makeResult(DecisionThrottled, 0), errorWithDetails(errTooManyRequests, cfg)
 		}
+		return makeResult(DecisionAccepted, 0), nil
+
 	case ThrottleBehaviorDelay:
 		reservations, delay, err := reserveAll(state, hits)
 		if err != nil {
-			return errorWithDetails(err, cfg)
+			return makeResult(DecisionThrottled, 0), errorWithDetails(err, cfg)
 		}
 		if delay <= 0 {
-			return nil
+			return makeResult(DecisionAccepted, 0), nil
 		}
 		timer := time.NewTimer(delay)
 		defer timer.Stop()
 		select {
 		case <-ctx.Done():
 			cancelReservations(reservations)
-			return ctx.Err()
+			return makeResult(DecisionCancelled, 0), ctx.Err()
 		case <-timer.C:
+			return makeResult(DecisionDelayed, delay), nil
 		}
 	}
 
-	return nil
+	return makeResult(DecisionAccepted, 0), nil
 }
 
 // reserveAll books all chunks for one caller atomically under

--- a/processor/ratelimitprocessor/local_test.go
+++ b/processor/ratelimitprocessor/local_test.go
@@ -77,10 +77,12 @@ func TestLocalRateLimiter_RateLimit(t *testing.T) {
 				assert.Equal(t, DecisionAccepted, result.Decision)
 				assert.Zero(t, result.Delay)
 				assert.Equal(t, float64(10), result.ConfigRate)
+				assert.Greater(t, result.TokensBefore, float64(0))
 			}
 
 			result, err := rateLimiter.RateLimit(context.Background(), 1) // should fail/delay
 			assert.Equal(t, float64(10), result.ConfigRate)
+			assert.GreaterOrEqual(t, result.TokensBefore, float64(0)) // bucket drained to 0, not in debt
 			switch behavior {
 			case ThrottleBehaviorError:
 				assert.EqualError(t, err, "rpc error: code = ResourceExhausted desc = too many requests")
@@ -202,6 +204,7 @@ func TestLocalRateLimiter_HitsExceedsBurst_Delay(t *testing.T) {
 	assert.Equal(t, DecisionDelayed, result.Decision)
 	assert.Greater(t, result.Delay, time.Duration(0))
 	assert.Equal(t, float64(100), result.ConfigRate)
+	assert.Greater(t, result.TokensBefore, float64(0)) // fresh limiter, bucket was full on arrival
 
 	// 100 hits at 100/s with burst=10: ~900ms expected. Allow generous
 	// margins for CI timing jitter.
@@ -227,6 +230,7 @@ func TestLocalRateLimiter_HitsExceedsBurst_Error(t *testing.T) {
 	assert.Equal(t, DecisionThrottled, result.Decision)
 	assert.Zero(t, result.Delay)
 	assert.Equal(t, float64(100), result.ConfigRate)
+	assert.Greater(t, result.TokensBefore, float64(0)) // fresh limiter, bucket was full on arrival
 }
 
 // TestLocalRateLimiter_FIFO_HitsExceedsBurst spawns multiple concurrent

--- a/processor/ratelimitprocessor/local_test.go
+++ b/processor/ratelimitprocessor/local_test.go
@@ -77,12 +77,16 @@ func TestLocalRateLimiter_RateLimit(t *testing.T) {
 				assert.Equal(t, DecisionAccepted, result.Decision)
 				assert.Zero(t, result.Delay)
 				assert.Equal(t, float64(10), result.ConfigRate)
-				assert.Greater(t, result.TokensBefore, float64(0))
+				if behavior == ThrottleBehaviorDelay {
+					assert.Greater(t, result.TokensBefore, float64(0))
+				}
 			}
 
 			result, err := rateLimiter.RateLimit(context.Background(), 1) // should fail/delay
 			assert.Equal(t, float64(10), result.ConfigRate)
-			assert.GreaterOrEqual(t, result.TokensBefore, float64(0)) // bucket drained to 0, not in debt
+			if behavior == ThrottleBehaviorDelay {
+				assert.GreaterOrEqual(t, result.TokensBefore, float64(0)) // bucket drained to 0, not in debt
+			}
 			switch behavior {
 			case ThrottleBehaviorError:
 				assert.EqualError(t, err, "rpc error: code = ResourceExhausted desc = too many requests")
@@ -230,7 +234,6 @@ func TestLocalRateLimiter_HitsExceedsBurst_Error(t *testing.T) {
 	assert.Equal(t, DecisionThrottled, result.Decision)
 	assert.Zero(t, result.Delay)
 	assert.Equal(t, float64(100), result.ConfigRate)
-	assert.Greater(t, result.TokensBefore, float64(0)) // fresh limiter, bucket was full on arrival
 }
 
 // TestLocalRateLimiter_FIFO_HitsExceedsBurst spawns multiple concurrent

--- a/processor/ratelimitprocessor/local_test.go
+++ b/processor/ratelimitprocessor/local_test.go
@@ -72,20 +72,25 @@ func TestLocalRateLimiter_RateLimit(t *testing.T) {
 			startTime := time.Now()
 
 			for i := 0; i < burst; i++ {
-				err = rateLimiter.RateLimit(context.Background(), 1) // should pass
+				result, err := rateLimiter.RateLimit(context.Background(), 1) // should pass
 				assert.NoError(t, err)
+				assert.Equal(t, DecisionAccepted, result.Decision)
 			}
 
-			err = rateLimiter.RateLimit(context.Background(), 1) // should fail
+			result, err := rateLimiter.RateLimit(context.Background(), 1) // should fail/delay
 			switch behavior {
 			case ThrottleBehaviorError:
 				assert.EqualError(t, err, "rpc error: code = ResourceExhausted desc = too many requests")
+				assert.Equal(t, DecisionThrottled, result.Decision)
 				// retry every 20ms to ensure that RateLimit will recover from error when bucket refills after 1 second
 				assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-					assert.NoError(collect, rateLimiter.RateLimit(context.Background(), 1))
+					r, e := rateLimiter.RateLimit(context.Background(), 1)
+					assert.NoError(collect, e)
+					assert.Equal(collect, DecisionAccepted, r.Decision)
 				}, 2*time.Second, 20*time.Millisecond)
 			case ThrottleBehaviorDelay:
 				assert.NoError(t, err)
+				assert.Equal(t, DecisionDelayed, result.Decision)
 				assert.GreaterOrEqual(t, time.Now(), startTime.Add(100*time.Millisecond))
 			}
 		})
@@ -118,9 +123,9 @@ func TestLocalRateLimiter_RateLimit_MetadataKeys(t *testing.T) {
 
 	// Each unique combination of metadata keys should get its own rate limit.
 	for i := 0; i < burst; i++ {
-		err = rateLimiter.RateLimit(clientContext1, 1) // should pass
+		_, err = rateLimiter.RateLimit(clientContext1, 1) // should pass
 		assert.NoError(t, err)
-		err = rateLimiter.RateLimit(clientContext2, 1) // should pass
+		_, err = rateLimiter.RateLimit(clientContext2, 1) // should pass
 		assert.NoError(t, err)
 	}
 }
@@ -140,7 +145,7 @@ func TestLocalRateLimiter_ZeroHits(t *testing.T) {
 				},
 			})
 			start := time.Now()
-			err := rl.RateLimit(context.Background(), 0)
+			_, err := rl.RateLimit(context.Background(), 0)
 			require.NoError(t, err)
 			assert.Less(t, time.Since(start), 50*time.Millisecond,
 				"hits=0 should return immediately without waiting")
@@ -148,11 +153,11 @@ func TestLocalRateLimiter_ZeroHits(t *testing.T) {
 			// A hits=0 call must not consume tokens. Drain the bucket
 			// and verify the limit still kicks in at the same threshold.
 			for i := 0; i < 10; i++ {
-				_ = rl.RateLimit(context.Background(), 1)
+				_, _ = rl.RateLimit(context.Background(), 1)
 			}
 			// 11th call: error mode should reject; delay mode should wait.
 			start = time.Now()
-			err = rl.RateLimit(context.Background(), 1)
+			_, err = rl.RateLimit(context.Background(), 1)
 			switch behavior {
 			case ThrottleBehaviorError:
 				assert.Error(t, err)
@@ -178,7 +183,7 @@ func TestLocalRateLimiter_HitsExceedsBurst_Delay(t *testing.T) {
 	})
 
 	start := time.Now()
-	err := rl.RateLimit(context.Background(), 100)
+	_, err := rl.RateLimit(context.Background(), 100)
 	require.NoError(t, err)
 	elapsed := time.Since(start)
 
@@ -201,7 +206,7 @@ func TestLocalRateLimiter_HitsExceedsBurst_Error(t *testing.T) {
 			RetryDelay:       100 * time.Millisecond,
 		},
 	})
-	err := rl.RateLimit(context.Background(), 100)
+	_, err := rl.RateLimit(context.Background(), 100)
 	assert.EqualError(t, err, "rpc error: code = ResourceExhausted desc = too many requests")
 }
 
@@ -233,7 +238,7 @@ func TestLocalRateLimiter_FIFO_HitsExceedsBurst(t *testing.T) {
 	for i := 0; i < N; i++ {
 		go func(i int) {
 			defer wg.Done()
-			err := rl.RateLimit(context.Background(), 20)
+			_, err := rl.RateLimit(context.Background(), 20)
 			require.NoError(t, err)
 			completions[i] = time.Now()
 		}(i)
@@ -279,11 +284,13 @@ func TestLocalRateLimiter_MixedBatchSizes(t *testing.T) {
 	for i := 0; i < eachKind; i++ {
 		go func() {
 			defer wg.Done()
-			require.NoError(t, rl.RateLimit(context.Background(), smallHits))
+			_, err := rl.RateLimit(context.Background(), smallHits)
+			require.NoError(t, err)
 		}()
 		go func() {
 			defer wg.Done()
-			require.NoError(t, rl.RateLimit(context.Background(), largeHits))
+			_, err := rl.RateLimit(context.Background(), largeHits)
+			require.NoError(t, err)
 		}()
 	}
 	wg.Wait()
@@ -318,7 +325,8 @@ func TestLocalRateLimiter_ContextCancellation_DuringDelay(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- rl.RateLimit(ctx, 30) // would take ~2s
+		_, err := rl.RateLimit(ctx, 30) // would take ~2s
+		errCh <- err
 	}()
 
 	time.Sleep(100 * time.Millisecond)
@@ -331,10 +339,18 @@ func TestLocalRateLimiter_ContextCancellation_DuringDelay(t *testing.T) {
 		t.Fatal("RateLimit did not return after context cancellation")
 	}
 
+	// Verify the Decision field is set correctly on a cancelled request.
+	cancelCtx, cancelFn := context.WithCancel(context.Background())
+	cancelFn() // pre-cancel so the select fires immediately
+	result, err := rl.RateLimit(cancelCtx, 5)
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, DecisionCancelled, result.Decision)
+
 	// A small request after cancellation should succeed quickly because
 	// the cancelled reservation released most of its tokens.
 	start := time.Now()
-	require.NoError(t, rl.RateLimit(context.Background(), 5))
+	_, postErr := rl.RateLimit(context.Background(), 5)
+	require.NoError(t, postErr)
 	elapsed := time.Since(start)
 	assert.Less(t, elapsed, 500*time.Millisecond,
 		"post-cancellation request took %v; cancelled tokens may not have been released", elapsed)
@@ -365,11 +381,13 @@ func TestLocalRateLimiter_PerKeyIsolation_HitsExceedsBurst(t *testing.T) {
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		require.NoError(t, rl.RateLimit(ctx1, 100))
+		_, err := rl.RateLimit(ctx1, 100)
+		require.NoError(t, err)
 	}()
 	go func() {
 		defer wg.Done()
-		require.NoError(t, rl.RateLimit(ctx2, 100))
+		_, err := rl.RateLimit(ctx2, 100)
+		require.NoError(t, err)
 	}()
 	wg.Wait()
 	elapsed := time.Since(start)
@@ -405,7 +423,7 @@ func TestLocalRateLimiter_MultipleRequests_Delay(t *testing.T) {
 	for i := 0; i < requests; i++ {
 		go func(i int) {
 			defer wg.Done()
-			err := rl.RateLimit(context.Background(), 1)
+			_, err := rl.RateLimit(context.Background(), 1)
 			require.NoError(t, err)
 			endingTimes[i] = time.Now()
 		}(i)

--- a/processor/ratelimitprocessor/local_test.go
+++ b/processor/ratelimitprocessor/local_test.go
@@ -75,22 +75,28 @@ func TestLocalRateLimiter_RateLimit(t *testing.T) {
 				result, err := rateLimiter.RateLimit(context.Background(), 1) // should pass
 				assert.NoError(t, err)
 				assert.Equal(t, DecisionAccepted, result.Decision)
+				assert.Zero(t, result.Delay)
+				assert.Equal(t, float64(10), result.ConfigRate)
 			}
 
 			result, err := rateLimiter.RateLimit(context.Background(), 1) // should fail/delay
+			assert.Equal(t, float64(10), result.ConfigRate)
 			switch behavior {
 			case ThrottleBehaviorError:
 				assert.EqualError(t, err, "rpc error: code = ResourceExhausted desc = too many requests")
 				assert.Equal(t, DecisionThrottled, result.Decision)
+				assert.Zero(t, result.Delay)
 				// retry every 20ms to ensure that RateLimit will recover from error when bucket refills after 1 second
 				assert.EventuallyWithT(t, func(collect *assert.CollectT) {
 					r, e := rateLimiter.RateLimit(context.Background(), 1)
 					assert.NoError(collect, e)
 					assert.Equal(collect, DecisionAccepted, r.Decision)
+					assert.Zero(collect, r.Delay)
 				}, 2*time.Second, 20*time.Millisecond)
 			case ThrottleBehaviorDelay:
 				assert.NoError(t, err)
 				assert.Equal(t, DecisionDelayed, result.Decision)
+				assert.Greater(t, result.Delay, time.Duration(0))
 				assert.GreaterOrEqual(t, time.Now(), startTime.Add(100*time.Millisecond))
 			}
 		})
@@ -145,10 +151,12 @@ func TestLocalRateLimiter_ZeroHits(t *testing.T) {
 				},
 			})
 			start := time.Now()
-			_, err := rl.RateLimit(context.Background(), 0)
+			zeroResult, err := rl.RateLimit(context.Background(), 0)
 			require.NoError(t, err)
 			assert.Less(t, time.Since(start), 50*time.Millisecond,
 				"hits=0 should return immediately without waiting")
+			assert.Equal(t, DecisionAccepted, zeroResult.Decision)
+			assert.Zero(t, zeroResult.Delay)
 
 			// A hits=0 call must not consume tokens. Drain the bucket
 			// and verify the limit still kicks in at the same threshold.
@@ -157,12 +165,16 @@ func TestLocalRateLimiter_ZeroHits(t *testing.T) {
 			}
 			// 11th call: error mode should reject; delay mode should wait.
 			start = time.Now()
-			_, err = rl.RateLimit(context.Background(), 1)
+			limitResult, err := rl.RateLimit(context.Background(), 1)
 			switch behavior {
 			case ThrottleBehaviorError:
 				assert.Error(t, err)
+				assert.Equal(t, DecisionThrottled, limitResult.Decision)
+				assert.Zero(t, limitResult.Delay)
 			case ThrottleBehaviorDelay:
 				require.NoError(t, err)
+				assert.Equal(t, DecisionDelayed, limitResult.Decision)
+				assert.Greater(t, limitResult.Delay, time.Duration(0))
 				assert.GreaterOrEqual(t, time.Since(start), 50*time.Millisecond)
 			}
 		})
@@ -183,9 +195,13 @@ func TestLocalRateLimiter_HitsExceedsBurst_Delay(t *testing.T) {
 	})
 
 	start := time.Now()
-	_, err := rl.RateLimit(context.Background(), 100)
+	result, err := rl.RateLimit(context.Background(), 100)
 	require.NoError(t, err)
 	elapsed := time.Since(start)
+
+	assert.Equal(t, DecisionDelayed, result.Decision)
+	assert.Greater(t, result.Delay, time.Duration(0))
+	assert.Equal(t, float64(100), result.ConfigRate)
 
 	// 100 hits at 100/s with burst=10: ~900ms expected. Allow generous
 	// margins for CI timing jitter.
@@ -206,8 +222,11 @@ func TestLocalRateLimiter_HitsExceedsBurst_Error(t *testing.T) {
 			RetryDelay:       100 * time.Millisecond,
 		},
 	})
-	_, err := rl.RateLimit(context.Background(), 100)
+	result, err := rl.RateLimit(context.Background(), 100)
 	assert.EqualError(t, err, "rpc error: code = ResourceExhausted desc = too many requests")
+	assert.Equal(t, DecisionThrottled, result.Decision)
+	assert.Zero(t, result.Delay)
+	assert.Equal(t, float64(100), result.ConfigRate)
 }
 
 // TestLocalRateLimiter_FIFO_HitsExceedsBurst spawns multiple concurrent

--- a/processor/ratelimitprocessor/metadata.yaml
+++ b/processor/ratelimitprocessor/metadata.yaml
@@ -87,9 +87,16 @@ telemetry:
         value_type: int
         monotonic: true
       attributes: ["decision", "reason"]
-    ratelimit.tokens:
+    ratelimit.tokens_after:
       enabled: true
-      description: Current token level in the rate limiter bucket per key. Negative values indicate active throttling.
+      description: Token bucket level after this request was served. Negative values indicate the bucket is in debt.
+      unit: "{tokens}"
+      stability: development
+      gauge:
+        value_type: double
+    ratelimit.tokens_before:
+      enabled: true
+      description: Token bucket level at the moment a request arrived, before any tokens were consumed. Negative values mean the bucket was already in deficit on arrival (sustained throttling).
       unit: "{tokens}"
       stability: development
       gauge:

--- a/processor/ratelimitprocessor/metadata.yaml
+++ b/processor/ratelimitprocessor/metadata.yaml
@@ -21,6 +21,14 @@ telemetry:
       sum:
         value_type: int
         monotonic: false
+    ratelimit.delay_duration:
+      enabled: true
+      description: Time (in seconds) a request spent waiting due to rate limiting. Only recorded when a delay occurs.
+      unit: "{seconds}"
+      stability: development
+      histogram:
+        value_type: double
+        bucket_boundaries: [ 0.0001, 0.0005, 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0, 30.0 ]
     ratelimit.request_duration:
       enabled: true
       description: Time(in seconds) taken to process a rate limit request
@@ -79,6 +87,13 @@ telemetry:
         value_type: int
         monotonic: true
       attributes: ["decision", "reason"]
+    ratelimit.tokens:
+      enabled: true
+      description: Current token level in the rate limiter bucket per key. Negative values indicate active throttling.
+      unit: "{tokens}"
+      stability: development
+      gauge:
+        value_type: double
 attributes:
   decision:
     description: rate limit decision

--- a/processor/ratelimitprocessor/metadata.yaml
+++ b/processor/ratelimitprocessor/metadata.yaml
@@ -89,14 +89,14 @@ telemetry:
       attributes: ["decision", "reason"]
     ratelimit.tokens_after:
       enabled: true
-      description: Token bucket level after this request was served. Negative values indicate the bucket is in debt.
+      description: Token bucket level after this request was served. Negative values indicate the bucket is in debt. Only emitted for throttle_behavior=delay.
       unit: "{tokens}"
       stability: development
       gauge:
         value_type: double
     ratelimit.tokens_before:
       enabled: true
-      description: Token bucket level at the moment a request arrived, before any tokens were consumed. Negative values mean the bucket was already in deficit on arrival (sustained throttling).
+      description: Token bucket level at the moment a request arrived, before any tokens were consumed. Negative values mean the bucket was already in deficit on arrival (sustained throttling). Only emitted for throttle_behavior=delay.
       unit: "{tokens}"
       stability: development
       gauge:

--- a/processor/ratelimitprocessor/processor.go
+++ b/processor/ratelimitprocessor/processor.go
@@ -232,9 +232,11 @@ func withRateLimit[T any](ctx context.Context,
 	if result.Decision == DecisionDelayed {
 		tb.RatelimitDelayDuration.Record(ctx, result.Delay.Seconds(), metric.WithAttributeSet(attrRequestsSet))
 	}
-	tokenAttrs := attribute.NewSet(append(attrsCommon, telemetry.WithLimitThreshold(result.ConfigRate))...)
-	tb.RatelimitTokensAfter.Record(ctx, result.TokensAfter, metric.WithAttributeSet(tokenAttrs))
-	tb.RatelimitTokensBefore.Record(ctx, result.TokensBefore, metric.WithAttributeSet(tokenAttrs))
+	if result.EmitTokenMetrics {
+		tokenAttrs := attribute.NewSet(append(attrsCommon, telemetry.WithLimitThreshold(result.ConfigRate))...)
+		tb.RatelimitTokensAfter.Record(ctx, result.TokensAfter, metric.WithAttributeSet(tokenAttrs))
+		tb.RatelimitTokensBefore.Record(ctx, result.TokensBefore, metric.WithAttributeSet(tokenAttrs))
+	}
 
 	if err != nil {
 		if result.Decision != DecisionCancelled {

--- a/processor/ratelimitprocessor/processor.go
+++ b/processor/ratelimitprocessor/processor.go
@@ -31,8 +31,6 @@ import (
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 
 	"github.com/elastic/opentelemetry-collector-components/internal/sharedcomponent"
 	"github.com/elastic/opentelemetry-collector-components/processor/ratelimitprocessor/internal/metadata"
@@ -185,30 +183,30 @@ func (r *ProfilesRateLimiterProcessor) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }
 
-func getTelemetryAttrs(attrsCommon []attribute.KeyValue, err error) (attrs []attribute.KeyValue) {
-	switch {
-	case err == nil:
-		attrs = append(attrsCommon,
+func getTelemetryAttrs(attrsCommon []attribute.KeyValue, result RateLimitResult, err error) []attribute.KeyValue {
+	switch result.Decision {
+	case DecisionDelayed, DecisionThrottled, DecisionCancelled:
+		return append(attrsCommon,
+			telemetry.WithDecision(string(result.Decision)),
+			telemetry.WithReason(telemetry.StatusOverLimit),
+		)
+	default: // DecisionAccepted
+		if err != nil {
+			return append(attrsCommon,
+				telemetry.WithDecision(string(DecisionAccepted)),
+				telemetry.WithReason(telemetry.RequestErr),
+			)
+		}
+		return append(attrsCommon,
+			telemetry.WithDecision(string(DecisionAccepted)),
 			telemetry.WithReason(telemetry.StatusUnderLimit),
-			telemetry.WithDecision("accepted"),
-		)
-	case status.Code(err) == codes.ResourceExhausted:
-		attrs = append(attrsCommon,
-			telemetry.WithDecision("throttled"),
-		)
-	default:
-		attrs = append(attrsCommon,
-			telemetry.WithReason(telemetry.RequestErr),
-			telemetry.WithDecision("accepted"),
 		)
 	}
-
-	return attrs
 }
 
 func withRateLimit[T any](ctx context.Context,
 	hits int,
-	rateLimit func(ctx context.Context, n int) error,
+	rateLimit func(ctx context.Context, n int) (RateLimitResult, error),
 	metadataKeys []string,
 	tb *metadata.TelemetryBuilder,
 	logger *zap.Logger,
@@ -221,32 +219,39 @@ func withRateLimit[T any](ctx context.Context,
 	defer tb.RatelimitConcurrentRequests.Add(ctx, -1, metric.WithAttributeSet(attrsSet))
 
 	start := time.Now()
-	err := rateLimit(ctx, hits)
+	result, err := rateLimit(ctx, hits)
 	tb.RatelimitRequestDuration.Record(ctx,
 		time.Since(start).Seconds(),
 		metric.WithAttributeSet(attrsSet),
 	)
 
-	attrRequests := getTelemetryAttrs(attrsCommon, err)
+	attrRequests := getTelemetryAttrs(attrsCommon, result, err)
 	attrRequestsSet := attribute.NewSet(attrRequests...)
 	tb.RatelimitRequestSize.Record(ctx, int64(hits), metric.WithAttributeSet(attrRequestsSet))
 	tb.RatelimitRequests.Add(ctx, 1, metric.WithAttributeSet(attrRequestsSet))
+	if result.Decision == DecisionDelayed {
+		tb.RatelimitDelayDuration.Record(ctx, result.Delay.Seconds(), metric.WithAttributeSet(attrRequestsSet))
+	}
+	tokenAttrs := attribute.NewSet(append(attrsCommon, telemetry.WithLimitThreshold(result.ConfigRate))...)
+	tb.RatelimitTokens.Record(ctx, result.Tokens, metric.WithAttributeSet(tokenAttrs))
 	if err != nil {
-		// enhance error logging with metadata keys
-		fields := make([]zap.Field, 0, len(attrsCommon)+1)
-		fields = append(fields, zap.Int("hits", hits))
-		for _, kv := range attrsCommon {
-			switch kv.Value.Type() {
-			case attribute.STRINGSLICE:
-				fields = append(fields, zap.Strings(string(kv.Key), kv.Value.AsStringSlice()))
-			default:
-				fields = append(fields, zap.String(string(kv.Key), kv.Value.AsString()))
+		if result.Decision != DecisionCancelled {
+			// enhance error logging with metadata keys
+			fields := make([]zap.Field, 0, len(attrsCommon)+1)
+			fields = append(fields, zap.Int("hits", hits))
+			for _, kv := range attrsCommon {
+				switch kv.Value.Type() {
+				case attribute.STRINGSLICE:
+					fields = append(fields, zap.Strings(string(kv.Key), kv.Value.AsStringSlice()))
+				default:
+					fields = append(fields, zap.String(string(kv.Key), kv.Value.AsString()))
+				}
 			}
+			logger.Error(
+				"request is over the limits defined by the rate limiter",
+				append(fields, zap.Error(err))...,
+			)
 		}
-		logger.Error(
-			"request is over the limits defined by the rate limiter",
-			append(fields, zap.Error(err))...,
-		)
 		return err
 	}
 	return next(ctx, data)

--- a/processor/ratelimitprocessor/processor.go
+++ b/processor/ratelimitprocessor/processor.go
@@ -233,7 +233,9 @@ func withRateLimit[T any](ctx context.Context,
 		tb.RatelimitDelayDuration.Record(ctx, result.Delay.Seconds(), metric.WithAttributeSet(attrRequestsSet))
 	}
 	tokenAttrs := attribute.NewSet(append(attrsCommon, telemetry.WithLimitThreshold(result.ConfigRate))...)
-	tb.RatelimitTokens.Record(ctx, result.Tokens, metric.WithAttributeSet(tokenAttrs))
+	tb.RatelimitTokensAfter.Record(ctx, result.TokensAfter, metric.WithAttributeSet(tokenAttrs))
+	tb.RatelimitTokensBefore.Record(ctx, result.TokensBefore, metric.WithAttributeSet(tokenAttrs))
+
 	if err != nil {
 		if result.Decision != DecisionCancelled {
 			// enhance error logging with metadata keys

--- a/processor/ratelimitprocessor/processor_test.go
+++ b/processor/ratelimitprocessor/processor_test.go
@@ -197,6 +197,7 @@ func TestConsume_Logs(t *testing.T) {
 			Sum:   1,
 			Attributes: attribute.NewSet(
 				telemetry.WithDecision("throttled"),
+				telemetry.WithReason(telemetry.StatusOverLimit),
 				attribute.String("x-tenant-id", "TestProjectID"),
 			),
 		},
@@ -272,6 +273,7 @@ func TestConsume_Metrics(t *testing.T) {
 			Sum:   1,
 			Attributes: attribute.NewSet(
 				telemetry.WithDecision("throttled"),
+				telemetry.WithReason(telemetry.StatusOverLimit),
 				attribute.String("x-tenant-id", "TestProjectID"),
 			),
 		},
@@ -347,6 +349,7 @@ func TestConsume_Traces(t *testing.T) {
 			Sum:   1,
 			Attributes: attribute.NewSet(
 				telemetry.WithDecision("throttled"),
+				telemetry.WithReason(telemetry.StatusOverLimit),
 				attribute.String("x-tenant-id", "TestProjectID"),
 			),
 		},
@@ -423,6 +426,7 @@ func TestConsume_Profiles(t *testing.T) {
 			Sum:   1,
 			Attributes: attribute.NewSet(
 				telemetry.WithDecision("throttled"),
+				telemetry.WithReason(telemetry.StatusOverLimit),
 				attribute.String("x-tenant-id", "TestProjectID"),
 			),
 		},
@@ -533,6 +537,7 @@ func testRateLimitTelemetry(t *testing.T, tel *componenttest.Telemetry) {
 			Attributes: attribute.NewSet(
 				[]attribute.KeyValue{
 					telemetry.WithDecision("throttled"),
+					telemetry.WithReason(telemetry.StatusOverLimit),
 					attribute.String("x-tenant-id", "TestProjectID"),
 				}...),
 		},
@@ -550,6 +555,15 @@ func testRateLimitTelemetry(t *testing.T, tel *componenttest.Telemetry) {
 			Value: 1,
 			Attributes: attribute.NewSet(
 				attribute.String("x-tenant-id", "TestProjectID"),
+			),
+		},
+	}, metricdatatest.IgnoreValue(), metricdatatest.IgnoreTimestamp())
+
+	metadatatest.AssertEqualRatelimitTokens(t, tel, []metricdata.DataPoint[float64]{
+		{
+			Attributes: attribute.NewSet(
+				attribute.String("x-tenant-id", "TestProjectID"),
+				telemetry.WithLimitThreshold(1),
 			),
 		},
 	}, metricdatatest.IgnoreValue(), metricdatatest.IgnoreTimestamp())
@@ -572,6 +586,147 @@ func testRatelimitLogMetadata(t *testing.T, logEntries []observer.LoggedEntry) {
 
 	assert.Equal(t, "TestProjectID", fields["x-tenant-id"])
 	assert.Equal(t, int64(1), fields["hits"])
+}
+
+func TestConsume_Logs_DelayMode(t *testing.T) {
+	// Rate=10/Burst=1: the second request waits ~100ms, which is far above any
+	// inter-statement timing jitter under -race.
+	rateLimiter := newTestLocalRateLimiter(t, &Config{
+		RateLimitSettings: RateLimitSettings{
+			Rate:             10,
+			Burst:            1,
+			ThrottleBehavior: ThrottleBehaviorDelay,
+			RetryDelay:       1 * time.Second,
+			ThrottleInterval: 1 * time.Second,
+		},
+	})
+	err := rateLimiter.Start(context.Background(), componenttest.NewNopHost())
+	require.NoError(t, err)
+
+	tt := componenttest.NewTelemetry()
+	telemetryBuilder, err := metadata.NewTelemetryBuilder(tt.NewTelemetrySettings())
+	require.NoError(t, err)
+
+	rl := rateLimiterProcessor{
+		rl:               rateLimiter,
+		telemetryBuilder: telemetryBuilder,
+		logger:           zap.NewNop(),
+		metadataKeys:     []string{"x-tenant-id"},
+		strategy:         StrategyRateLimitRequests,
+	}
+	p := &LogsRateLimiterProcessor{
+		rateLimiterProcessor: rl,
+		count:                func(plog.Logs) int { return 1 },
+		next:                 func(context.Context, plog.Logs) error { return nil },
+	}
+
+	logs := plog.NewLogs()
+
+	// First request: within burst, no delay → decision=accepted
+	require.NoError(t, p.ConsumeLogs(clientContext, logs))
+
+	// Second request: burst exhausted → delayed, no error returned
+	require.NoError(t, p.ConsumeLogs(clientContext, logs))
+
+	metadatatest.AssertEqualRatelimitRequests(t, tt, []metricdata.DataPoint[int64]{
+		{
+			Value: 1,
+			Attributes: attribute.NewSet(
+				telemetry.WithDecision("accepted"),
+				telemetry.WithReason(telemetry.StatusUnderLimit),
+				attribute.String("x-tenant-id", "TestProjectID"),
+			),
+		},
+		{
+			Value: 1,
+			Attributes: attribute.NewSet(
+				telemetry.WithDecision("delayed"),
+				telemetry.WithReason(telemetry.StatusOverLimit),
+				attribute.String("x-tenant-id", "TestProjectID"),
+			),
+		},
+	}, metricdatatest.IgnoreTimestamp())
+
+	metadatatest.AssertEqualRatelimitDelayDuration(t, tt, []metricdata.HistogramDataPoint[float64]{
+		{
+			Attributes: attribute.NewSet(
+				telemetry.WithDecision("delayed"),
+				telemetry.WithReason(telemetry.StatusOverLimit),
+				attribute.String("x-tenant-id", "TestProjectID"),
+			),
+		},
+	}, metricdatatest.IgnoreValue(), metricdatatest.IgnoreTimestamp())
+
+	metadatatest.AssertEqualRatelimitTokens(t, tt, []metricdata.DataPoint[float64]{
+		{
+			Attributes: attribute.NewSet(
+				attribute.String("x-tenant-id", "TestProjectID"),
+				telemetry.WithLimitThreshold(10),
+			),
+		},
+	}, metricdatatest.IgnoreValue(), metricdatatest.IgnoreTimestamp())
+}
+
+func TestConsume_Logs_CancelledMode(t *testing.T) {
+	// Rate=1/Burst=1: second request requires a ~1s wait, long enough to cancel reliably.
+	rateLimiter := newTestLocalRateLimiter(t, &Config{
+		RateLimitSettings: RateLimitSettings{
+			Rate:             1,
+			Burst:            1,
+			ThrottleBehavior: ThrottleBehaviorDelay,
+			RetryDelay:       1 * time.Second,
+			ThrottleInterval: 1 * time.Second,
+		},
+	})
+	err := rateLimiter.Start(context.Background(), componenttest.NewNopHost())
+	require.NoError(t, err)
+
+	tt := componenttest.NewTelemetry()
+	telemetryBuilder, err := metadata.NewTelemetryBuilder(tt.NewTelemetrySettings())
+	require.NoError(t, err)
+
+	rl := rateLimiterProcessor{
+		rl:               rateLimiter,
+		telemetryBuilder: telemetryBuilder,
+		logger:           zap.NewNop(),
+		metadataKeys:     []string{"x-tenant-id"},
+		strategy:         StrategyRateLimitRequests,
+	}
+	p := &LogsRateLimiterProcessor{
+		rateLimiterProcessor: rl,
+		count:                func(plog.Logs) int { return 1 },
+		next:                 func(context.Context, plog.Logs) error { return nil },
+	}
+
+	logs := plog.NewLogs()
+
+	// First request: within burst, no delay.
+	require.NoError(t, p.ConsumeLogs(clientContext, logs))
+
+	// Second request: burst exhausted, would wait ~1s. Cancel the context immediately.
+	ctx, cancel := context.WithCancel(clientContext)
+	cancel()
+	err = p.ConsumeLogs(ctx, logs)
+	require.ErrorIs(t, err, context.Canceled)
+
+	metadatatest.AssertEqualRatelimitRequests(t, tt, []metricdata.DataPoint[int64]{
+		{
+			Value: 1,
+			Attributes: attribute.NewSet(
+				telemetry.WithDecision("accepted"),
+				telemetry.WithReason(telemetry.StatusUnderLimit),
+				attribute.String("x-tenant-id", "TestProjectID"),
+			),
+		},
+		{
+			Value: 1,
+			Attributes: attribute.NewSet(
+				telemetry.WithDecision("cancelled"),
+				telemetry.WithReason(telemetry.StatusOverLimit),
+				attribute.String("x-tenant-id", "TestProjectID"),
+			),
+		},
+	}, metricdatatest.IgnoreTimestamp())
 }
 
 func testError(t *testing.T, err error) {

--- a/processor/ratelimitprocessor/processor_test.go
+++ b/processor/ratelimitprocessor/processor_test.go
@@ -613,7 +613,16 @@ func testRateLimitTelemetry(t *testing.T, tel *componenttest.Telemetry) {
 		},
 	}, metricdatatest.IgnoreValue(), metricdatatest.IgnoreTimestamp())
 
-	metadatatest.AssertEqualRatelimitTokens(t, tel, []metricdata.DataPoint[float64]{
+	metadatatest.AssertEqualRatelimitTokensAfter(t, tel, []metricdata.DataPoint[float64]{
+		{
+			Attributes: attribute.NewSet(
+				attribute.String("x-tenant-id", "TestProjectID"),
+				telemetry.WithLimitThreshold(1),
+			),
+		},
+	}, metricdatatest.IgnoreValue(), metricdatatest.IgnoreTimestamp())
+
+	metadatatest.AssertEqualRatelimitTokensBefore(t, tel, []metricdata.DataPoint[float64]{
 		{
 			Attributes: attribute.NewSet(
 				attribute.String("x-tenant-id", "TestProjectID"),
@@ -706,7 +715,16 @@ func TestConsume_DelayMode(t *testing.T) {
 				},
 			}, metricdatatest.IgnoreValue(), metricdatatest.IgnoreTimestamp())
 
-			metadatatest.AssertEqualRatelimitTokens(t, tt, []metricdata.DataPoint[float64]{
+			metadatatest.AssertEqualRatelimitTokensAfter(t, tt, []metricdata.DataPoint[float64]{
+				{
+					Attributes: attribute.NewSet(
+						attribute.String("x-tenant-id", "TestProjectID"),
+						telemetry.WithLimitThreshold(10),
+					),
+				},
+			}, metricdatatest.IgnoreValue(), metricdatatest.IgnoreTimestamp())
+
+			metadatatest.AssertEqualRatelimitTokensBefore(t, tt, []metricdata.DataPoint[float64]{
 				{
 					Attributes: attribute.NewSet(
 						attribute.String("x-tenant-id", "TestProjectID"),
@@ -775,6 +793,15 @@ func TestConsume_DelayMode_ContextCancelled(t *testing.T) {
 					),
 				},
 			}, metricdatatest.IgnoreTimestamp())
+
+			metadatatest.AssertEqualRatelimitTokensBefore(t, tt, []metricdata.DataPoint[float64]{
+				{
+					Attributes: attribute.NewSet(
+						attribute.String("x-tenant-id", "TestProjectID"),
+						telemetry.WithLimitThreshold(1),
+					),
+				},
+			}, metricdatatest.IgnoreValue(), metricdatatest.IgnoreTimestamp())
 		})
 	}
 }

--- a/processor/ratelimitprocessor/processor_test.go
+++ b/processor/ratelimitprocessor/processor_test.go
@@ -613,23 +613,6 @@ func testRateLimitTelemetry(t *testing.T, tel *componenttest.Telemetry) {
 		},
 	}, metricdatatest.IgnoreValue(), metricdatatest.IgnoreTimestamp())
 
-	metadatatest.AssertEqualRatelimitTokensAfter(t, tel, []metricdata.DataPoint[float64]{
-		{
-			Attributes: attribute.NewSet(
-				attribute.String("x-tenant-id", "TestProjectID"),
-				telemetry.WithLimitThreshold(1),
-			),
-		},
-	}, metricdatatest.IgnoreValue(), metricdatatest.IgnoreTimestamp())
-
-	metadatatest.AssertEqualRatelimitTokensBefore(t, tel, []metricdata.DataPoint[float64]{
-		{
-			Attributes: attribute.NewSet(
-				attribute.String("x-tenant-id", "TestProjectID"),
-				telemetry.WithLimitThreshold(1),
-			),
-		},
-	}, metricdatatest.IgnoreValue(), metricdatatest.IgnoreTimestamp())
 }
 
 func testRatelimitLogMetadata(t *testing.T, logEntries []observer.LoggedEntry) {
@@ -793,6 +776,15 @@ func TestConsume_DelayMode_ContextCancelled(t *testing.T) {
 					),
 				},
 			}, metricdatatest.IgnoreTimestamp())
+
+			metadatatest.AssertEqualRatelimitTokensAfter(t, tt, []metricdata.DataPoint[float64]{
+				{
+					Attributes: attribute.NewSet(
+						attribute.String("x-tenant-id", "TestProjectID"),
+						telemetry.WithLimitThreshold(1),
+					),
+				},
+			}, metricdatatest.IgnoreValue(), metricdatatest.IgnoreTimestamp())
 
 			metadatatest.AssertEqualRatelimitTokensBefore(t, tt, []metricdata.DataPoint[float64]{
 				{

--- a/processor/ratelimitprocessor/processor_test.go
+++ b/processor/ratelimitprocessor/processor_test.go
@@ -55,6 +55,60 @@ var (
 	})
 )
 
+// signalCase abstracts the signal-type differences (pdata type, count func, Consume method)
+// so delay-mode tests can range over all four signal types without duplication.
+type signalCase struct {
+	name        string
+	newConsumer func(rl rateLimiterProcessor) func(ctx context.Context) error
+}
+
+var signalCases = []signalCase{
+	{
+		name: "logs",
+		newConsumer: func(rl rateLimiterProcessor) func(ctx context.Context) error {
+			p := &LogsRateLimiterProcessor{
+				rateLimiterProcessor: rl,
+				count:                func(plog.Logs) int { return 1 },
+				next:                 func(context.Context, plog.Logs) error { return nil },
+			}
+			return func(ctx context.Context) error { return p.ConsumeLogs(ctx, plog.NewLogs()) }
+		},
+	},
+	{
+		name: "metrics",
+		newConsumer: func(rl rateLimiterProcessor) func(ctx context.Context) error {
+			p := &MetricsRateLimiterProcessor{
+				rateLimiterProcessor: rl,
+				count:                func(pmetric.Metrics) int { return 1 },
+				next:                 func(context.Context, pmetric.Metrics) error { return nil },
+			}
+			return func(ctx context.Context) error { return p.ConsumeMetrics(ctx, pmetric.NewMetrics()) }
+		},
+	},
+	{
+		name: "traces",
+		newConsumer: func(rl rateLimiterProcessor) func(ctx context.Context) error {
+			p := &TracesRateLimiterProcessor{
+				rateLimiterProcessor: rl,
+				count:                func(ptrace.Traces) int { return 1 },
+				next:                 func(context.Context, ptrace.Traces) error { return nil },
+			}
+			return func(ctx context.Context) error { return p.ConsumeTraces(ctx, ptrace.NewTraces()) }
+		},
+	},
+	{
+		name: "profiles",
+		newConsumer: func(rl rateLimiterProcessor) func(ctx context.Context) error {
+			p := &ProfilesRateLimiterProcessor{
+				rateLimiterProcessor: rl,
+				count:                func(pprofile.Profiles) int { return 1 },
+				next:                 func(context.Context, pprofile.Profiles) error { return nil },
+			}
+			return func(ctx context.Context) error { return p.ConsumeProfiles(ctx, pprofile.NewProfiles()) }
+		},
+	},
+}
+
 func TestGetCountFunc_Logs(t *testing.T) {
 	logs := plog.NewLogs()
 	resourceLogs := logs.ResourceLogs().AppendEmpty()
@@ -588,145 +642,141 @@ func testRatelimitLogMetadata(t *testing.T, logEntries []observer.LoggedEntry) {
 	assert.Equal(t, int64(1), fields["hits"])
 }
 
-func TestConsume_Logs_DelayMode(t *testing.T) {
-	// Rate=10/Burst=1: the second request waits ~100ms, which is far above any
-	// inter-statement timing jitter under -race.
-	rateLimiter := newTestLocalRateLimiter(t, &Config{
-		RateLimitSettings: RateLimitSettings{
-			Rate:             10,
-			Burst:            1,
-			ThrottleBehavior: ThrottleBehaviorDelay,
-			RetryDelay:       1 * time.Second,
-			ThrottleInterval: 1 * time.Second,
-		},
-	})
-	err := rateLimiter.Start(context.Background(), componenttest.NewNopHost())
-	require.NoError(t, err)
+func TestConsume_DelayMode(t *testing.T) {
+	for _, sig := range signalCases {
+		t.Run(sig.name, func(t *testing.T) {
+			// Rate=10/Burst=1: the second request waits ~100ms, which is far above any
+			// inter-statement timing jitter under -race.
+			rateLimiter := newTestLocalRateLimiter(t, &Config{
+				RateLimitSettings: RateLimitSettings{
+					Rate:             10,
+					Burst:            1,
+					ThrottleBehavior: ThrottleBehaviorDelay,
+					RetryDelay:       1 * time.Second,
+					ThrottleInterval: 1 * time.Second,
+				},
+			})
+			err := rateLimiter.Start(context.Background(), componenttest.NewNopHost())
+			require.NoError(t, err)
 
-	tt := componenttest.NewTelemetry()
-	telemetryBuilder, err := metadata.NewTelemetryBuilder(tt.NewTelemetrySettings())
-	require.NoError(t, err)
+			tt := componenttest.NewTelemetry()
+			telemetryBuilder, err := metadata.NewTelemetryBuilder(tt.NewTelemetrySettings())
+			require.NoError(t, err)
 
-	rl := rateLimiterProcessor{
-		rl:               rateLimiter,
-		telemetryBuilder: telemetryBuilder,
-		logger:           zap.NewNop(),
-		metadataKeys:     []string{"x-tenant-id"},
-		strategy:         StrategyRateLimitRequests,
+			consume := sig.newConsumer(rateLimiterProcessor{
+				rl:               rateLimiter,
+				telemetryBuilder: telemetryBuilder,
+				logger:           zap.NewNop(),
+				metadataKeys:     []string{"x-tenant-id"},
+				strategy:         StrategyRateLimitRequests,
+			})
+
+			// First request: within burst, no delay → decision=accepted
+			require.NoError(t, consume(clientContext))
+
+			// Second request: burst exhausted → delayed, no error returned
+			require.NoError(t, consume(clientContext))
+
+			metadatatest.AssertEqualRatelimitRequests(t, tt, []metricdata.DataPoint[int64]{
+				{
+					Value: 1,
+					Attributes: attribute.NewSet(
+						telemetry.WithDecision("accepted"),
+						telemetry.WithReason(telemetry.StatusUnderLimit),
+						attribute.String("x-tenant-id", "TestProjectID"),
+					),
+				},
+				{
+					Value: 1,
+					Attributes: attribute.NewSet(
+						telemetry.WithDecision("delayed"),
+						telemetry.WithReason(telemetry.StatusOverLimit),
+						attribute.String("x-tenant-id", "TestProjectID"),
+					),
+				},
+			}, metricdatatest.IgnoreTimestamp())
+
+			metadatatest.AssertEqualRatelimitDelayDuration(t, tt, []metricdata.HistogramDataPoint[float64]{
+				{
+					Attributes: attribute.NewSet(
+						telemetry.WithDecision("delayed"),
+						telemetry.WithReason(telemetry.StatusOverLimit),
+						attribute.String("x-tenant-id", "TestProjectID"),
+					),
+				},
+			}, metricdatatest.IgnoreValue(), metricdatatest.IgnoreTimestamp())
+
+			metadatatest.AssertEqualRatelimitTokens(t, tt, []metricdata.DataPoint[float64]{
+				{
+					Attributes: attribute.NewSet(
+						attribute.String("x-tenant-id", "TestProjectID"),
+						telemetry.WithLimitThreshold(10),
+					),
+				},
+			}, metricdatatest.IgnoreValue(), metricdatatest.IgnoreTimestamp())
+		})
 	}
-	p := &LogsRateLimiterProcessor{
-		rateLimiterProcessor: rl,
-		count:                func(plog.Logs) int { return 1 },
-		next:                 func(context.Context, plog.Logs) error { return nil },
-	}
-
-	logs := plog.NewLogs()
-
-	// First request: within burst, no delay → decision=accepted
-	require.NoError(t, p.ConsumeLogs(clientContext, logs))
-
-	// Second request: burst exhausted → delayed, no error returned
-	require.NoError(t, p.ConsumeLogs(clientContext, logs))
-
-	metadatatest.AssertEqualRatelimitRequests(t, tt, []metricdata.DataPoint[int64]{
-		{
-			Value: 1,
-			Attributes: attribute.NewSet(
-				telemetry.WithDecision("accepted"),
-				telemetry.WithReason(telemetry.StatusUnderLimit),
-				attribute.String("x-tenant-id", "TestProjectID"),
-			),
-		},
-		{
-			Value: 1,
-			Attributes: attribute.NewSet(
-				telemetry.WithDecision("delayed"),
-				telemetry.WithReason(telemetry.StatusOverLimit),
-				attribute.String("x-tenant-id", "TestProjectID"),
-			),
-		},
-	}, metricdatatest.IgnoreTimestamp())
-
-	metadatatest.AssertEqualRatelimitDelayDuration(t, tt, []metricdata.HistogramDataPoint[float64]{
-		{
-			Attributes: attribute.NewSet(
-				telemetry.WithDecision("delayed"),
-				telemetry.WithReason(telemetry.StatusOverLimit),
-				attribute.String("x-tenant-id", "TestProjectID"),
-			),
-		},
-	}, metricdatatest.IgnoreValue(), metricdatatest.IgnoreTimestamp())
-
-	metadatatest.AssertEqualRatelimitTokens(t, tt, []metricdata.DataPoint[float64]{
-		{
-			Attributes: attribute.NewSet(
-				attribute.String("x-tenant-id", "TestProjectID"),
-				telemetry.WithLimitThreshold(10),
-			),
-		},
-	}, metricdatatest.IgnoreValue(), metricdatatest.IgnoreTimestamp())
 }
 
-func TestConsume_Logs_CancelledMode(t *testing.T) {
-	// Rate=1/Burst=1: second request requires a ~1s wait, long enough to cancel reliably.
-	rateLimiter := newTestLocalRateLimiter(t, &Config{
-		RateLimitSettings: RateLimitSettings{
-			Rate:             1,
-			Burst:            1,
-			ThrottleBehavior: ThrottleBehaviorDelay,
-			RetryDelay:       1 * time.Second,
-			ThrottleInterval: 1 * time.Second,
-		},
-	})
-	err := rateLimiter.Start(context.Background(), componenttest.NewNopHost())
-	require.NoError(t, err)
+func TestConsume_DelayMode_ContextCancelled(t *testing.T) {
+	for _, sig := range signalCases {
+		t.Run(sig.name, func(t *testing.T) {
+			// Rate=1/Burst=1: second request requires a ~1s wait. The context is
+			// pre-cancelled so the select in local.go fires immediately — no actual sleep.
+			rateLimiter := newTestLocalRateLimiter(t, &Config{
+				RateLimitSettings: RateLimitSettings{
+					Rate:             1,
+					Burst:            1,
+					ThrottleBehavior: ThrottleBehaviorDelay,
+					RetryDelay:       1 * time.Second,
+					ThrottleInterval: 1 * time.Second,
+				},
+			})
+			err := rateLimiter.Start(context.Background(), componenttest.NewNopHost())
+			require.NoError(t, err)
 
-	tt := componenttest.NewTelemetry()
-	telemetryBuilder, err := metadata.NewTelemetryBuilder(tt.NewTelemetrySettings())
-	require.NoError(t, err)
+			tt := componenttest.NewTelemetry()
+			telemetryBuilder, err := metadata.NewTelemetryBuilder(tt.NewTelemetrySettings())
+			require.NoError(t, err)
 
-	rl := rateLimiterProcessor{
-		rl:               rateLimiter,
-		telemetryBuilder: telemetryBuilder,
-		logger:           zap.NewNop(),
-		metadataKeys:     []string{"x-tenant-id"},
-		strategy:         StrategyRateLimitRequests,
+			consume := sig.newConsumer(rateLimiterProcessor{
+				rl:               rateLimiter,
+				telemetryBuilder: telemetryBuilder,
+				logger:           zap.NewNop(),
+				metadataKeys:     []string{"x-tenant-id"},
+				strategy:         StrategyRateLimitRequests,
+			})
+
+			// First request: within burst, no delay.
+			require.NoError(t, consume(clientContext))
+
+			// Second request: burst exhausted, would wait ~1s. Pre-cancel the context
+			// so the select fires immediately without sleeping.
+			ctx, cancel := context.WithCancel(clientContext)
+			cancel()
+			err = consume(ctx)
+			require.ErrorIs(t, err, context.Canceled)
+
+			metadatatest.AssertEqualRatelimitRequests(t, tt, []metricdata.DataPoint[int64]{
+				{
+					Value: 1,
+					Attributes: attribute.NewSet(
+						telemetry.WithDecision("accepted"),
+						telemetry.WithReason(telemetry.StatusUnderLimit),
+						attribute.String("x-tenant-id", "TestProjectID"),
+					),
+				},
+				{
+					Value: 1,
+					Attributes: attribute.NewSet(
+						telemetry.WithDecision("cancelled"),
+						telemetry.WithReason(telemetry.StatusOverLimit),
+						attribute.String("x-tenant-id", "TestProjectID"),
+					),
+				},
+			}, metricdatatest.IgnoreTimestamp())
+		})
 	}
-	p := &LogsRateLimiterProcessor{
-		rateLimiterProcessor: rl,
-		count:                func(plog.Logs) int { return 1 },
-		next:                 func(context.Context, plog.Logs) error { return nil },
-	}
-
-	logs := plog.NewLogs()
-
-	// First request: within burst, no delay.
-	require.NoError(t, p.ConsumeLogs(clientContext, logs))
-
-	// Second request: burst exhausted, would wait ~1s. Cancel the context immediately.
-	ctx, cancel := context.WithCancel(clientContext)
-	cancel()
-	err = p.ConsumeLogs(ctx, logs)
-	require.ErrorIs(t, err, context.Canceled)
-
-	metadatatest.AssertEqualRatelimitRequests(t, tt, []metricdata.DataPoint[int64]{
-		{
-			Value: 1,
-			Attributes: attribute.NewSet(
-				telemetry.WithDecision("accepted"),
-				telemetry.WithReason(telemetry.StatusUnderLimit),
-				attribute.String("x-tenant-id", "TestProjectID"),
-			),
-		},
-		{
-			Value: 1,
-			Attributes: attribute.NewSet(
-				telemetry.WithDecision("cancelled"),
-				telemetry.WithReason(telemetry.StatusOverLimit),
-				attribute.String("x-tenant-id", "TestProjectID"),
-			),
-		},
-	}, metricdatatest.IgnoreTimestamp())
 }
 
 func testError(t *testing.T, err error) {

--- a/processor/ratelimitprocessor/ratelimiter.go
+++ b/processor/ratelimitprocessor/ratelimiter.go
@@ -54,11 +54,12 @@ const (
 // needed by the processor layer to record telemetry without any OTel
 // dependencies inside the limiter itself.
 type RateLimitResult struct {
-	Decision     Decision
-	Delay        time.Duration // non-zero only when Decision == DecisionDelayed
-	TokensBefore float64       // bucket level before this request consumed any tokens
-	TokensAfter  float64       // bucket level after the call; negative means in debt
-	ConfigRate   float64       // effective configured rate (tokens/sec) for the key
+	Decision         Decision
+	Delay            time.Duration // non-zero only when Decision == DecisionDelayed
+	TokensBefore     float64       // bucket level before this request consumed any tokens; delay mode only
+	TokensAfter      float64       // bucket level after the call; negative means in debt; delay mode only
+	ConfigRate       float64       // effective configured rate (tokens/sec) for the key
+	EmitTokenMetrics bool          // true only for delay mode, where token metrics are meaningful and accurate
 }
 
 // RateLimiter provides an interface for rate limiting by some number

--- a/processor/ratelimitprocessor/ratelimiter.go
+++ b/processor/ratelimitprocessor/ratelimiter.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"go.opentelemetry.io/otel/attribute"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
@@ -35,10 +36,34 @@ var (
 	errTooManyRequests = status.Error(codes.ResourceExhausted, "too many requests")
 )
 
+// Decision is the outcome of a RateLimit call, used as a metric label value.
+type Decision string
+
+const (
+	// DecisionAccepted means the request passed through with no wait.
+	DecisionAccepted Decision = "accepted"
+	// DecisionDelayed means the request waited in delay mode before continuing.
+	DecisionDelayed Decision = "delayed"
+	// DecisionThrottled means the request was rejected in error mode.
+	DecisionThrottled Decision = "throttled"
+	// DecisionCancelled means the context was cancelled while waiting for a delayed request.
+	DecisionCancelled Decision = "cancelled"
+)
+
+// RateLimitResult carries the outcome of a RateLimit call plus the data
+// needed by the processor layer to record telemetry without any OTel
+// dependencies inside the limiter itself.
+type RateLimitResult struct {
+	Decision   Decision
+	Delay      time.Duration // non-zero only when Decision == DecisionDelayed
+	Tokens     float64       // bucket level after the call; negative means in debt
+	ConfigRate float64       // effective configured rate (tokens/sec) for the key
+}
+
 // RateLimiter provides an interface for rate limiting by some number
 // of things: requests, records, or bytes.
 type RateLimiter interface {
-	RateLimit(ctx context.Context, n int) error
+	RateLimit(ctx context.Context, n int) (RateLimitResult, error)
 }
 
 // getUniqueKey returns a unique key based on client metadata stored

--- a/processor/ratelimitprocessor/ratelimiter.go
+++ b/processor/ratelimitprocessor/ratelimiter.go
@@ -54,10 +54,11 @@ const (
 // needed by the processor layer to record telemetry without any OTel
 // dependencies inside the limiter itself.
 type RateLimitResult struct {
-	Decision   Decision
-	Delay      time.Duration // non-zero only when Decision == DecisionDelayed
-	Tokens     float64       // bucket level after the call; negative means in debt
-	ConfigRate float64       // effective configured rate (tokens/sec) for the key
+	Decision     Decision
+	Delay        time.Duration // non-zero only when Decision == DecisionDelayed
+	TokensBefore float64       // bucket level before this request consumed any tokens
+	TokensAfter  float64       // bucket level after the call; negative means in debt
+	ConfigRate   float64       // effective configured rate (tokens/sec) for the key
 }
 
 // RateLimiter provides an interface for rate limiting by some number


### PR DESCRIPTION
### What changed

#### Two new metrics

| Metric | Type | When recorded |
|--------|------|---------------|
| `otelcol_ratelimit.delay_duration` | Histogram | Only when a request actually waited (`throttle_behavior: delay`) |
| `otelcol_ratelimit.tokens` | Gauge | Every request — shows current token bucket level, negative means active debt |

#### Richer `decision` attribute on `otelcol_ratelimit.requests`

Previously only `accepted` / `throttled` were distinguishable via the error return. Now every outcome is explicit:

| `decision` | `reason` | Meaning |
|------------|----------|---------|
| `accepted` | `under_limit` | Tokens available, passed immediately |
| `delayed` | `over_limit` | Waited for bucket to refill, no error returned |
| `throttled` | `over_limit` | Rejected — bucket empty in error mode |
| `cancelled` | `over_limit` | Was waiting in delay mode but client context was cancelled |

#### Internal: `RateLimiter.RateLimit` now returns `RateLimitResult`

The interface changed from `RateLimit(ctx, n) error` to `RateLimit(ctx, n) (RateLimitResult, error)`. The result carries `Decision`, `Delay`, `Tokens`, and `ConfigRate` so the processor layer can record all telemetry without the rate limiter needing any OTel imports.

### Test improvements

- `TestConsume_DelayMode` and `TestConsume_DelayMode_ContextCancelled` are now table-driven over all four signal types (logs, metrics, traces, profiles) — previously only logs were covered in delay mode.
- `local_test.go` now asserts `Decision`, `Delay`, and `ConfigRate` on all core behaviour tests, closing a gap where a wrong return value from `local.go` would have gone undetected.
