### PR TITLE
[receiver/akamaisiemreceiver] - Resolve storage extensions renamed by Fleet, fixing cursor persistence

### DIFF
--- a/distributions/elastic-components/manifest.yaml
+++ b/distributions/elastic-components/manifest.yaml
@@ -40,7 +40,7 @@ receivers:
   - gomod: github.com/elastic/opentelemetry-collector-components/receiver/loadgenreceiver v0.50.0
   - gomod: github.com/elastic/opentelemetry-collector-components/receiver/elasticapmintakereceiver v0.52.0
   - gomod: github.com/elastic/opentelemetry-collector-components/receiver/entityanalyticsreceiver v0.0.0
-  - gomod: github.com/elastic/opentelemetry-collector-components/receiver/akamaisiemreceiver v0.1.0
+  - gomod: github.com/elastic/opentelemetry-collector-components/receiver/akamaisiemreceiver v0.2.0
 
 processors:
   - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.153.0

--- a/receiver/akamaisiemreceiver/README.md
+++ b/receiver/akamaisiemreceiver/README.md
@@ -414,7 +414,7 @@ The example pipelines compose standard Collector components. Each one is indepen
 
 **`file_storage` extension** (optional) — `extensions.file_storage`
 
-- `directory` — where the BoltDB-backed key-value file lives. Used by both the receiver's cursor and the exporter's persistent sending queue. Both live in the same DB but in separate keyspaces — no conflict.
+- `directory` — where the BoltDB-backed key-value file lives. Used by both the receiver's cursor and the exporter's persistent sending queue. Both live in the same DB but in separate keyspaces — no conflict. **The directory must be writable by the collector process**: `file_storage` fails at service initialization when it cannot create or write the directory (even with `create_directory: true`, e.g. a non-root container user and a path outside any writable mount), and an extension that fails to start takes the whole collector down — no receiver-side handling can degrade gracefully around it, because the failure happens before receivers start.
 - `compaction.on_rebound` — when enabled, BoltDB is compacted after a spike (queue drained from large to small). Without this, the file only grows. Strongly recommended for long-running deployments.
 - `fsync` — fsync each write. Trades throughput for durability. Set to `true` if a power loss must not lose the last few queued events; leave default for higher-throughput-but-eventually-durable setups.
 
@@ -664,11 +664,81 @@ The `_id` (`1774777751-zW7QLk7MmGNbuha8XEVw2iitcJc=`) is set by the ingest pipel
 | `batch_size` | int | `1000` | Events per ConsumeLogs call. Controls memory per batch. |
 | `stream_buffer_size` | int | `4` | Bounded channel capacity between NDJSON scanner and batch consumer. Controls back-pressure. |
 | `timeout` | duration | `60s` | HTTP request timeout. Plus other `confighttp.ClientConfig` fields (`tls`, `headers`, `compression`, `proxy_url`, …) at the receiver root. |
-| `storage` | component.ID | (nil) | Storage extension for cursor persistence (e.g., `file_storage`). Optional — when unset the receiver still tracks chain state in memory and runs without errors, but every collector restart re-fetches from `initial_lookback` since the cursor doesn't survive the process. |
+| `storage` | component.ID | (nil) | Storage extension for cursor persistence (e.g., `file_storage`). Optional — when unset the receiver still tracks chain state in memory and runs without errors, but every collector restart re-fetches from `initial_lookback` since the cursor doesn't survive the process. See [Storage Extension Resolution](#storage-extension-resolution) for how the reference resolves. |
 
 > **Note on `http.auth`**: configuring an `auth` authenticator on the HTTP client is rejected at validation time. The receiver wraps the configured transport with the EdgeGrid signer, so a chained authenticator would run after EdgeGrid signs the request and silently invalidate the signature. Use the top-level `authentication` block (`client_token`, `client_secret`, `access_token`) for EdgeGrid HMAC-SHA256 credentials — that is the only supported auth mechanism for this receiver.
 
 The receiver also embeds [`confighttp.ClientConfig`](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/confighttp/README.md) for TLS, proxy, and advanced HTTP settings.
