### PR TITLE
[receiver/elasticapm]preserve 499 on client-canceled intake requests

### DIFF
--- a/receiver/elasticapmintakereceiver/go.mod
+++ b/receiver/elasticapmintakereceiver/go.mod
@@ -32,6 +32,7 @@ require (
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.28.0
 	golang.org/x/sync v0.20.0
+	google.golang.org/grpc v1.81.1
 	google.golang.org/protobuf v1.36.11
 )
 
@@ -126,7 +127,6 @@ require (
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260226221140-a57be14db171 // indirect
-	google.golang.org/grpc v1.81.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 

--- a/receiver/elasticapmintakereceiver/receiver.go
+++ b/receiver/elasticapmintakereceiver/receiver.go
@@ -46,6 +46,8 @@ import (
 	"go.opentelemetry.io/collector/receiver/receiverhelper"
 	"go.uber.org/zap"
 	"golang.org/x/sync/semaphore"
+	"google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
 
 	"github.com/elastic/apm-data/input/elasticapm"
 	"github.com/elastic/apm-data/model/modelpb"
@@ -218,12 +220,16 @@ func (r *elasticAPMIntakeReceiver) newElasticAPMEventsHandler(ctxFunc func(*http
 		}
 
 		requestContextErr := ctx.Err()
+		if errors.Is(requestContextErr, context.Canceled) {
+			// Request-context cancellation is authoritative. Preserve 499 even
+			// when downstream returns a wrapped/non-canonical cancellation shape
+			// (e.g. gRPC Unknown with "context canceled").
+			statusCode = statusClientClosed
+		}
 
 		if streamErr != nil {
 			r.settings.Logger.Error("failed to process APM events stream", zap.Error(streamErr))
-			// If request context is done and streamErr is context.Canceled, treat
-			// streamErr as a client canceled request context error (MIS behavior).
-			processError(streamErr, requestContextErr != nil && errors.Is(streamErr, context.Canceled))
+			processError(streamErr, false)
 		}
 		if requestContextErr != nil {
 			processError(requestContextErr, true)
@@ -238,6 +244,9 @@ func (r *elasticAPMIntakeReceiver) newElasticAPMEventsHandler(ctxFunc func(*http
 	}
 }
 
+// intakeStatusCodeFromErr maps a processing error to an HTTP status code.
+// Context outcomes are evaluated after invalid-input detection so cancellation
+// and deadline semantics can take precedence in the final mapping.
 func intakeStatusCodeFromErr(err error, isRequestContextErr bool) int {
 	code := http.StatusInternalServerError
 
@@ -249,13 +258,31 @@ func intakeStatusCodeFromErr(err error, isRequestContextErr bool) int {
 		}
 	}
 
-	if isRequestContextErr && errors.Is(err, context.Canceled) {
-		return statusClientClosed
-	}
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+	// Evaluate final context/grpc outcome here (instead of early-returning above)
+	// so request cancellation/deadline can override a provisional invalid-input
+	// status when both signals are present.
+	switch contextCodeFromErr(err) {
+	case codes.Canceled:
+		if isRequestContextErr {
+			return statusClientClosed
+		}
+		return http.StatusServiceUnavailable
+	case codes.DeadlineExceeded:
 		return http.StatusServiceUnavailable
 	}
 	return code
+}
+
+func contextCodeFromErr(err error) codes.Code {
+	// Handles context errors and wrapped context errors.
+	if contextCode := grpcstatus.FromContextError(err).Code(); contextCode == codes.Canceled || contextCode == codes.DeadlineExceeded {
+		return contextCode
+	}
+	// Handles canonical gRPC status errors.
+	if grpcCode := grpcstatus.Code(err); grpcCode == codes.Canceled || grpcCode == codes.DeadlineExceeded {
+		return grpcCode
+	}
+	return codes.OK
 }
 
 func (r *elasticAPMIntakeReceiver) processBatch(ctx context.Context, batch *modelpb.Batch) error {

--- a/receiver/elasticapmintakereceiver/receiver_test.go
+++ b/receiver/elasticapmintakereceiver/receiver_test.go
@@ -49,6 +49,8 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/receiver/receivertest"
+	"google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
 
 	"github.com/elastic/apm-data/model/modelpb"
 	"github.com/elastic/opentelemetry-collector-components/internal/elasticattr"
@@ -119,6 +121,20 @@ func (blockingTracesConsumer) Capabilities() consumer.Capabilities {
 
 func (c blockingTracesConsumer) ConsumeTraces(ctx context.Context, _ ptrace.Traces) error {
 	return c.wait(ctx)
+}
+
+type cancelingUnknownTracesConsumer struct {
+	cancel context.CancelFunc
+}
+
+func (cancelingUnknownTracesConsumer) Capabilities() consumer.Capabilities {
+	return consumer.Capabilities{}
+}
+
+func (c cancelingUnknownTracesConsumer) ConsumeTraces(ctx context.Context, _ ptrace.Traces) error {
+	c.cancel()
+	<-ctx.Done()
+	return grpcstatus.Error(codes.Unknown, context.Canceled.Error())
 }
 
 func TestAgentCfgHandlerNoFetcher(t *testing.T) {
@@ -802,6 +818,32 @@ func TestEventsHandlerUsesConfiguredBatchSize(t *testing.T) {
 		allTraces[1].SpanCount(),
 		allTraces[2].SpanCount(),
 	})
+}
+
+func TestEventsHandler_ContextCanceledWithUnknownRPCError(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	cfg.BatchSize = 1
+
+	rcvr, err := newElasticAPMIntakeReceiver(
+		func(context.Context, component.Host) (agentcfg.Fetcher, error) { return nil, nil },
+		cfg,
+		receivertest.NewNopSettings(metadata.Type),
+	)
+	require.NoError(t, err)
+
+	reqCtx, cancelReq := context.WithCancel(context.Background())
+	defer cancelReq()
+
+	rcvr.nextTraces = cancelingUnknownTracesConsumer{cancel: cancelReq}
+	handler := rcvr.newElasticAPMEventsHandler(func(req *http.Request) context.Context {
+		return withECSMappingMode(req.Context(), false)
+	})
+	req := httptest.NewRequest(http.MethodPost, intakeV2EventsPath, bytes.NewReader(generateTransactionPayload(1))).WithContext(reqCtx)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, statusClientClosed, rec.Code)
 }
 
 func TestGlobalLabelsMetadataPropagation(t *testing.T) {


### PR DESCRIPTION
## Summary
- fix intake status handling so request-context cancellation preserves `499` even when stream processing returns wrapped/non-canonical cancellation errors (e.g. gRPC `Unknown: context canceled`)
- remove fragile stream-level `errors.Is(streamErr, context.Canceled)` coupling and treat request-context cancellation as authoritative for final status
- add an end-to-end receiver test reproducing the `Unknown + context canceled` path and asserting the expected `499` behavior

There is still rough edges around the error handling in mOTLP and they don't translate MIS very well. I think we might need to re-think this through from scratch for mOTLP rather than attempt to mimic MIS.