### PR TITLE
[receiver/elasticapm]perf: Make max concurrent decoders configurable

### DIFF
--- a/receiver/elasticapmintakereceiver/config.go
+++ b/receiver/elasticapmintakereceiver/config.go
@@ -33,6 +33,10 @@ type Config struct {
 	// BatchSize is the number of intake v2 events decoded and processed together.
 	BatchSize int `mapstructure:"batch_size"`
 
+	// MaxConcurrentDecoders is the maximum number of intake requests whose bodies
+	// can be decoded concurrently.
+	MaxConcurrentDecoders int `mapstructure:"max_concurrent_decoders"`
+
 	confighttp.ServerConfig `mapstructure:",squash"`
 }
 
@@ -55,6 +59,9 @@ func (cfg *Config) Validate() error {
 	if cfg.BatchSize <= 0 {
 		return fmt.Errorf("batch_size must be positive")
 	}
+	if cfg.MaxConcurrentDecoders <= 0 {
+		return fmt.Errorf("max_concurrent_decoders must be positive")
+	}
 	return cfg.AgentConfig.Elasticsearch.Validate()
 }
 
@@ -63,4 +70,11 @@ func (cfg *Config) batchSize() int {
 		return defaultBatchSize
 	}
 	return cfg.BatchSize
+}
+
+func (cfg *Config) maxConcurrentDecoders() int64 {
+	if cfg.MaxConcurrentDecoders <= 0 {
+		return int64(defaultMaxConcurrentDecoders)
+	}
+	return int64(cfg.MaxConcurrentDecoders)
 }

--- a/receiver/elasticapmintakereceiver/config_test.go
+++ b/receiver/elasticapmintakereceiver/config_test.go
@@ -44,7 +44,8 @@ func TestLoadConfig(t *testing.T) {
 					Transport: confignet.TransportTypeTCP,
 				},
 			},
-			BatchSize: defaultBatchSize,
+			BatchSize:             defaultBatchSize,
+			MaxConcurrentDecoders: int(defaultMaxConcurrentDecoders),
 			AgentConfig: AgentConfig{
 				Enabled:       false,
 				CacheDuration: 30 * time.Second,
@@ -76,8 +77,20 @@ func TestLoadConfig(t *testing.T) {
 			}(),
 		},
 		{
+			id: component.NewIDWithName(metadata.Type, "custom_max_concurrent_decoders"),
+			expected: func() *Config {
+				cfg := expectedDefaultConfig()
+				cfg.MaxConcurrentDecoders = 256
+				return cfg
+			}(),
+		},
+		{
 			id:                   component.NewIDWithName(metadata.Type, "invalid_batch_size"),
 			validateErrorMessage: "batch_size must be positive",
+		},
+		{
+			id:                   component.NewIDWithName(metadata.Type, "invalid_max_concurrent_decoders"),
+			validateErrorMessage: "max_concurrent_decoders must be positive",
 		},
 		{
 			id: component.NewIDWithName(metadata.Type, "elasticsearch_agentcfg"),

--- a/receiver/elasticapmintakereceiver/factory.go
+++ b/receiver/elasticapmintakereceiver/factory.go
@@ -64,8 +64,8 @@ func createDefaultConfig() component.Config {
 	defaultESClientConfig.Endpoint = defaultESEndpoint
 
 	return &Config{
-		ServerConfig: defaultServerConfig,
-		BatchSize:    defaultBatchSize,
+		ServerConfig:          defaultServerConfig,
+		BatchSize:             defaultBatchSize,
 		MaxConcurrentDecoders: defaultMaxConcurrentDecoders,
 		AgentConfig: AgentConfig{
 			Enabled:       false,

--- a/receiver/elasticapmintakereceiver/factory.go
+++ b/receiver/elasticapmintakereceiver/factory.go
@@ -34,9 +34,10 @@ import (
 )
 
 const (
-	defaultEndpoint   = "localhost:8200"
-	defaultESEndpoint = "http://localhost:9200"
-	defaultBatchSize  = 10
+	defaultEndpoint              = "localhost:8200"
+	defaultESEndpoint            = "http://localhost:9200"
+	defaultBatchSize             = 10
+	defaultMaxConcurrentDecoders = 100
 )
 
 // NewFactory creates a new factory for the elasticapm receiver.
@@ -65,6 +66,7 @@ func createDefaultConfig() component.Config {
 	return &Config{
 		ServerConfig: defaultServerConfig,
 		BatchSize:    defaultBatchSize,
+		MaxConcurrentDecoders: defaultMaxConcurrentDecoders,
 		AgentConfig: AgentConfig{
 			Enabled:       false,
 			Elasticsearch: defaultESClientConfig,

--- a/receiver/elasticapmintakereceiver/receiver.go
+++ b/receiver/elasticapmintakereceiver/receiver.go
@@ -165,9 +165,8 @@ func errorHandler(w http.ResponseWriter, r *http.Request, errMsg string, statusC
 
 func (r *elasticAPMIntakeReceiver) newElasticAPMEventsHandler(ctxFunc func(*http.Request) context.Context) http.HandlerFunc {
 	var (
-		// TODO make semaphore size configurable and/or find a different way
-		// to limit concurrency that fits better with OTel Collector.
-		sem = semaphore.NewWeighted(100)
+		// Limit concurrent intake request decoding.
+		sem = semaphore.NewWeighted(r.cfg.maxConcurrentDecoders())
 
 		// TODO make event size configurable
 		maxEventSize = 1024 * 1024 // 1MiB

--- a/receiver/elasticapmintakereceiver/testdata/config.yaml
+++ b/receiver/elasticapmintakereceiver/testdata/config.yaml
@@ -3,8 +3,14 @@ elasticapmintake:
 elasticapmintake/custom_batch_size:
   batch_size: 25
 
+elasticapmintake/custom_max_concurrent_decoders:
+  max_concurrent_decoders: 256
+
 elasticapmintake/invalid_batch_size:
   batch_size: 0
+
+elasticapmintake/invalid_max_concurrent_decoders:
+  max_concurrent_decoders: 0
 
 elasticapmintake/elasticsearch_agentcfg:
   agent_config:


### PR DESCRIPTION
Related to: https://github.com/elastic/hosted-otel-collector/issues/2723

Makes the max concurrent decoders configurable to allow more concurrent requests per pod.