### PR TITLE
[receiver/elasticapm]perf: reduce per-batch allocations via stream-scoped state

### DIFF
--- a/receiver/elasticapmintakereceiver/receiver.go
+++ b/receiver/elasticapmintakereceiver/receiver.go
@@ -166,8 +166,17 @@ func errorHandler(w http.ResponseWriter, r *http.Request, errMsg string, statusC
 	// TODO
 }
 
+// streamState holds per-stream mutable state that is shared across all
+// processBatch calls for a single HandleStream invocation (one HTTP request).
+// It must not be used concurrently; HandleStream calls processBatch
+// sequentially, so no synchronisation is needed.
+type streamState struct {
+	rcv      *elasticAPMIntakeReceiver
+	groups   signalGroups
+	fpHasher *xxhashv2.Digest
+}
+
 func (r *elasticAPMIntakeReceiver) newElasticAPMEventsHandler(ctxFunc func(*http.Request) context.Context) http.HandlerFunc {
-	batchProcessor := modelpb.ProcessBatchFunc(r.processBatch)
 	elasticapmProcessor := elasticapm.NewProcessor(elasticapm.Config{
 		Logger:       r.settings.Logger,
 		MaxEventSize: r.cfg.MaxEventSize,
@@ -185,6 +194,13 @@ func (r *elasticAPMIntakeReceiver) newElasticAPMEventsHandler(ctxFunc func(*http
 			_ = req.Body.Close()
 		})
 		defer stopBodyClose()
+
+		// Allocate per-stream state here so signalGroups and fpHasher are
+		// shared across all processBatch calls for this request, eliminating
+		// repeated resource fingerprinting and attribute-map population for
+		// events that share the same resource within a stream.
+		ss := &streamState{rcv: r, fpHasher: xxhashv2.New()}
+		batchProcessor := modelpb.ProcessBatchFunc(ss.processBatch)
 
 		var elasticapmResult elasticapm.Result
 		baseEvent := &modelpb.APMEvent{}
@@ -285,16 +301,20 @@ func contextCodeFromErr(err error) codes.Code {
 	return codes.OK
 }
 
-func (r *elasticAPMIntakeReceiver) processBatch(ctx context.Context, batch *modelpb.Batch) error {
+func (s *streamState) processBatch(ctx context.Context, batch *modelpb.Batch) error {
+	r := s.rcv
 	if err := ctx.Err(); err != nil {
 		return err
 	}
 
+	// Reset the resource-grouping cache on every exit path so that stale
+	// ScopeSpans/ScopeLogs references from this batch are never visible to
+	// the next processBatch call in the same stream.
+	defer s.groups.reset()
+
 	var ld *plog.Logs
 	var md *pmetric.Metrics
 	var td *ptrace.Traces
-	var mainGroups signalGroups
-	fpHasher := xxhashv2.New()
 
 	processors := modelprocessor.Chained{
 		modelprocessor.SetGroupingKey{
@@ -346,7 +366,7 @@ func (r *elasticAPMIntakeReceiver) processBatch(ctx context.Context, batch *mode
 	// Skip shadow-mask computation and shadowed-batch bookkeeping entirely.
 	if len(keyIndex) == 0 {
 		for _, event := range *batch {
-			if err := r.appendEvent(event, &ld, &md, &td, &mainGroups, fpHasher); err != nil {
+			if err := r.appendEvent(event, &ld, &md, &td, &s.groups, s.fpHasher); err != nil {
 				return err
 			}
 		}
@@ -364,13 +384,13 @@ func (r *elasticAPMIntakeReceiver) processBatch(ctx context.Context, batch *mode
 			}
 			mask, shadowed := eventShadowMaskUint64(event, keyIndex)
 			if !shadowed {
-				if err := r.appendEvent(event, &ld, &md, &td, &mainGroups, fpHasher); err != nil {
+				if err := r.appendEvent(event, &ld, &md, &td, &s.groups, s.fpHasher); err != nil {
 					return err
 				}
 				continue
 			}
 			sb := getOrCreateShadowedBatchUint64(mask, &shadowIndex, &shadowedBatches)
-			if err := r.appendEvent(event, &sb.ld, &sb.md, &sb.td, &sb.groups, fpHasher); err != nil {
+			if err := r.appendEvent(event, &sb.ld, &sb.md, &sb.td, &sb.groups, s.fpHasher); err != nil {
 				return err
 			}
 		}
@@ -383,13 +403,13 @@ func (r *elasticAPMIntakeReceiver) processBatch(ctx context.Context, batch *mode
 			}
 			mask, shadowed := eventShadowMaskBigInt(event, keyIndex)
 			if !shadowed {
-				if err := r.appendEvent(event, &ld, &md, &td, &mainGroups, fpHasher); err != nil {
+				if err := r.appendEvent(event, &ld, &md, &td, &s.groups, s.fpHasher); err != nil {
 					return err
 				}
 				continue
 			}
 			sb := getOrCreateShadowedBatchBigInt(mask, &shadowIndex, &shadowedBatches)
-			if err := r.appendEvent(event, &sb.ld, &sb.md, &sb.td, &sb.groups, fpHasher); err != nil {
+			if err := r.appendEvent(event, &sb.ld, &sb.md, &sb.td, &sb.groups, s.fpHasher); err != nil {
 				return err
 			}
 		}

--- a/receiver/elasticapmintakereceiver/receiver.go
+++ b/receiver/elasticapmintakereceiver/receiver.go
@@ -855,6 +855,7 @@ func createBreakdownMetricsCommon(metric pmetric.Metric, event *modelpb.APMEvent
 	dp.SetTimestamp(pcommon.Timestamp(timestampNanos))
 
 	attr := dp.Attributes()
+	attr.EnsureCapacity(5)
 	if event.Transaction != nil {
 		attr.PutStr(elasticattr.TransactionName, event.Transaction.Name)
 		attr.PutStr(elasticattr.TransactionType, event.Transaction.Type)
@@ -873,6 +874,7 @@ func createBreakdownMetricsCommon(metric pmetric.Metric, event *modelpb.APMEvent
 
 func (r *elasticAPMIntakeReceiver) elasticErrorToOtelLogRecord(sl plog.ScopeLogs, event *modelpb.APMEvent, timestampNanos uint64) {
 	l := sl.LogRecords().AppendEmpty()
+	l.Attributes().EnsureCapacity(4)
 
 	mappers.SetTopLevelFieldsLogRecord(event, timestampNanos, l, r.settings.Logger)
 	mappers.SetDerivedFieldsForError(event, l.Attributes())
@@ -899,6 +901,7 @@ func (r *elasticAPMIntakeReceiver) setLogSeverity(event *modelpb.APMEvent, l plo
 
 func (r *elasticAPMIntakeReceiver) elasticLogToOtelLogRecord(sl plog.ScopeLogs, event *modelpb.APMEvent, timestampNanos uint64) {
 	l := sl.LogRecords().AppendEmpty()
+	l.Attributes().EnsureCapacity(4)
 
 	mappers.SetTopLevelFieldsLogRecord(event, timestampNanos, l, r.settings.Logger)
 	mappers.SetDerivedFieldsForLog(event, l.Attributes())
@@ -944,6 +947,7 @@ func (r *elasticAPMIntakeReceiver) elasticTransactionToOtelSpan(s *ptrace.Span, 
 	transaction := event.GetTransaction()
 	s.SetName(transaction.GetName())
 
+	s.Attributes().EnsureCapacity(4)
 	mappers.SetDerivedFieldsForTransaction(event, s.Attributes())
 	mappers.TranslateIntakeV2TransactionToOTelAttributes(event, s.Attributes())
 	mappers.SetElasticSpecificFieldsForTransaction(event, s.Attributes())
@@ -953,6 +957,7 @@ func (r *elasticAPMIntakeReceiver) elasticSpanToOTelSpan(s *ptrace.Span, event *
 	span := event.GetSpan()
 	s.SetName(span.GetName())
 
+	s.Attributes().EnsureCapacity(6)
 	mappers.SetDerivedFieldsForSpan(event, s.Attributes())
 	mappers.TranslateIntakeV2SpanToOTelAttributes(event, s.Attributes())
 	mappers.SetElasticSpecificFieldsForSpan(event, s.Attributes())

--- a/receiver/elasticapmintakereceiver/receiver_bench_test.go
+++ b/receiver/elasticapmintakereceiver/receiver_bench_test.go
@@ -28,6 +28,7 @@ import (
 	"strconv"
 	"testing"
 
+	xxhashv2 "github.com/cespare/xxhash/v2"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/confighttp"
@@ -178,7 +179,8 @@ func runHandleStream(b *testing.B, rcv *elasticAPMIntakeReceiver, payload []byte
 		MaxEventSize: maxEventSize,
 		Semaphore:    semaphore.NewWeighted(100),
 	})
-	batchProcessor := modelpb.ProcessBatchFunc(rcv.processBatch)
+	ss := &streamState{rcv: rcv, fpHasher: xxhashv2.New()}
+	batchProcessor := modelpb.ProcessBatchFunc(ss.processBatch)
 	ctx := withECSMappingMode(context.Background(), false)
 
 	b.SetBytes(int64(len(payload)))

--- a/receiver/elasticapmintakereceiver/receiver_test.go
+++ b/receiver/elasticapmintakereceiver/receiver_test.go
@@ -32,6 +32,7 @@ import (
 	"testing"
 	"time"
 
+	xxhashv2 "github.com/cespare/xxhash/v2"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest/plogtest"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest/pmetrictest"
@@ -1081,6 +1082,7 @@ func TestProcessBatchReturnsOnCanceledContext(t *testing.T) {
 	batch := modelpb.Batch{
 		&modelpb.APMEvent{},
 	}
-	err := r.processBatch(ctx, &batch)
+	ss := &streamState{rcv: r, fpHasher: xxhashv2.New()}
+	err := ss.processBatch(ctx, &batch)
 	require.ErrorIs(t, err, context.Canceled)
 }

--- a/receiver/elasticapmintakereceiver/resource_grouping.go
+++ b/receiver/elasticapmintakereceiver/resource_grouping.go
@@ -91,13 +91,9 @@ func (g *signalGroups) recordLogScope(fp uint64, sl plog.ScopeLogs) {
 // consumed pdata to be garbage collected promptly. The backing slices
 // themselves are retained to avoid re-allocation on the next batch.
 func (g *signalGroups) reset() {
-	for i := range g.traces {
-		g.traces[i] = traceGroup{}
-	}
+	clear(g.traces)
 	g.traces = g.traces[:0]
-	for i := range g.logs {
-		g.logs[i] = logGroup{}
-	}
+	clear(g.logs)
 	g.logs = g.logs[:0]
 }
 

--- a/receiver/elasticapmintakereceiver/resource_grouping.go
+++ b/receiver/elasticapmintakereceiver/resource_grouping.go
@@ -84,6 +84,23 @@ func (g *signalGroups) recordLogScope(fp uint64, sl plog.ScopeLogs) {
 	g.logs = append(g.logs, logGroup{fp: fp, sl: sl})
 }
 
+// reset clears the cache so the stored ScopeSpans/ScopeLogs references
+// are no longer held after the pdata structures have been handed off to
+// consumeOTel. Entries are zeroed before the slice is truncated so that
+// the backing array does not retain pdata pointers, allowing the
+// consumed pdata to be garbage collected promptly. The backing slices
+// themselves are retained to avoid re-allocation on the next batch.
+func (g *signalGroups) reset() {
+	for i := range g.traces {
+		g.traces[i] = traceGroup{}
+	}
+	g.traces = g.traces[:0]
+	for i := range g.logs {
+		g.logs[i] = logGroup{}
+	}
+	g.logs = g.logs[:0]
+}
+
 // fpKVSep separates a key from a value within a single attribute write.
 // fpEntrySep separates one attribute write from the next.
 //


### PR DESCRIPTION
## Summary

  - Introduce `streamState` to hold the `signalGroups` cache and `xxhashv2.Digest`
    at the HTTP-request level rather than the per-batch level.
  - Use `EnsureCapacity` for known attributes to preserve reallocs.

  ## What changes and why

  `processBatch` is called N times per `HandleStream` invocation (once per
  `batchSize` events). Previously, both the `xxhashv2.Digest` and the
  `signalGroups` backing slices were allocated fresh on every call:

  ```go
  var mainGroups signalGroups
  fpHasher := xxhashv2.New()
```

  Moving them onto a streamState allocated once per HTTP request means:

  - The xxhashv2.Digest is allocated once and reused across all batches in
  the stream (saved via h.Reset() before each fingerprint call). For a
  1000-event stream at batchSize=10 this eliminates 100 Digest
  allocations.
  - The signalGroups backing slices ([]traceGroup, []logGroup) survive
  between batches. reset() truncates them to zero length while keeping the
  backing array, so from the second batch onward no slice growth allocation
  occurs.

  The signalGroups cache itself still covers only one batch at a time: after
  consumeOTel the stored ScopeSpans/ScopeLogs are stale (they point into
  pdata that is now owned by the downstream consumer) and must be cleared before
  the next batch. The reset() call is deferred at the top of processBatch so
  it fires on every return path — including error returns and context
  cancellations — preventing stale references from leaking to subsequent batches
  in the same stream.

  reset() zeroes each entry before truncating rather than using [:0] alone.
  The bare truncation would keep pdata pointers live in the backing array beyond
  len, delaying GC of the consumed pdata until those slots were overwritten by
  the next batch.

Related to: https://github.com/elastic/hosted-otel-collector/issues/859