### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,8 +6,8 @@ internal/elasticattr                   @elastic/obs-ds-intake-services @elastic/
 loadgen                                @elastic/obs-ds-intake-services @elastic/obs-ds-hosted-services @elastic/ingest-otel-data
 receiver/loadgenreceiver               @elastic/obs-ds-intake-services @elastic/obs-ds-hosted-services @elastic/ingest-otel-data
 receiver/elasticapmintakereceiver      @elastic/obs-ds-intake-services @elastic/obs-ds-hosted-services @elastic/ingest-otel-data
-receiver/akamaisiemreceiver            @elastic/security-service-integrations
-receiver/entityanalyticsreceiver       @elastic/security-service-integrations
+receiver/akamaisiemreceiver            @elastic/security-service-integrations @elastic/ingest-otel-data
+receiver/entityanalyticsreceiver       @elastic/security-service-integrations @elastic/ingest-otel-data
 processor/elasticinframetricsprocessor @elastic/obs-infraobs-integrations @elastic/ingest-otel-data
 processor/elasticapmprocessor          @elastic/obs-ds-intake-services @elastic/obs-ds-hosted-services @elastic/ingest-otel-data
 processor/elastictraceprocessor        @elastic/obs-ds-intake-services @elastic/obs-ds-hosted-services @elastic/ingest-otel-data


### PR DESCRIPTION
Adding elastic/ingest-otel-data ad code owner for all the modules, so the team can do the release.

Without this, we'd always need an approval from the `security-service-integrations ` team. 

We added `elastic/ingest-otel-data` for all modules because this team is primarily responsible for releasing this repo and keeping upstream OTel dependencies in sync - for this, with each upstream update we bump the dependency in `go.mod` files in each module resulting changes in `go.mod` and `go.sum` in all modules. In order to be able to do this as a single team we added this team in https://github.com/elastic/opentelemetry-collector-components/pull/1020 - this PR just keeps this in sync. If we ever need to do more than just bumping up the version, we always ping the real code owner of the module