### PR TITLE
[receiver/elasticapm]Add GET / handler with fake versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ bin/
 .tools/
 .release/
 _build/
+*.test
 
 ### IntelliJ IDEA ###
 .idea/

--- a/receiver/elasticapmintakereceiver/receiver.go
+++ b/receiver/elasticapmintakereceiver/receiver.go
@@ -63,7 +63,13 @@ const dataFormatElasticAPM = "elasticapm"
 const (
 	agentConfigPath    = "/config/v1/agents"
 	intakeV2EventsPath = "/intake/v2/events"
+	rootPath           = "/"
 	statusClientClosed = 499
+
+	// fakeVersion is returned by the root handler to satisfy APM agent version
+	// checks without exposing internal server details. Matches the value used
+	// by MIS so agents see consistent behaviour during migration.
+	fakeVersion = "8.9.0"
 )
 
 type agentCfgFetcherFactory = func(context.Context, component.Host) (agentcfg.Fetcher, error)
@@ -118,6 +124,7 @@ func (r *elasticAPMIntakeReceiver) Start(ctx context.Context, host component.Hos
 func (r *elasticAPMIntakeReceiver) startHTTPServer(ctx context.Context, host component.Host) error {
 	httpMux := http.NewServeMux()
 
+	httpMux.HandleFunc("GET /{$}", r.newRootHandler())
 	httpMux.HandleFunc(intakeV2EventsPath, r.newElasticAPMEventsHandler(func(req *http.Request) context.Context {
 		return withECSMappingMode(req.Context(), r.cfg.IncludeMetadata)
 	}))
@@ -174,6 +181,17 @@ type streamState struct {
 	rcv      *elasticAPMIntakeReceiver
 	groups   signalGroups
 	fpHasher *xxhashv2.Digest
+}
+
+// newRootHandler returns an unauthenticated handler for GET /. It mirrors the
+// MIS behaviour: return HTTP 200 with a JSON version payload so that APM
+// agents can confirm they are talking to a compatible server.
+func (r *elasticAPMIntakeReceiver) newRootHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set(ContentType, "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]string{"version": fakeVersion})
+	}
 }
 
 func (r *elasticAPMIntakeReceiver) newElasticAPMEventsHandler(ctxFunc func(*http.Request) context.Context) http.HandlerFunc {

--- a/receiver/elasticapmintakereceiver/receiver_test.go
+++ b/receiver/elasticapmintakereceiver/receiver_test.go
@@ -158,7 +158,7 @@ func TestRootHandler(t *testing.T) {
 
 	res, err := http.Get("http://" + testEndpoint + rootPath)
 	require.NoError(t, err)
-	defer res.Body.Close()
+	defer func() { require.NoError(t, res.Body.Close()) }()
 
 	assert.Equal(t, http.StatusOK, res.StatusCode)
 	body, err := io.ReadAll(res.Body)

--- a/receiver/elasticapmintakereceiver/receiver_test.go
+++ b/receiver/elasticapmintakereceiver/receiver_test.go
@@ -138,6 +138,34 @@ func (c cancelingUnknownTracesConsumer) ConsumeTraces(ctx context.Context, _ ptr
 	return grpcstatus.Error(codes.Unknown, context.Canceled.Error())
 }
 
+func TestRootHandler(t *testing.T) {
+	testEndpoint := testutil.GetAvailableLocalAddress(t)
+	rcvr, err := newElasticAPMIntakeReceiver(func(_ context.Context, _ component.Host) (agentcfg.Fetcher, error) {
+		return nil, nil
+	}, &Config{
+		ServerConfig: confighttp.ServerConfig{
+			NetAddr: confignet.AddrConfig{
+				Endpoint:  testEndpoint,
+				Transport: confignet.TransportTypeTCP,
+			},
+		},
+	}, receivertest.NewNopSettings(metadata.Type))
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	require.NoError(t, rcvr.Start(ctx, componenttest.NewNopHost()))
+	defer func() { require.NoError(t, rcvr.Shutdown(ctx)) }()
+
+	res, err := http.Get("http://" + testEndpoint + rootPath)
+	require.NoError(t, err)
+	defer res.Body.Close()
+
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+	body, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"version":"8.9.0"}`, string(body))
+}
+
 func TestAgentCfgHandlerNoFetcher(t *testing.T) {
 	testEndpoint := testutil.GetAvailableLocalAddress(t)
 	rcvr, err := newElasticAPMIntakeReceiver(func(ctx context.Context, h component.Host) (agentcfg.Fetcher, error) {


### PR DESCRIPTION
## Summary

Returns {"version":"8.9.0"} with HTTP 200 for APM agent server discovery, matching MIS behaviour. Registered as "GET /{$}" for exact path matching — without the {$} anchor Go ServeMux treats / as a rooted subtree match.

Related to: https://github.com/elastic/hosted-otel-collector/issues/3252