### PR TITLE
Fix otelbench multi-arch image publishing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,6 +2,8 @@
 * @elastic/otel-devs
 
 # Per-component owners
+.github/workflows/bump_otelbench.yaml    @elastic/obs-ds-intake-services @elastic/obs-ds-hosted-services
+.github/workflows/changelog_otelbench.yaml @elastic/obs-ds-intake-services @elastic/obs-ds-hosted-services
 .github/workflows/release_otelbench.yaml @elastic/obs-ds-intake-services @elastic/obs-ds-hosted-services
 internal/elasticattr                   @elastic/obs-ds-intake-services @elastic/obs-ds-hosted-services @elastic/ingest-otel-data
 loadgen                                @elastic/obs-ds-intake-services @elastic/obs-ds-hosted-services @elastic/ingest-otel-data

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,6 +2,7 @@
 * @elastic/otel-devs
 
 # Per-component owners
+.github/workflows/release_otelbench.yaml @elastic/obs-ds-intake-services @elastic/obs-ds-hosted-services
 internal/elasticattr                   @elastic/obs-ds-intake-services @elastic/obs-ds-hosted-services @elastic/ingest-otel-data
 loadgen                                @elastic/obs-ds-intake-services @elastic/obs-ds-hosted-services @elastic/ingest-otel-data
 receiver/loadgenreceiver               @elastic/obs-ds-intake-services @elastic/obs-ds-hosted-services @elastic/ingest-otel-data

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,9 +2,9 @@
 * @elastic/otel-devs
 
 # Per-component owners
-.github/workflows/bump_otelbench.yaml    @elastic/obs-ds-intake-services @elastic/obs-ds-hosted-services
+.github/workflows/bump_otelbench.yaml      @elastic/obs-ds-intake-services @elastic/obs-ds-hosted-services
 .github/workflows/changelog_otelbench.yaml @elastic/obs-ds-intake-services @elastic/obs-ds-hosted-services
-.github/workflows/release_otelbench.yaml @elastic/obs-ds-intake-services @elastic/obs-ds-hosted-services
+.github/workflows/release_otelbench.yaml   @elastic/obs-ds-intake-services @elastic/obs-ds-hosted-services
 internal/elasticattr                   @elastic/obs-ds-intake-services @elastic/obs-ds-hosted-services @elastic/ingest-otel-data
 loadgen                                @elastic/obs-ds-intake-services @elastic/obs-ds-hosted-services @elastic/ingest-otel-data
 receiver/loadgenreceiver               @elastic/obs-ds-intake-services @elastic/obs-ds-hosted-services @elastic/ingest-otel-data

--- a/.github/workflows/release_otelbench.yaml
+++ b/.github/workflows/release_otelbench.yaml
@@ -20,9 +20,6 @@ jobs:
       contents: write
     env:
       ELASTIC_REGISTRY: "docker.elastic.co/observability-ci/otelbench"
-    strategy:
-      matrix:
-        platform: ["linux/amd64", "linux/arm64"] 
     steps:
       - uses: actions/checkout@v6
 
@@ -45,4 +42,4 @@ jobs:
         working-directory: ./loadgen/cmd/otelbench
         run: |
           export KO_DOCKER_REPO=${{ env.ELASTIC_REGISTRY }}
-          ko build --bare --platform=${{ matrix.platform }} --tags ${{ env.OTELBENCH_VERSION }}
+          ko build --bare --platform=linux/amd64,linux/arm64 --tags ${{ env.OTELBENCH_VERSION }}


### PR DESCRIPTION
Currently, the release workflow builds `linux/amd64` and `linux/arm64` in separate matrix jobs, but both jobs push the same tag, `v0.8.0`:

```yaml
matrix:
  platform: ["linux/amd64", "linux/arm64"]

ko build --bare --platform=${{ matrix.platform }} --tags ${{ env.OTELBENCH_VERSION }}
```

That does not publish one multi-arch manifest. It publishes the same tag twice. Whichever matrix job pushes last owns `docker.elastic.co/observability-ci/otelbench:v0.8.0`.

This PR fixes that to support both architectures.