+
+### Storage Extension Resolution
+
+Fleet-managed Elastic Agent configurations rename every component declared in
+a policy stream to `<type>/<stream-suffix>` (receiver and extension get the
+**same** suffix) without rewriting the receiver's `storage:` reference, which
+would leave that reference dangling. The receiver therefore resolves storage
+with the following precedence:
+
+1. **Exact match** of the configured component ID (standalone behavior,
+   unchanged).
+2. For **bare type references only** (e.g. `storage: file_storage`):
+   the extension of that type whose instance name equals the receiver's own
+   instance name, then — if that fails — the only extension of that type.
+   Ambiguity (multiple candidates, none name-matched) fails `Start` with the
+   candidate list.
+3. Explicit `type/name` references (e.g. `storage: file_storage/foo`) never
+   fall back — a missing named reference is a hard error.
+
+When `storage:` is **not** configured and the receiver has a non-empty
+instance name, exactly one storage-capable extension sharing that instance
+name is **auto-bound** (logged at info). This lets a Fleet integration package
+enable persistence by declaring a `file_storage` extension in the stream
+without any receiver-body reference. Unnamed receivers — the standalone
+shape — never auto-bind: keep using the explicit `storage:` reference.
+
+Auto-bind failures (no candidate, multiple candidates, client creation error)
+only disable persistence — a config without `storage:` never fails to start
+because of them. Note the limit of that guarantee: it covers receiver-side
+resolution only. A declared `file_storage` extension that cannot start —
+typically an unwritable `directory` — fails the collector at service
+initialization, before any receiver runs (see the `file_storage` notes in the
+components section).
+
+#### Verifying and resetting persistence
+
+**Is persistence active?** The startup log line tells you directly — its
+`storage` field carries the resolved extension ID, or `disabled`:
+
+```
+info  akamai SIEM receiver started  {..., "storage": "file_storage"}
+```
+
+When a fallback or auto-bind was involved, an info line precedes it naming
+the rule and the resolved ID: `resolved storage extension via instance-name
+match`, `resolved storage extension via unique type match`, or `auto-bound
+storage extension declared in this stream`.
+
+**Is the cursor surviving restarts?** After a restart you should see:
+
+```
+info  loaded persisted cursor  {"chain_from": ..., "chain_to": ..., "caught_up": ..., "last_offset": "..."}
+```
+
+If that line is absent on a restart, the receiver started fresh and will
+re-fetch the `initial_lookback` window.
+
+**Where the state lives.** The `file_storage` extension creates one
+BoltDB file per component inside its `directory`, named
+`receiver_akamai_siem_<instance name>` — e.g. `receiver_akamai_siem_` for an
+unnamed `akamai_siem:` receiver (note the trailing underscore), or
+`receiver_akamai_siem_prod` for `akamai_siem/prod:`. Its existence and a
+recent mtime are the on-disk confirmation that the cursor is being written.
+
+**Forcing a replay.** Stop the collector, delete that state file, and start
+it again: the next run has no cursor and re-fetches `initial_lookback` of
+history. When shipping to the Akamai integration's data stream, replayed
+events are deduplicated by the ingest pipeline's fingerprint-based `_id`
+(replays surface as benign `version_conflict_engine_exception` bulk errors in
+the exporter logs).
 
 ### Tuning Guide
 

--- a/receiver/akamaisiemreceiver/config.go
+++ b/receiver/akamaisiemreceiver/config.go
@@ -90,8 +90,21 @@ type Config struct {
 	DataStream DataStreamConfig `mapstructure:"data_stream"`
 
 	// StorageID references a storage extension for persisting cursor state across
-	// restarts. If nil, cursor persistence is disabled and the receiver starts fresh.
-	// Use with the file_storage extension for file-based persistence.
+	// restarts. Use with the file_storage extension for file-based persistence.
+	//
+	// A configured reference resolves to, in order: the exact component ID; and
+	// for bare type references only (e.g. `file_storage`), the extension of that
+	// type whose instance name equals this receiver's own instance name, then
+	// the only extension of that type. The fallbacks exist for Fleet-managed
+	// configurations, which rename every component declared in a policy stream
+	// to <type>/<stream-suffix> without rewriting the receiver's storage
+	// reference. Explicit <type>/<name> references never fall back.
+	//
+	// If nil, cursor persistence is disabled and the receiver starts fresh —
+	// unless the receiver has a non-empty instance name and exactly one
+	// storage-capable extension shares that instance name, in which case it is
+	// auto-bound (the Fleet-managed shape, where the stream-declared extension
+	// carries the receiver's suffix). Unnamed receivers never auto-bind.
 	StorageID *component.ID `mapstructure:"storage"`
 }
 

