### PR TITLE
[bug]Fix incorrect handling of datstream attributes

### DIFF
--- a/processor/elasticapmprocessor/internal/routing/data_stream.go
+++ b/processor/elasticapmprocessor/internal/routing/data_stream.go
@@ -35,7 +35,7 @@ const (
 
 	ServiceNameAttributeKey = "service.name"
 
-	NamespaceDefault = "default" //TODO: make this configurable
+	NamespaceDefault = "default"
 
 	ServiceNameUnknownAttributeUnknonw = "unknown"
 )
@@ -52,7 +52,9 @@ func encodeDataStreamDefault(resource pcommon.Resource, dataStreamType string) {
 	attributes := resource.Attributes()
 	attributes.PutStr(elasticattr.DataStreamType, dataStreamType)
 	attributes.PutStr(elasticattr.DataStreamDataset, "apm")
-	attributes.PutStr(elasticattr.DataStreamNamespace, NamespaceDefault)
+	if _, exists := attributes.Get(elasticattr.DataStreamNamespace); !exists {
+		attributes.PutStr(elasticattr.DataStreamNamespace, NamespaceDefault)
+	}
 }
 
 func encodeDataStreamWithServiceName(resource pcommon.Resource, dataStreamType string) {
@@ -65,7 +67,9 @@ func encodeDataStreamWithServiceName(resource pcommon.Resource, dataStreamType s
 
 	attributes.PutStr(elasticattr.DataStreamType, dataStreamType)
 	attributes.PutStr(elasticattr.DataStreamDataset, "apm.app."+normalizeServiceName(serviceName.Str()))
-	attributes.PutStr(elasticattr.DataStreamNamespace, NamespaceDefault)
+	if _, exists := attributes.Get(elasticattr.DataStreamNamespace); !exists {
+		attributes.PutStr(elasticattr.DataStreamNamespace, NamespaceDefault)
+	}
 }
 
 // IsErrorEvent checks if a log record or span event represents an APM error event.
@@ -96,7 +100,9 @@ func IsErrorEvent(attributes pcommon.Map) bool {
 func EncodeErrorDataStream(attributes pcommon.Map, dataStreamType string) {
 	attributes.PutStr(elasticattr.DataStreamType, dataStreamType)
 	attributes.PutStr(elasticattr.DataStreamDataset, "apm.error")
-	attributes.PutStr(elasticattr.DataStreamNamespace, NamespaceDefault)
+	if _, exists := attributes.Get(elasticattr.DataStreamNamespace); !exists {
+		attributes.PutStr(elasticattr.DataStreamNamespace, NamespaceDefault)
+	}
 }
 
 // hasTransactionSpanContext checks if the attributes contain transaction or span context.
@@ -151,14 +157,18 @@ func isServiceSummary(attributes pcommon.Map) bool {
 func internalMetricDataStream(attributes pcommon.Map, dataStreamType string) {
 	attributes.PutStr(elasticattr.DataStreamType, dataStreamType)
 	attributes.PutStr(elasticattr.DataStreamDataset, "apm.internal")
-	attributes.PutStr(elasticattr.DataStreamNamespace, NamespaceDefault)
+	if _, exists := attributes.Get(elasticattr.DataStreamNamespace); !exists {
+		attributes.PutStr(elasticattr.DataStreamNamespace, NamespaceDefault)
+	}
 }
 
 // Data stream formatted as: apm.${metricset.name}.${metricset.interval}
 func internalIntervalMetricDataStream(attributes pcommon.Map, dataStreamType, metricsetName, interval string) {
 	attributes.PutStr(elasticattr.DataStreamType, dataStreamType)
 	attributes.PutStr(elasticattr.DataStreamDataset, fmt.Sprintf("apm.%s.%s", metricsetName, interval))
-	attributes.PutStr(elasticattr.DataStreamNamespace, NamespaceDefault)
+	if _, exists := attributes.Get(elasticattr.DataStreamNamespace); !exists {
+		attributes.PutStr(elasticattr.DataStreamNamespace, NamespaceDefault)
+	}
 }
 
 // EncodeDataStreamMetricDataPoint determines if the metric represents an internal metric

--- a/processor/elasticapmprocessor/internal/routing/data_stream_test.go
+++ b/processor/elasticapmprocessor/internal/routing/data_stream_test.go
@@ -294,21 +294,108 @@ func TestIsErrorEvent(t *testing.T) {
 	}
 }
 
-func TestEncodeErrorDataStream(t *testing.T) {
-	attrs := pcommon.NewMap()
-	routing.EncodeErrorDataStream(attrs, "logs")
+func TestDataStreamEncodersNamespaceBehavior(t *testing.T) {
+	tests := []struct {
+		name              string
+		run               func() pcommon.Map
+		expectedType      string
+		expectedDataset   string
+		expectedNamespace string
+	}{
+		{
+			name: "EncodeDataStream preserves namespace without service name dataset",
+			run: func() pcommon.Map {
+				resource := pcommon.NewResource()
+				attributes := resource.Attributes()
+				attributes.PutStr("data_stream.namespace", "custom-ns")
+				routing.EncodeDataStream(resource, "traces", false)
+				return attributes
+			},
+			expectedType:      "traces",
+			expectedDataset:   "apm",
+			expectedNamespace: "custom-ns",
+		},
+		{
+			name: "EncodeDataStream preserves namespace with service name dataset",
+			run: func() pcommon.Map {
+				resource := pcommon.NewResource()
+				attributes := resource.Attributes()
+				attributes.PutStr("service.name", "my-svc")
+				attributes.PutStr("data_stream.namespace", "prod")
+				routing.EncodeDataStream(resource, "logs", true)
+				return attributes
+			},
+			expectedType:      "logs",
+			expectedDataset:   "apm.app.my_svc",
+			expectedNamespace: "prod",
+		},
+		{
+			name: "EncodeErrorDataStream preserves namespace",
+			run: func() pcommon.Map {
+				attributes := pcommon.NewMap()
+				attributes.PutStr("data_stream.namespace", "staging")
+				routing.EncodeErrorDataStream(attributes, "logs")
+				return attributes
+			},
+			expectedType:      "logs",
+			expectedDataset:   "apm.error",
+			expectedNamespace: "staging",
+		},
+		{
+			name: "EncodeDataStream defaults namespace without service name dataset",
+			run: func() pcommon.Map {
+				resource := pcommon.NewResource()
+				attributes := resource.Attributes()
+				routing.EncodeDataStream(resource, "traces", false)
+				return attributes
+			},
+			expectedType:      "traces",
+			expectedDataset:   "apm",
+			expectedNamespace: "default",
+		},
+		{
+			name: "EncodeDataStream defaults namespace with service name dataset",
+			run: func() pcommon.Map {
+				resource := pcommon.NewResource()
+				attributes := resource.Attributes()
+				attributes.PutStr("service.name", "my-svc")
+				routing.EncodeDataStream(resource, "logs", true)
+				return attributes
+			},
+			expectedType:      "logs",
+			expectedDataset:   "apm.app.my_svc",
+			expectedNamespace: "default",
+		},
+		{
+			name: "EncodeErrorDataStream defaults namespace",
+			run: func() pcommon.Map {
+				attributes := pcommon.NewMap()
+				routing.EncodeErrorDataStream(attributes, "logs")
+				return attributes
+			},
+			expectedType:      "logs",
+			expectedDataset:   "apm.error",
+			expectedNamespace: "default",
+		},
+	}
 
-	dataStreamType, ok := attrs.Get("data_stream.type")
-	assert.True(t, ok)
-	assert.Equal(t, "logs", dataStreamType.Str())
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			attributes := tt.run()
 
-	dataStreamDataset, ok := attrs.Get("data_stream.dataset")
-	assert.True(t, ok)
-	assert.Equal(t, "apm.error", dataStreamDataset.Str())
+			dataStreamType, ok := attributes.Get("data_stream.type")
+			assert.True(t, ok)
+			assert.Equal(t, tt.expectedType, dataStreamType.Str())
 
-	dataStreamNamespace, ok := attrs.Get("data_stream.namespace")
-	assert.True(t, ok)
-	assert.Equal(t, "default", dataStreamNamespace.Str())
+			dataStreamDataset, ok := attributes.Get("data_stream.dataset")
+			assert.True(t, ok)
+			assert.Equal(t, tt.expectedDataset, dataStreamDataset.Str())
+
+			dataStreamNamespace, ok := attributes.Get("data_stream.namespace")
+			assert.True(t, ok)
+			assert.Equal(t, tt.expectedNamespace, dataStreamNamespace.Str())
+		})
+	}
 }
 
 func TestRouteMetricDataPoint(t *testing.T) {

--- a/processor/elasticapmprocessor/processor_test.go
+++ b/processor/elasticapmprocessor/processor_test.go
@@ -1331,13 +1331,13 @@ func TestECSMappingModeTriggersDataStreamRouting(t *testing.T) {
 	type consumeFn func(t *testing.T, ctx context.Context, factory processor.Factory, settings processor.Settings, cfg *Config) pcommon.Map
 
 	tests := []struct {
-		name               string
-		consume            consumeFn
-		mappingMode        string
-		expectedType       string
-		expectedDataset    string
-		expectedNamespace  string
-		expectDataStream   bool
+		name              string
+		consume           consumeFn
+		mappingMode       string
+		expectedType      string
+		expectedDataset   string
+		expectedNamespace string
+		expectDataStream  bool
 	}{
 		{
 			name:              "traces with ecs mapping mode",
@@ -1349,10 +1349,10 @@ func TestECSMappingModeTriggersDataStreamRouting(t *testing.T) {
 			expectDataStream:  true,
 		},
 		{
-			name:             "traces without mapping mode",
-			consume:          consumeTraceResourceAttrs,
+			name:              "traces without mapping mode",
+			consume:           consumeTraceResourceAttrs,
 			expectedNamespace: "custom-ns",
-			expectDataStream: false,
+			expectDataStream:  false,
 		},
 		{
 			name:              "logs with ecs mapping mode",
@@ -1364,10 +1364,10 @@ func TestECSMappingModeTriggersDataStreamRouting(t *testing.T) {
 			expectDataStream:  true,
 		},
 		{
-			name:             "logs without mapping mode",
-			consume:          consumeLogResourceAttrs,
+			name:              "logs without mapping mode",
+			consume:           consumeLogResourceAttrs,
 			expectedNamespace: "custom-ns",
-			expectDataStream: false,
+			expectDataStream:  false,
 		},
 		{
 			name:              "metrics with ecs mapping mode",
@@ -1379,10 +1379,10 @@ func TestECSMappingModeTriggersDataStreamRouting(t *testing.T) {
 			expectDataStream:  true,
 		},
 		{
-			name:             "metrics without mapping mode",
-			consume:          consumeMetricResourceAttrs,
+			name:              "metrics without mapping mode",
+			consume:           consumeMetricResourceAttrs,
 			expectedNamespace: "custom-ns",
-			expectDataStream: false,
+			expectDataStream:  false,
 		},
 	}
 

--- a/processor/elasticapmprocessor/processor_test.go
+++ b/processor/elasticapmprocessor/processor_test.go
@@ -1326,3 +1326,161 @@ func TestIsIntakeECS(t *testing.T) {
 		})
 	}
 }
+
+func TestECSMappingModeTriggersDataStreamRouting(t *testing.T) {
+	type consumeFn func(t *testing.T, ctx context.Context, factory processor.Factory, settings processor.Settings, cfg *Config) pcommon.Map
+
+	tests := []struct {
+		name               string
+		consume            consumeFn
+		mappingMode        string
+		expectedType       string
+		expectedDataset    string
+		expectedNamespace  string
+		expectDataStream   bool
+	}{
+		{
+			name:              "traces with ecs mapping mode",
+			consume:           consumeTraceResourceAttrs,
+			mappingMode:       "ecs",
+			expectedType:      "traces",
+			expectedDataset:   "apm",
+			expectedNamespace: "custom-ns",
+			expectDataStream:  true,
+		},
+		{
+			name:             "traces without mapping mode",
+			consume:          consumeTraceResourceAttrs,
+			expectedNamespace: "custom-ns",
+			expectDataStream: false,
+		},
+		{
+			name:              "logs with ecs mapping mode",
+			consume:           consumeLogResourceAttrs,
+			mappingMode:       "ecs",
+			expectedType:      "logs",
+			expectedDataset:   "apm",
+			expectedNamespace: "custom-ns",
+			expectDataStream:  true,
+		},
+		{
+			name:             "logs without mapping mode",
+			consume:          consumeLogResourceAttrs,
+			expectedNamespace: "custom-ns",
+			expectDataStream: false,
+		},
+		{
+			name:              "metrics with ecs mapping mode",
+			consume:           consumeMetricResourceAttrs,
+			mappingMode:       "ecs",
+			expectedType:      "metrics",
+			expectedDataset:   "apm",
+			expectedNamespace: "custom-ns",
+			expectDataStream:  true,
+		},
+		{
+			name:             "metrics without mapping mode",
+			consume:          consumeMetricResourceAttrs,
+			expectedNamespace: "custom-ns",
+			expectDataStream: false,
+		},
+	}
+
+	factory := NewFactory()
+	settings := processortest.NewNopSettings(metadata.Type)
+	cfg := NewDefaultConfig().(*Config)
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			if tc.mappingMode != "" {
+				ctx = client.NewContext(ctx, client.Info{
+					Metadata: client.NewMetadata(map[string][]string{
+						"x-elastic-mapping-mode": {tc.mappingMode},
+					}),
+				})
+			}
+
+			attrs := tc.consume(t, ctx, factory, settings, cfg)
+			dataStreamType, hasType := attrs.Get("data_stream.type")
+			dataStreamDataset, hasDataset := attrs.Get("data_stream.dataset")
+			dataStreamNamespace, hasNamespace := attrs.Get("data_stream.namespace")
+			require.True(t, hasNamespace)
+			assert.Equal(t, tc.expectedNamespace, dataStreamNamespace.Str())
+
+			if tc.expectDataStream {
+				require.True(t, hasType)
+				require.True(t, hasDataset)
+				assert.Equal(t, tc.expectedType, dataStreamType.Str())
+				assert.Equal(t, tc.expectedDataset, dataStreamDataset.Str())
+				return
+			}
+
+			assert.False(t, hasType)
+			assert.False(t, hasDataset)
+		})
+	}
+}
+
+func consumeTraceResourceAttrs(t *testing.T, ctx context.Context, factory processor.Factory, settings processor.Settings, cfg *Config) pcommon.Map {
+	t.Helper()
+
+	next := &consumertest.TracesSink{}
+	tp, err := factory.CreateTraces(ctx, settings, cfg, next)
+	require.NoError(t, err)
+
+	traces := ptrace.NewTraces()
+	resourceSpan := traces.ResourceSpans().AppendEmpty()
+	resource := resourceSpan.Resource()
+	resource.Attributes().PutStr("service.name", "test-service")
+	resource.Attributes().PutStr("data_stream.namespace", "custom-ns")
+	resource.Attributes().PutStr(string(semconv.TelemetrySDKNameKey), "opentelemetry")
+	scopeSpans := resourceSpan.ScopeSpans().AppendEmpty()
+	span := scopeSpans.Spans().AppendEmpty()
+	span.SetName("test-span")
+	span.SetStartTimestamp(pcommon.Timestamp(1_000_000_000))
+	span.SetEndTimestamp(pcommon.Timestamp(2_000_000_000))
+
+	require.NoError(t, tp.ConsumeTraces(ctx, traces))
+	return next.AllTraces()[0].ResourceSpans().At(0).Resource().Attributes()
+}
+
+func consumeLogResourceAttrs(t *testing.T, ctx context.Context, factory processor.Factory, settings processor.Settings, cfg *Config) pcommon.Map {
+	t.Helper()
+
+	next := &consumertest.LogsSink{}
+	lp, err := factory.CreateLogs(ctx, settings, cfg, next)
+	require.NoError(t, err)
+
+	logs := plog.NewLogs()
+	resourceLog := logs.ResourceLogs().AppendEmpty()
+	resource := resourceLog.Resource()
+	resource.Attributes().PutStr("service.name", "test-service")
+	resource.Attributes().PutStr("data_stream.namespace", "custom-ns")
+	resource.Attributes().PutStr(string(semconv.TelemetrySDKNameKey), "opentelemetry")
+	resourceLog.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty().Body().SetStr("test-log")
+
+	require.NoError(t, lp.ConsumeLogs(ctx, logs))
+	return next.AllLogs()[0].ResourceLogs().At(0).Resource().Attributes()
+}
+
+func consumeMetricResourceAttrs(t *testing.T, ctx context.Context, factory processor.Factory, settings processor.Settings, cfg *Config) pcommon.Map {
+	t.Helper()
+
+	next := &consumertest.MetricsSink{}
+	mp, err := factory.CreateMetrics(ctx, settings, cfg, next)
+	require.NoError(t, err)
+
+	metrics := pmetric.NewMetrics()
+	resourceMetric := metrics.ResourceMetrics().AppendEmpty()
+	resource := resourceMetric.Resource()
+	resource.Attributes().PutStr("service.name", "test-service")
+	resource.Attributes().PutStr("data_stream.namespace", "custom-ns")
+	resource.Attributes().PutStr(string(semconv.TelemetrySDKNameKey), "opentelemetry")
+	metric := resourceMetric.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+	metric.SetName("custom.metric")
+	metric.SetEmptyGauge().DataPoints().AppendEmpty().SetIntValue(1)
+
+	require.NoError(t, mp.ConsumeMetrics(ctx, metrics))
+	return next.AllMetrics()[0].ResourceMetrics().At(0).Resource().Attributes()
+}


### PR DESCRIPTION
Datastream attributes were not handled by the elasticapm processor. Note that this only affects OTel data coming via `.apm` endpoint as the non-otel data (intake-v2) has no concept of overriding datstream attributes.

Related to: https://github.com/elastic/hosted-otel-collector/issues/3324