### PR TITLE
fix(extension/apikeyauth): match scheme case-insensitively

### DIFF
--- a/extension/apikeyauthextension/authenticator.go
+++ b/extension/apikeyauthextension/authenticator.go
@@ -231,8 +231,9 @@ func (a *authenticator) parseAuthorizationHeader(headers map[string][]string) (s
 	//
 	//     Authorization: ApiKey base64(ID:APIKey)
 	//
-	encoded, found := strings.CutPrefix(orig, "ApiKey ")
-	if !found {
+	// The scheme name is matched case-insensitively per RFC 7235.
+	scheme, encoded, found := strings.Cut(orig, " ")
+	if !found || !strings.EqualFold(scheme, "ApiKey") {
 		return "", "", errAuthorizationHeaderWrongScheme
 	}
 

--- a/extension/apikeyauthextension/authenticator_test.go
+++ b/extension/apikeyauthextension/authenticator_test.go
@@ -854,6 +854,21 @@ func TestAuthenticator_AuthorizationHeader(t *testing.T) {
 				},
 			},
 		},
+		// elastic-transport-go emits "APIKey"
+		"APIKey_scheme": {
+			headers: map[string][]string{
+				"Authorization": {
+					"APIKey " + base64.StdEncoding.EncodeToString([]byte("id:secret")),
+				},
+			},
+		},
+		"apikey_scheme_lowercase": {
+			headers: map[string][]string{
+				"Authorization": {
+					"apikey " + base64.StdEncoding.EncodeToString([]byte("id:secret")),
+				},
+			},
+		},
 		"missing_header": {
 			headers:     map[string][]string{},
 			expectedErr: `rpc error: code = Unauthenticated desc = missing header "Authorization", expected "ApiKey <value>"`,


### PR DESCRIPTION
Compare auth scheme case-insensitively per RFC 7235.

elastic-transport-go emits "APIKey" while the extension only accepted "ApiKey", causing auth failures for clients using that library.

Fixes #1240