--- a/receiver/akamaisiemreceiver/receiver.go
+++ b/receiver/akamaisiemreceiver/receiver.go
@@ -21,6 +21,8 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -69,12 +71,50 @@ func newAkamaiReceiver(cfg *Config, settings receiver.Settings, cons consumer.Lo
 func (r *akamaiReceiver) Start(ctx context.Context, host component.Host) error {
 	// Create cursor store for state persistence via storage extension.
 	var cursorStore *cursor.CursorStore
+	storageInfo := "disabled"
 	if r.cfg.StorageID != nil {
-		storageClient, err := getStorageClient(ctx, host, r.cfg.StorageID, r.settings.ID)
+		se, resolvedID, rule, err := resolveStorageExtension(host, *r.cfg.StorageID, r.settings.ID)
+		if err != nil {
+			return fmt.Errorf("failed to get storage client: %w", err)
+		}
+		if rule != "" {
+			r.log.Info("resolved storage extension via "+rule,
+				zap.String("configured", r.cfg.StorageID.String()),
+				zap.String("resolved", resolvedID.String()),
+			)
+		}
+		storageClient, err := se.GetClient(ctx, component.KindReceiver, r.settings.ID, "")
 		if err != nil {
 			return fmt.Errorf("failed to get storage client: %w", err)
 		}
 		cursorStore = cursor.NewCursorStore(storageClient)
+		storageInfo = resolvedID.String()
+	} else if candidates := autoBindStorageExtension(host, r.settings.ID); len(candidates) == 1 {
+		// Opt-in persistence for Fleet-managed configurations, which cannot
+		// carry a storage reference (Kibana renames stream-declared extensions
+		// without rewriting receiver-body references): a single storage-capable
+		// extension sharing this receiver's instance name was necessarily
+		// declared in the same policy stream, so bind to it. Failures here only
+		// disable persistence — a config without `storage:` must never fail.
+		id := candidates[0]
+		se := host.GetExtensions()[id].(storage.Extension)
+		storageClient, err := se.GetClient(ctx, component.KindReceiver, r.settings.ID, "")
+		if err != nil {
+			r.log.Warn("failed to get client from auto-bound storage extension, cursor persistence disabled",
+				zap.String("storage", id.String()),
+				zap.Error(err),
+			)
+		} else {
+			r.log.Info("auto-bound storage extension declared in this stream",
+				zap.String("storage", id.String()),
+			)
+			cursorStore = cursor.NewCursorStore(storageClient)
+			storageInfo = id.String()
+		}
+	} else if len(candidates) > 1 {
+		r.log.Warn("multiple storage extensions match this receiver's instance name, cursor persistence disabled; reference one explicitly via the storage setting",
+			zap.Strings("candidates", idStrings(candidates)),
+		)
 	}
 
 	// Load persisted cursor.
@@ -183,10 +223,6 @@ func (r *akamaiReceiver) Start(ctx context.Context, host component.Host) error {
 		r.pollLoop(pollCtx, poll)
 	}()
 
-	storageInfo := "disabled"
-	if r.cfg.StorageID != nil {
-		storageInfo = r.cfg.StorageID.String()
-	}
 	r.log.Info("akamai SIEM receiver started",
 		zap.String("endpoint", r.cfg.HTTP.Endpoint),
 		zap.String("config_ids", r.cfg.ConfigIDs),
@@ -301,18 +337,114 @@ func (r *akamaiReceiver) emitEvents(ctx context.Context, events []string) error 
 	return r.consumer.ConsumeLogs(ctx, logs)
 }
 
-// getStorageClient retrieves a storage.Client from the configured storage extension.
-func getStorageClient(ctx context.Context, host component.Host, id *component.ID, componentID component.ID) (storage.Client, error) {
-	if id == nil {
-		return nil, fmt.Errorf("storage extension ID is nil")
+// resolveStorageExtension finds the storage extension for the configured
+// reference. An exact component-ID match always wins. A bare type reference
+// (no instance name, e.g. `file_storage`) additionally tolerates the
+// per-stream component renaming applied by Fleet-managed OTel configurations,
+// which suffix every component declared in a policy stream
+// (file_storage -> file_storage/<stream-suffix>) without rewriting the
+// receiver's storage reference: the reference falls back to the extension of
+// the configured type whose instance name equals the receiver's own (Fleet
+// gives both the same suffix), then to the only extension of that type.
+// Explicit type/name references never fall back.
+//
+// The returned rule is non-empty when a fallback step resolved the reference,
+// for caller logging.
+func resolveStorageExtension(host component.Host, configured, self component.ID) (storage.Extension, component.ID, string, error) {
+	exts := host.GetExtensions()
+	if ext, ok := exts[configured]; ok {
+		se, ok := ext.(storage.Extension)
+		if !ok {
+			return nil, component.ID{}, "", fmt.Errorf("extension %q is not a storage extension", configured)
+		}
+		return se, configured, "", nil
 	}
-	ext, ok := host.GetExtensions()[*id]
-	if !ok {
-		return nil, fmt.Errorf("storage extension %q not found", id)
+	if configured.Name() != "" {
+		return nil, component.ID{}, "", fmt.Errorf("storage extension %q not found%s", configured, availableStorageHint(exts))
 	}
-	se, ok := ext.(storage.Extension)
-	if !ok {
-		return nil, fmt.Errorf("extension %q is not a storage extension", id)
+
+	var sameType []component.ID
+	for id := range exts {
+		if id.Type() == configured.Type() {
+			sameType = append(sameType, id)
+		}
 	}
-	return se.GetClient(ctx, component.KindReceiver, componentID, "")
+	sortIDs(sameType)
+
+	for _, id := range sameType {
+		if id.Name() == self.Name() {
+			se, ok := exts[id].(storage.Extension)
+			if !ok {
+				return nil, component.ID{}, "", fmt.Errorf("extension %q is not a storage extension", id)
+			}
+			return se, id, "instance-name match", nil
+		}
+	}
+	if len(sameType) == 1 {
+		se, ok := exts[sameType[0]].(storage.Extension)
+		if !ok {
+			return nil, component.ID{}, "", fmt.Errorf("extension %q is not a storage extension", sameType[0])
+		}
+		return se, sameType[0], "unique type match", nil
+	}
+	if len(sameType) > 1 {
+		return nil, component.ID{}, "", fmt.Errorf("storage extension %q is ambiguous: matches [%s]; use an explicit type/name reference", configured, strings.Join(idStrings(sameType), ", "))
+	}
+	return nil, component.ID{}, "", fmt.Errorf("storage extension %q not found%s", configured, availableStorageHint(exts))
+}
+
+// autoBindStorageExtension returns the storage-capable extensions whose
+// instance name equals the receiver's own. Under Fleet-managed configurations
+// every component declared in a policy stream shares one instance-name suffix,
+// so such an extension was necessarily declared alongside this receiver; a
+// package template can therefore enable cursor persistence by declaring a
+// storage extension without any receiver-body reference (which Fleet cannot
+// rewrite). Unnamed receivers (the standalone shape) never auto-bind — they
+// keep requiring an explicit storage reference.
+func autoBindStorageExtension(host component.Host, self component.ID) []component.ID {
+	if self.Name() == "" {
+		return nil
+	}
+	var candidates []component.ID
+	for id, ext := range host.GetExtensions() {
+		if id.Name() != self.Name() {
+			continue
+		}
+		if _, ok := ext.(storage.Extension); !ok {
+			continue
+		}
+		candidates = append(candidates, id)
+	}
+	sortIDs(candidates)
+	return candidates
+}
+
+// availableStorageHint renders the storage-capable extension IDs present on
+// the host for not-found error messages.
+func availableStorageHint(exts map[component.ID]component.Component) string {
+	var ids []component.ID
+	for id, ext := range exts {
+		if _, ok := ext.(storage.Extension); ok {
+			ids = append(ids, id)
+		}
+	}
+	if len(ids) == 0 {
+		return " (no storage extensions are available)"
+	}
+	sortIDs(ids)
+	return fmt.Sprintf(" (available storage extensions: [%s])", strings.Join(idStrings(ids), ", "))
+}
+
+func sortIDs(ids []component.ID) {
+	slices.SortFunc(ids, func(a, b component.ID) int {
+		return strings.Compare(a.String(), b.String())
+	})
+}
+
+func idStrings(ids []component.ID) []string {
+	out := make([]string, len(ids))
+	for i, id := range ids {
+		out[i] = id.String()
+	}
+	return out
 }

--- a/receiver/akamaisiemreceiver/storage_resolution_test.go
+++ b/receiver/akamaisiemreceiver/storage_resolution_test.go
@@ -1,0 +1,328 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package akamaisiemreceiver
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configopaque"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/receiver"
+	"go.opentelemetry.io/collector/receiver/receivertest"
+)
+
+// Tests in this file cover storage-extension resolution (explicit `storage:`
+// references with Fleet-suffix fallback) and instance-name auto-bind (no
+// `storage:` configured). Fleet-managed configurations rename every component
+// declared in a policy stream to <type>/<stream-suffix> without rewriting the
+// receiver's storage reference; the resolver reconstructs that binding.
+
+// mockHostWithExtensions builds a component.Host exposing an arbitrary
+// extension map, unlike mockHost which hardcodes an unnamed file_storage.
+func mockHostWithExtensions(exts map[component.ID]component.Component) component.Host {
+	return &mockHostImpl{extensions: exts}
+}
+
+// nonStorageExtension is a component that does NOT implement storage.Extension.
+type nonStorageExtension struct {
+	component.StartFunc
+	component.ShutdownFunc
+}
+
+// storageTestServer returns a mock Akamai SIEM endpoint serving one event so
+// a poll completes and the cursor is persisted.
+func storageTestServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprintln(w, `{"httpMessage":{"start":"1000","host":"test.com","status":"200"}}`)
+		_, _ = fmt.Fprintln(w, `{"offset":"resolution-test-offset","total":1,"limit":10000}`)
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func storageTestConfig(endpoint string) *Config {
+	cfg := createDefaultConfig().(*Config)
+	cfg.HTTP.Endpoint = endpoint
+	cfg.ConfigIDs = "1"
+	cfg.Authentication = EdgeGridAuth{
+		ClientToken:  configopaque.String("ct"),
+		ClientSecret: configopaque.String("cs"),
+		AccessToken:  configopaque.String("at"),
+	}
+	cfg.PollInterval = 24 * time.Hour
+	return cfg
+}
+
+// namedSettings returns receiver settings with a deterministic instance name.
+// NewNopSettings assigns a random UUID name, so tests must override it: an
+// empty name yields the standalone shape, a non-empty one the Fleet shape.
+func namedSettings(name string) receiver.Settings {
+	set := receivertest.NewNopSettings(NewFactory().Type())
+	if name == "" {
+		set.ID = component.MustNewID("akamai_siem")
+	} else {
+		set.ID = component.MustNewIDWithName("akamai_siem", name)
+	}
+	return set
+}
+
+// runUntilFirstPoll starts the receiver, waits for one event, and shuts it
+// down. Shutdown waits for the poll goroutine, so cursor persistence (or its
+// absence) is deterministic afterwards.
+func runUntilFirstPoll(t *testing.T, cfg *Config, set receiver.Settings, host component.Host) {
+	t.Helper()
+	sink := &consumertest.LogsSink{}
+	rcv, err := NewFactory().CreateLogs(context.Background(), set, cfg, sink)
+	require.NoError(t, err)
+	require.NoError(t, rcv.Start(context.Background(), host))
+	require.Eventually(t, func() bool { return sink.LogRecordCount() >= 1 }, 5*time.Second, 50*time.Millisecond)
+	require.NoError(t, rcv.Shutdown(context.Background()))
+}
+
+// startExpectingError asserts that Start fails and returns the error.
+func startExpectingError(t *testing.T, cfg *Config, set receiver.Settings, host component.Host) error {
+	t.Helper()
+	rcv, err := NewFactory().CreateLogs(context.Background(), set, cfg, &consumertest.LogsSink{})
+	require.NoError(t, err)
+	err = rcv.Start(context.Background(), host)
+	require.Error(t, err)
+	return err
+}
+
+func cursorBytes(t *testing.T, client *memStorageClient) []byte {
+	t.Helper()
+	data, err := client.Get(context.Background(), "akamai_siem_cursor")
+	require.NoError(t, err)
+	return data
+}
+
+// Bare reference, host has only the suffixed instance whose name matches the
+// receiver's own (the Fleet-managed shape) → resolves via instance-name match.
+func TestStorageResolution_BareRef_InstanceNameMatch(t *testing.T) {
+	server := storageTestServer(t)
+	memClient := newMemStorageClient()
+	host := mockHostWithExtensions(map[component.ID]component.Component{
+		component.MustNewIDWithName("file_storage", "policy-suffix"): &mockStorageExtension{client: memClient},
+	})
+
+	cfg := storageTestConfig(server.URL)
+	storageID := component.MustNewID("file_storage")
+	cfg.StorageID = &storageID
+
+	runUntilFirstPoll(t, cfg, namedSettings("policy-suffix"), host)
+	require.NotNil(t, cursorBytes(t, memClient), "cursor should persist via instance-name-matched extension")
+}
+
+// Bare reference, single same-type extension with a different instance name →
+// resolves via unique type match.
+func TestStorageResolution_BareRef_UniqueTypeMatch(t *testing.T) {
+	server := storageTestServer(t)
+	memClient := newMemStorageClient()
+	host := mockHostWithExtensions(map[component.ID]component.Component{
+		component.MustNewIDWithName("file_storage", "other"): &mockStorageExtension{client: memClient},
+	})
+
+	cfg := storageTestConfig(server.URL)
+	storageID := component.MustNewID("file_storage")
+	cfg.StorageID = &storageID
+
+	runUntilFirstPoll(t, cfg, namedSettings("policy-suffix"), host)
+	require.NotNil(t, cursorBytes(t, memClient), "cursor should persist via unique-type-matched extension")
+}
+
+// Bare reference, two same-type extensions, one matching the receiver's
+// instance name → instance-name match beats ambiguity.
+func TestStorageResolution_BareRef_NameBeatsAmbiguity(t *testing.T) {
+	server := storageTestServer(t)
+	memA := newMemStorageClient()
+	memB := newMemStorageClient()
+	host := mockHostWithExtensions(map[component.ID]component.Component{
+		component.MustNewIDWithName("file_storage", "a"): &mockStorageExtension{client: memA},
+		component.MustNewIDWithName("file_storage", "b"): &mockStorageExtension{client: memB},
+	})
+
+	cfg := storageTestConfig(server.URL)
+	storageID := component.MustNewID("file_storage")
+	cfg.StorageID = &storageID
+
+	runUntilFirstPoll(t, cfg, namedSettings("b"), host)
+	require.NotNil(t, cursorBytes(t, memB), "cursor should persist to the name-matched extension")
+	assert.Nil(t, cursorBytes(t, memA), "non-matching extension must stay untouched")
+}
+
+// Bare reference, two same-type extensions, neither matching the receiver's
+// instance name → Start fails listing both candidates.
+func TestStorageResolution_BareRef_Ambiguous(t *testing.T) {
+	host := mockHostWithExtensions(map[component.ID]component.Component{
+		component.MustNewIDWithName("file_storage", "a"): &mockStorageExtension{client: newMemStorageClient()},
+		component.MustNewIDWithName("file_storage", "b"): &mockStorageExtension{client: newMemStorageClient()},
+	})
+
+	cfg := storageTestConfig("http://localhost:0")
+	storageID := component.MustNewID("file_storage")
+	cfg.StorageID = &storageID
+
+	err := startExpectingError(t, cfg, namedSettings("c"), host)
+	assert.Contains(t, err.Error(), "ambiguous")
+	assert.Contains(t, err.Error(), "file_storage/a")
+	assert.Contains(t, err.Error(), "file_storage/b")
+}
+
+// Explicitly named reference that is missing → hard error, no fallback to
+// other instances of the same type.
+func TestStorageResolution_NamedRef_NoFallback(t *testing.T) {
+	host := mockHostWithExtensions(map[component.ID]component.Component{
+		component.MustNewIDWithName("file_storage", "bar"): &mockStorageExtension{client: newMemStorageClient()},
+	})
+
+	cfg := storageTestConfig("http://localhost:0")
+	storageID := component.MustNewIDWithName("file_storage", "foo")
+	cfg.StorageID = &storageID
+
+	err := startExpectingError(t, cfg, namedSettings("bar"), host)
+	assert.Contains(t, err.Error(), `storage extension "file_storage/foo" not found`)
+	assert.Contains(t, err.Error(), "file_storage/bar", "error should list available storage extensions")
+}
+
+// Bare reference with no storage extensions on the host → Start fails.
+func TestStorageResolution_BareRef_NoStorageExtensions(t *testing.T) {
+	host := mockHostWithExtensions(map[component.ID]component.Component{})
+
+	cfg := storageTestConfig("http://localhost:0")
+	storageID := component.MustNewID("file_storage")
+	cfg.StorageID = &storageID
+
+	err := startExpectingError(t, cfg, namedSettings("policy-suffix"), host)
+	assert.Contains(t, err.Error(), `storage extension "file_storage" not found`)
+	assert.Contains(t, err.Error(), "no storage extensions are available")
+}
+
+// A same-type component that does not implement storage.Extension keeps
+// today's "not a storage extension" error on every explicit-ref path.
+func TestStorageResolution_NotAStorageExtension(t *testing.T) {
+	cfg := storageTestConfig("http://localhost:0")
+	storageID := component.MustNewID("file_storage")
+	cfg.StorageID = &storageID
+
+	t.Run("exact match", func(t *testing.T) {
+		host := mockHostWithExtensions(map[component.ID]component.Component{
+			component.MustNewID("file_storage"): &nonStorageExtension{},
+		})
+		err := startExpectingError(t, cfg, namedSettings("policy-suffix"), host)
+		assert.Contains(t, err.Error(), `extension "file_storage" is not a storage extension`)
+	})
+
+	t.Run("instance-name match", func(t *testing.T) {
+		host := mockHostWithExtensions(map[component.ID]component.Component{
+			component.MustNewIDWithName("file_storage", "policy-suffix"): &nonStorageExtension{},
+		})
+		err := startExpectingError(t, cfg, namedSettings("policy-suffix"), host)
+		assert.Contains(t, err.Error(), `extension "file_storage/policy-suffix" is not a storage extension`)
+	})
+}
+
+// No storage configured, named receiver, one storage-capable extension with
+// the same instance name → auto-binds and the cursor survives a stop/start
+// cycle through that extension.
+func TestAutoBind_InstanceNameMatch(t *testing.T) {
+	server := storageTestServer(t)
+	memClient := newMemStorageClient()
+	host := mockHostWithExtensions(map[component.ID]component.Component{
+		component.MustNewIDWithName("file_storage", "sfx"): &mockStorageExtension{client: memClient},
+	})
+
+	cfg := storageTestConfig(server.URL)
+	require.Nil(t, cfg.StorageID)
+
+	set := namedSettings("sfx")
+	runUntilFirstPoll(t, cfg, set, host)
+	first := cursorBytes(t, memClient)
+	require.NotNil(t, first, "cursor should persist via auto-bound extension")
+
+	// Second instance binds to the same store and starts from the persisted
+	// cursor rather than a fresh initial_lookback window.
+	runUntilFirstPoll(t, cfg, set, host)
+	require.NotNil(t, cursorBytes(t, memClient), "cursor should survive the stop/start cycle")
+}
+
+// No storage configured, named receiver, the only storage extension has a
+// different instance name → starts without persistence.
+func TestAutoBind_NoMatch_RunsUnpersisted(t *testing.T) {
+	server := storageTestServer(t)
+	memClient := newMemStorageClient()
+	host := mockHostWithExtensions(map[component.ID]component.Component{
+		component.MustNewIDWithName("file_storage", "other"): &mockStorageExtension{client: memClient},
+	})
+
+	cfg := storageTestConfig(server.URL)
+	runUntilFirstPoll(t, cfg, namedSettings("sfx"), host)
+	assert.Nil(t, cursorBytes(t, memClient), "non-matching extension must not be auto-bound")
+}
+
+// Regression guard: an UNNAMED receiver next to an unnamed file_storage must
+// NOT auto-bind — standalone behavior is unchanged and an explicit storage
+// reference stays required.
+func TestAutoBind_UnnamedReceiver_NoBind(t *testing.T) {
+	server := storageTestServer(t)
+	memClient := newMemStorageClient()
+	host := mockHostWithExtensions(map[component.ID]component.Component{
+		component.MustNewID("file_storage"): &mockStorageExtension{client: memClient},
+	})
+
+	cfg := storageTestConfig(server.URL)
+	runUntilFirstPoll(t, cfg, namedSettings(""), host)
+	assert.Nil(t, cursorBytes(t, memClient), "unnamed receivers must never auto-bind")
+}
+
+// Two storage-capable extensions share the receiver's instance name → ambiguous,
+// run without persistence (a config without `storage:` must never fail).
+func TestAutoBind_MultipleCandidates_RunsUnpersisted(t *testing.T) {
+	server := storageTestServer(t)
+	memA := newMemStorageClient()
+	memB := newMemStorageClient()
+	host := mockHostWithExtensions(map[component.ID]component.Component{
+		component.MustNewIDWithName("file_storage", "sfx"):  &mockStorageExtension{client: memA},
+		component.MustNewIDWithName("other_storage", "sfx"): &mockStorageExtension{client: memB},
+	})
+
+	cfg := storageTestConfig(server.URL)
+	runUntilFirstPoll(t, cfg, namedSettings("sfx"), host)
+	assert.Nil(t, cursorBytes(t, memA), "ambiguous auto-bind must not persist")
+	assert.Nil(t, cursorBytes(t, memB), "ambiguous auto-bind must not persist")
+}
+
+// A non-storage extension sharing the receiver's instance name is ignored by
+// auto-bind.
+func TestAutoBind_NonStorageExtensionIgnored(t *testing.T) {
+	server := storageTestServer(t)
+	host := mockHostWithExtensions(map[component.ID]component.Component{
+		component.MustNewIDWithName("some_ext", "sfx"): &nonStorageExtension{},
+	})
+
+	cfg := storageTestConfig(server.URL)
+	runUntilFirstPoll(t, cfg, namedSettings("sfx"), host)
+}


### PR DESCRIPTION
## Proposed Commit Message
```
receiver/akamaisiemreceiver: resolve storage extensions renamed by Fleet

Fleet renames every component in a policy stream to
<type>/<stream-suffix> without rewriting the receiver's storage
reference, so a bare `storage: file_storage` dangles and Start fails.
Resolve bare references via instance-name match, then unique type
match; explicit type/name references never fall back. When storage is
unset, auto-bind a single storage-capable extension sharing the
receiver's instance name so integration packages can enable cursor
persistence by declaring the extension alone. Standalone (unnamed)
receivers are unchanged.
```

## Issues
 - Closes https://github.com/elastic/opentelemetry-collector-components/issues/1261 
 
 ## Local Testing

Everything was tested against a local 9.5.0-SNAPSHOT stack with the akamai
integration installed, polling a mock Akamai SIEM endpoint with real EdgeGrid
credentials.

### 1. Reproduce the bug

Before touching any code, we built a baseline binary from current source and ran it
with a config shaped exactly like Fleet's output: receiver and `file_storage` both
suffixed, receiver body still saying `storage: file_storage`. It fails the way a
Fleet-managed agent fails today:

```
Error: cannot start pipelines: ... storage extension "file_storage" not found
```

### 2. Verify the fix on the same config

The fixed binary starts cleanly on the byte-identical config and says how it healed
the reference:

```
info  resolved storage extension via instance-name match
      {"configured": "file_storage", "resolved": "file_storage/akamai-0a1b2c3d-siem_otel"}
```

The cursor file appears on disk and advances with every poll.

### 3. Test the shape the integration package will actually ship

Same config with no `storage:` line at all — the package template deliberately omits
it. The receiver logs `auto-bound storage extension declared in this stream`, and
after a kill-and-restart it logs `loaded persisted cursor` and picks up where it left
off instead of re-fetching the lookback window. The ambiguous case (two candidate
extensions, neither matching) fails with an error listing both, as intended.

### 4. Check against real Kibana

We installed the akamai package into the stack, enabled the otelcol input with
storage on, and pulled the policy Fleet actually renders. It confirmed everything the
fix relies on: receiver and extension share the identical suffix, the receiver body
carries no `storage:` key, and the `${env:STATE_PATH:-...}` directory expression
passes through untouched.

### 5. Prove it works inside a container

We built the collector Docker image from this branch and ran it with the real suffix
Kibana rendered in step 4. The state file showed up inside the container at
`/usr/share/elastic-agent/state`, survived `docker restart` (cursor loaded on the way
back up), and moved when `STATE_PATH` was overridden.

### 6. Unit tests

`storage_resolution_test.go` adds 13 cases covering every resolution and auto-bind
path, including the guard that an unnamed receiver never auto-binds — so the
standalone behavior stays exactly as documented. `go test`, `go vet`, and `make lint`
are clean.
