### PR TITLE
fix(receiver/elasticapmintake): reduce intake batch wait latency

### DIFF
--- a/receiver/elasticapmintakereceiver/README.md
+++ b/receiver/elasticapmintakereceiver/README.md
@@ -24,6 +24,7 @@ All that is required to enable the elasticapmintake receiver is to include it in
 ```
 receivers:
   elasticapmintake:
+    batch_size: 10
     agent_config:
       enabled: false
 ```
@@ -31,6 +32,8 @@ receivers:
 ## Advanced configuration
 
 The elasticapmintake receiver embeds the [confighttp.ServerConfig](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/confighttp/README.md), which means it supports standard HTTP server configuration, including TLS/mTLS and authentication.
+
+`batch_size` controls how many intake v2 events are decoded and processed together before the receiver sends the resulting pdata to the next component. The default is `10`.
 
 ### TLS and mTLS settings
 

--- a/receiver/elasticapmintakereceiver/config.go
+++ b/receiver/elasticapmintakereceiver/config.go
@@ -18,6 +18,7 @@
 package elasticapmintakereceiver // import "github.com/elastic/opentelemetry-collector-components/receiver/elasticapmintakereceiver"
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/elastic/opentelemetry-lib/config/configelasticsearch"
@@ -28,6 +29,9 @@ import (
 type Config struct {
 	// When using APM agent configuration, information fetched from Elasticsearch will be cached in memory for some time.
 	AgentConfig AgentConfig `mapstructure:"agent_config"`
+
+	// BatchSize is the number of intake v2 events decoded and processed together.
+	BatchSize int `mapstructure:"batch_size"`
 
 	confighttp.ServerConfig `mapstructure:",squash"`
 }
@@ -48,5 +52,15 @@ type AgentConfig struct {
 
 // Validate checks the receiver configuration is valid.
 func (cfg *Config) Validate() error {
+	if cfg.BatchSize <= 0 {
+		return fmt.Errorf("batch_size must be positive")
+	}
 	return cfg.AgentConfig.Elasticsearch.Validate()
+}
+
+func (cfg *Config) batchSize() int {
+	if cfg.BatchSize <= 0 {
+		return defaultBatchSize
+	}
+	return cfg.BatchSize
 }

--- a/receiver/elasticapmintakereceiver/config_test.go
+++ b/receiver/elasticapmintakereceiver/config_test.go
@@ -44,6 +44,7 @@ func TestLoadConfig(t *testing.T) {
 					Transport: confignet.TransportTypeTCP,
 				},
 			},
+			BatchSize: defaultBatchSize,
 			AgentConfig: AgentConfig{
 				Enabled:       false,
 				CacheDuration: 30 * time.Second,
@@ -65,6 +66,18 @@ func TestLoadConfig(t *testing.T) {
 		{
 			id:       component.NewID(metadata.Type),
 			expected: expectedDefaultConfig(),
+		},
+		{
+			id: component.NewIDWithName(metadata.Type, "custom_batch_size"),
+			expected: func() *Config {
+				cfg := expectedDefaultConfig()
+				cfg.BatchSize = 25
+				return cfg
+			}(),
+		},
+		{
+			id:                   component.NewIDWithName(metadata.Type, "invalid_batch_size"),
+			validateErrorMessage: "batch_size must be positive",
 		},
 		{
 			id: component.NewIDWithName(metadata.Type, "elasticsearch_agentcfg"),

--- a/receiver/elasticapmintakereceiver/factory.go
+++ b/receiver/elasticapmintakereceiver/factory.go
@@ -36,6 +36,7 @@ import (
 const (
 	defaultEndpoint   = "localhost:8200"
 	defaultESEndpoint = "http://localhost:9200"
+	defaultBatchSize  = 10
 )
 
 // NewFactory creates a new factory for the elasticapm receiver.
@@ -63,6 +64,7 @@ func createDefaultConfig() component.Config {
 
 	return &Config{
 		ServerConfig: defaultServerConfig,
+		BatchSize:    defaultBatchSize,
 		AgentConfig: AgentConfig{
 			Enabled:       false,
 			Elasticsearch: defaultESClientConfig,

--- a/receiver/elasticapmintakereceiver/receiver.go
+++ b/receiver/elasticapmintakereceiver/receiver.go
@@ -171,10 +171,9 @@ func (r *elasticAPMIntakeReceiver) newElasticAPMEventsHandler(ctxFunc func(*http
 
 		// TODO make event size configurable
 		maxEventSize = 1024 * 1024 // 1MiB
-
-		// TODO make batch size configurable?
-		batchSize = 10
 	)
+
+	batchSize := r.cfg.batchSize()
 
 	batchProcessor := modelpb.ProcessBatchFunc(r.processBatch)
 	elasticapmProcessor := elasticapm.NewProcessor(elasticapm.Config{

--- a/receiver/elasticapmintakereceiver/receiver.go
+++ b/receiver/elasticapmintakereceiver/receiver.go
@@ -430,31 +430,57 @@ func (r *elasticAPMIntakeReceiver) getOrCreateLogScope(
 // consumeOTel sends the populated pdata structures to downstream consumers.
 // Nil pointers are skipped.
 func (r *elasticAPMIntakeReceiver) consumeOTel(ctx context.Context, ld *plog.Logs, md *pmetric.Metrics, td *ptrace.Traces) []error {
-	var errs []error
+	var consumeFns []func() error
 	if ld != nil {
 		if numRecords := ld.LogRecordCount(); numRecords != 0 && r.nextLogs != nil {
-			obsCtx := r.obsreport.StartLogsOp(ctx)
-			err := r.nextLogs.ConsumeLogs(obsCtx, *ld)
-			r.obsreport.EndLogsOp(obsCtx, dataFormatElasticAPM, numRecords, err)
-			errs = append(errs, err)
+			consumeFns = append(consumeFns, func() error {
+				obsCtx := r.obsreport.StartLogsOp(ctx)
+				err := r.nextLogs.ConsumeLogs(obsCtx, *ld)
+				r.obsreport.EndLogsOp(obsCtx, dataFormatElasticAPM, numRecords, err)
+				return err
+			})
 		}
 	}
 	if md != nil {
 		if numDataPoints := md.DataPointCount(); numDataPoints != 0 && r.nextMetrics != nil {
-			obsCtx := r.obsreport.StartMetricsOp(ctx)
-			err := r.nextMetrics.ConsumeMetrics(obsCtx, *md)
-			r.obsreport.EndMetricsOp(obsCtx, dataFormatElasticAPM, numDataPoints, err)
-			errs = append(errs, err)
+			consumeFns = append(consumeFns, func() error {
+				obsCtx := r.obsreport.StartMetricsOp(ctx)
+				err := r.nextMetrics.ConsumeMetrics(obsCtx, *md)
+				r.obsreport.EndMetricsOp(obsCtx, dataFormatElasticAPM, numDataPoints, err)
+				return err
+			})
 		}
 	}
 	if td != nil {
 		if numSpans := td.SpanCount(); numSpans != 0 && r.nextTraces != nil {
-			obsCtx := r.obsreport.StartTracesOp(ctx)
-			err := r.nextTraces.ConsumeTraces(obsCtx, *td)
-			r.obsreport.EndTracesOp(obsCtx, dataFormatElasticAPM, numSpans, err)
-			errs = append(errs, err)
+			consumeFns = append(consumeFns, func() error {
+				obsCtx := r.obsreport.StartTracesOp(ctx)
+				err := r.nextTraces.ConsumeTraces(obsCtx, *td)
+				r.obsreport.EndTracesOp(obsCtx, dataFormatElasticAPM, numSpans, err)
+				return err
+			})
 		}
 	}
+
+	if len(consumeFns) == 0 {
+		return nil
+	}
+
+	errs := make([]error, len(consumeFns))
+	if len(consumeFns) == 1 {
+		errs[0] = consumeFns[0]()
+		return errs
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(len(consumeFns))
+	for i, consume := range consumeFns {
+		go func(i int, consume func() error) {
+			defer wg.Done()
+			errs[i] = consume()
+		}(i, consume)
+	}
+	wg.Wait()
 	return errs
 }
 

--- a/receiver/elasticapmintakereceiver/receiver_test.go
+++ b/receiver/elasticapmintakereceiver/receiver_test.go
@@ -25,6 +25,7 @@ import (
 	"flag"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -803,6 +804,35 @@ func TestConsumeOTelConsumesSignalsConcurrently(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for consumers to finish")
 	}
+}
+
+func TestEventsHandlerUsesConfiguredBatchSize(t *testing.T) {
+	rcvr, err := newElasticAPMIntakeReceiver(
+		func(context.Context, component.Host) (agentcfg.Fetcher, error) { return nil, nil },
+		&Config{BatchSize: 2},
+		receivertest.NewNopSettings(metadata.Type),
+	)
+	require.NoError(t, err)
+
+	nextTraces := new(consumertest.TracesSink)
+	rcvr.nextTraces = nextTraces
+
+	handler := rcvr.newElasticAPMEventsHandler(func(req *http.Request) context.Context {
+		return withECSMappingMode(req.Context(), false)
+	})
+	req := httptest.NewRequest(http.MethodPost, intakeV2EventsPath, bytes.NewReader(generateTransactionPayload(5)))
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusAccepted, rec.Code)
+	allTraces := nextTraces.AllTraces()
+	require.Len(t, allTraces, 3)
+	require.Equal(t, []int{2, 2, 1}, []int{
+		allTraces[0].SpanCount(),
+		allTraces[1].SpanCount(),
+		allTraces[2].SpanCount(),
+	})
 }
 
 func TestGlobalLabelsMetadataPropagation(t *testing.T) {

--- a/receiver/elasticapmintakereceiver/receiver_test.go
+++ b/receiver/elasticapmintakereceiver/receiver_test.go
@@ -41,6 +41,7 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/confignet"
+	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -63,6 +64,58 @@ type fetcherMock struct {
 
 func (f *fetcherMock) Fetch(ctx context.Context, query agentcfg.Query) (agentcfg.Result, error) {
 	return f.fetchFn(ctx, query)
+}
+
+type blockingSignalConsumer struct {
+	signal  string
+	started chan<- string
+	release <-chan struct{}
+}
+
+func (c blockingSignalConsumer) wait(ctx context.Context) error {
+	c.started <- c.signal
+	select {
+	case <-c.release:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+type blockingLogsConsumer struct {
+	blockingSignalConsumer
+}
+
+func (blockingLogsConsumer) Capabilities() consumer.Capabilities {
+	return consumer.Capabilities{}
+}
+
+func (c blockingLogsConsumer) ConsumeLogs(ctx context.Context, _ plog.Logs) error {
+	return c.wait(ctx)
+}
+
+type blockingMetricsConsumer struct {
+	blockingSignalConsumer
+}
+
+func (blockingMetricsConsumer) Capabilities() consumer.Capabilities {
+	return consumer.Capabilities{}
+}
+
+func (c blockingMetricsConsumer) ConsumeMetrics(ctx context.Context, _ pmetric.Metrics) error {
+	return c.wait(ctx)
+}
+
+type blockingTracesConsumer struct {
+	blockingSignalConsumer
+}
+
+func (blockingTracesConsumer) Capabilities() consumer.Capabilities {
+	return consumer.Capabilities{}
+}
+
+func (c blockingTracesConsumer) ConsumeTraces(ctx context.Context, _ ptrace.Traces) error {
+	return c.wait(ctx)
 }
 
 func TestAgentCfgHandlerNoFetcher(t *testing.T) {
@@ -678,6 +731,77 @@ func TestMetadataPropagation(t *testing.T) {
 				require.Equal(t, tcase.expectedMetadata, md)
 			}
 		})
+	}
+}
+
+func TestConsumeOTelConsumesSignalsConcurrently(t *testing.T) {
+	rcvr, err := newElasticAPMIntakeReceiver(
+		func(context.Context, component.Host) (agentcfg.Fetcher, error) { return nil, nil },
+		&Config{},
+		receivertest.NewNopSettings(metadata.Type),
+	)
+	require.NoError(t, err)
+
+	started := make(chan string, 3)
+	release := make(chan struct{})
+	released := false
+	defer func() {
+		if !released {
+			close(release)
+		}
+	}()
+
+	rcvr.nextLogs = blockingLogsConsumer{blockingSignalConsumer{
+		signal:  "logs",
+		started: started,
+		release: release,
+	}}
+	rcvr.nextMetrics = blockingMetricsConsumer{blockingSignalConsumer{
+		signal:  "metrics",
+		started: started,
+		release: release,
+	}}
+	rcvr.nextTraces = blockingTracesConsumer{blockingSignalConsumer{
+		signal:  "traces",
+		started: started,
+		release: release,
+	}}
+
+	ld := plog.NewLogs()
+	ld.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+
+	md := pmetric.NewMetrics()
+	metric := md.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+	metric.SetName("test.metric")
+	metric.SetEmptyGauge().DataPoints().AppendEmpty()
+
+	td := ptrace.NewTraces()
+	td.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+
+	done := make(chan []error, 1)
+	go func() {
+		done <- rcvr.consumeOTel(context.Background(), &ld, &md, &td)
+	}()
+
+	seen := make(map[string]struct{})
+	timeout := time.After(time.Second)
+	for len(seen) < 3 {
+		select {
+		case signal := <-started:
+			seen[signal] = struct{}{}
+		case <-timeout:
+			t.Fatalf("expected all signal consumers to start before any returned, got %v", seen)
+		}
+	}
+
+	close(release)
+	released = true
+
+	select {
+	case errs := <-done:
+		require.NoError(t, errors.Join(errs...))
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for consumers to finish")
 	}
 }
 

--- a/receiver/elasticapmintakereceiver/testdata/config.yaml
+++ b/receiver/elasticapmintakereceiver/testdata/config.yaml
@@ -1,5 +1,11 @@
 elasticapmintake:
 
+elasticapmintake/custom_batch_size:
+  batch_size: 25
+
+elasticapmintake/invalid_batch_size:
+  batch_size: 0
+
 elasticapmintake/elasticsearch_agentcfg:
   agent_config:
     enabled: true


### PR DESCRIPTION
## Summary
- Consume non-empty logs, metrics, and traces concurrently within each Elastic APM intake batch.
- Preserve existing request semantics by waiting for all downstream consumers before returning.
- Add configurable `batch_size` for intake v2 processing, keeping the default at `10`.
- Add regression coverage for concurrent signal consumption and configured batch sizing.

## Test plan
- `go test -run 'TestLoadConfig|TestEventsHandlerUsesConfiguredBatchSize|TestConsumeOTelConsumesSignalsConcurrently' -count=1 ./...`
- `go test ./...`