### PR TITLE
Fix incorrect example config in awscredentialsproviderextension README

### DIFF
--- a/extension/awscredentialsproviderextension/README.md
+++ b/extension/awscredentialsproviderextension/README.md
@@ -56,24 +56,19 @@ service:
 ## Consuming the extension from a component
 
 Components resolve the extension from the host at start and type-assert it to the
-`awsCredentialsProvider` interface (importing this package, or declaring a structurally
-identical local interface to avoid the module dependency):
+`Provider` interface (importing this package, or declaring a structurally identical
+local interface to avoid the module dependency):
 
 ```go
-// resolveCredentialsProvider returns the credentials provider from the
-// awscredentialsprovider extension referenced by id, or nil when none is configured.
-func resolveCredentialsProvider(host component.Host, id *component.ID) (aws.CredentialsProvider, error) {
-    if id == nil {
-        return nil, nil
-    }
-    ext, ok := host.GetExtensions()[*id]
-    if !ok {
-        return nil, fmt.Errorf("unknown credentials_provider extension %q", id)
-    }
-    provider, ok := ext.(awsCredentialsProvider)
-    if !ok {
-        return nil, fmt.Errorf("extension %q does not provide AWS credentials", id)
-    }
-    return provider.GetCredentialsProvider(), nil
+ext, ok := host.GetExtensions()[cfg.CredentialsProvider]
+if !ok {
+    return fmt.Errorf("unknown credentials_provider extension %q", cfg.CredentialsProvider)
 }
+provider, ok := ext.(interface {
+    GetCredentialsProvider() aws.CredentialsProvider
+})
+if !ok {
+    return fmt.Errorf("extension %q does not provide AWS credentials", cfg.CredentialsProvider)
+}
+awsCfg.Credentials = provider.GetCredentialsProvider()
 ```

--- a/extension/awscredentialsproviderextension/README.md
+++ b/extension/awscredentialsproviderextension/README.md
@@ -56,19 +56,24 @@ service:
 ## Consuming the extension from a component
 
 Components resolve the extension from the host at start and type-assert it to the
-`Provider` interface (importing this package, or declaring a structurally identical
-local interface to avoid the module dependency):
+`awsCredentialsProvider` interface (importing this package, or declaring a structurally
+identical local interface to avoid the module dependency):
 
 ```go
-ext, ok := host.GetExtensions()[cfg.Auth]
-if !ok {
-    return fmt.Errorf("unknown auth extension %q", cfg.Auth)
+// resolveCredentialsProvider returns the credentials provider from the
+// awscredentialsprovider extension referenced by id, or nil when none is configured.
+func resolveCredentialsProvider(host component.Host, id *component.ID) (aws.CredentialsProvider, error) {
+    if id == nil {
+        return nil, nil
+    }
+    ext, ok := host.GetExtensions()[*id]
+    if !ok {
+        return nil, fmt.Errorf("unknown credentials_provider extension %q", id)
+    }
+    provider, ok := ext.(awsCredentialsProvider)
+    if !ok {
+        return nil, fmt.Errorf("extension %q does not provide AWS credentials", id)
+    }
+    return provider.GetCredentialsProvider(), nil
 }
-provider, ok := ext.(interface {
-    GetCredentialsProvider() aws.CredentialsProvider
-})
-if !ok {
-    return fmt.Errorf("extension %q is not an AWS credentials provider", cfg.Auth)
-}
-awsCfg.Credentials = provider.GetCredentialsProvider()
 ```

--- a/extension/awscredentialsproviderextension/README.md
+++ b/extension/awscredentialsproviderextension/README.md
@@ -60,6 +60,10 @@ Components resolve the extension from the host at start and type-assert it to th
 local interface to avoid the module dependency):
 
 ```go
+if cfg.CredentialsProvider == (component.ID{}) {
+    // no extension configured; AWS SDK default credential chain applies
+    return nil
+}
 ext, ok := host.GetExtensions()[cfg.CredentialsProvider]
 if !ok {
     return fmt.Errorf("unknown credentials_provider extension %q", cfg.CredentialsProvider)

--- a/extension/awscredentialsproviderextension/README.md
+++ b/extension/awscredentialsproviderextension/README.md
@@ -46,7 +46,7 @@ extensions:
 receivers:
   awscloudwatch:
     region: us-west-2
-    auth: awscredentialsprovider
+    credentials_provider: awscredentialsprovider
     ...
 
 service:


### PR DESCRIPTION
## What

The [example config](https://github.com/elastic/opentelemetry-collector-components/tree/main/extension/awscredentialsproviderextension#example) referenced the extension under `auth:` on the receiver. The correct receiver-side setting is `credentials_provider` (see the [awscloudwatch receiver docs](https://github.com/elastic/opentelemetry-collector-contrib/tree/0.153.0/receiver/awscloudwatchreceiver#top-level-parameters)).

This changes the example to use `credentials_provider:`.

Fixes #1279

🤖 Generated with [Claude Code](https://claude.com/claude-code)