### PR TITLE
[bug]Refactor and fix data_stream attribute handling

### DIFF
--- a/processor/elasticapmprocessor/internal/ecs/ecs_translation.go
+++ b/processor/elasticapmprocessor/internal/ecs/ecs_translation.go
@@ -241,6 +241,7 @@ func TranslateResourceMetadata(resource pcommon.Resource, sanitizeExistingLabels
 		context.K8SPodUID != "" ||
 		context.K8SNamespaceName != "" {
 		// kubernetes.* is set but kubernetes.node.name is not: don't set host.hostname
+		context.HostHostName = ""
 		attributes.Remove(elasticattr.HostHostName)
 	}
 	// Mirror host.hostname into host.name when host.name is missing so downstream

--- a/processor/elasticapmprocessor/internal/ecs/ecs_translation.go
+++ b/processor/elasticapmprocessor/internal/ecs/ecs_translation.go
@@ -43,6 +43,21 @@ type kv struct {
 	v pcommon.Value
 }
 
+// ResourceAttrContext is collected while translating resource attributes and
+// reused by data stream routing.
+type ResourceAttrContext struct {
+	ServiceName         string
+	HostName            string
+	HostHostName        string
+	K8SNodeName         string
+	K8SPodName          string
+	K8SPodUID           string
+	K8SNamespaceName    string
+	DataStreamType      string
+	DataStreamDataset   string
+	DataStreamNamespace string
+}
+
 // TranslateResourceMetadata normalizes resource attributes.
 // Moves unsupported attributes to labels.* / numeric_labels.* (key sanitized),
 // and leaves supported ECS attributes unchanged.
@@ -53,11 +68,51 @@ type kv struct {
 // When false (OTel path), all unsupported attributes — including any that
 // already carry a labels.* prefix — are treated as raw keys and re-normalized
 // from scratch.
-func TranslateResourceMetadata(resource pcommon.Resource, sanitizeExistingLabels bool) {
+//
+// It also applies resource-level conventions (for example host.hostname
+// derivation from kubernetes metadata) and returns the resulting
+// ResourceAttrContext.
+func TranslateResourceMetadata(resource pcommon.Resource, sanitizeExistingLabels bool) ResourceAttrContext {
 	attributes := resource.Attributes()
+	var context ResourceAttrContext
 	var toAppend []kv
 	attributes.RemoveIf(func(k string, v pcommon.Value) bool {
 		switch k {
+		case elasticattr.DataStreamType:
+			context.DataStreamType = v.Str()
+			return false
+		case elasticattr.DataStreamDataset:
+			context.DataStreamDataset = v.Str()
+			return false
+		case elasticattr.DataStreamNamespace:
+			context.DataStreamNamespace = v.Str()
+			return false
+		case elasticattr.HostHostName:
+			context.HostHostName = v.Str()
+			return false
+		case string(semconv.ServiceNameKey):
+			context.ServiceName = v.Str()
+			return false
+		case string(semconv.HostNameKey):
+			truncatePreservedStringAttribute(v)
+			context.HostName = v.Str()
+			return false
+		case string(semconv.K8SNodeNameKey):
+			truncatePreservedStringAttribute(v)
+			context.K8SNodeName = v.Str()
+			return false
+		case string(semconv.K8SPodNameKey):
+			truncatePreservedStringAttribute(v)
+			context.K8SPodName = v.Str()
+			return false
+		case string(semconv.K8SPodUIDKey):
+			truncatePreservedStringAttribute(v)
+			context.K8SPodUID = v.Str()
+			return false
+		case string(semconv.K8SNamespaceNameKey):
+			truncatePreservedStringAttribute(v)
+			context.K8SNamespaceName = v.Str()
+			return false
 		case elasticattr.AgentActivationMethod,
 			elasticattr.AgentEphemeralID,
 			elasticattr.AgentName,
@@ -72,13 +127,9 @@ func TranslateResourceMetadata(resource pcommon.Resource, sanitizeExistingLabels
 			elasticattr.CloudOriginServiceName,
 			elasticattr.CloudProjectID,
 			elasticattr.CloudProjectName,
-			elasticattr.DataStreamDataset,
-			elasticattr.DataStreamNamespace,
-			elasticattr.DataStreamType,
 			elasticattr.DestinationIP,
 			elasticattr.FaaSExecution,
 			elasticattr.FaaSTriggerRequestID,
-			elasticattr.HostHostName,
 			elasticattr.HostOSType,
 			elasticattr.MetricsetName,
 			elasticattr.ServiceFrameworkName,
@@ -108,7 +159,6 @@ func TranslateResourceMetadata(resource pcommon.Resource, sanitizeExistingLabels
 			string(semconv.ProcessExecutableNameKey),
 			string(semconv.ProcessParentPIDKey),
 			string(semconv.ProcessPIDKey),
-			string(semconv.ServiceNameKey),
 			string(semconv.ServiceNamespaceKey),
 			string(semconv.SourceAddressKey),
 			string(semconv.SourcePortKey),
@@ -139,12 +189,7 @@ func TranslateResourceMetadata(resource pcommon.Resource, sanitizeExistingLabels
 			string(semconv.DeviceModelNameKey),
 			string(semconv.HostArchKey),
 			string(semconv.HostIDKey),
-			string(semconv.HostNameKey),
 			string(semconv.HostTypeKey),
-			string(semconv.K8SNamespaceNameKey),
-			string(semconv.K8SNodeNameKey),
-			string(semconv.K8SPodNameKey),
-			string(semconv.K8SPodUIDKey),
 			string(semconv.OSDescriptionKey),
 			string(semconv.OSNameKey),
 			string(semconv.OSTypeKey),
@@ -185,6 +230,26 @@ func TranslateResourceMetadata(resource pcommon.Resource, sanitizeExistingLabels
 	for _, l := range toAppend {
 		l.v.CopyTo(attributes.PutEmpty(l.k))
 	}
+
+	// set host.name and host.hostname
+	if context.K8SNodeName != "" {
+		// Keep legacy MIS/APM-server hostname behavior for kubernetes workloads:
+		// when node.name is present, host.hostname must resolve to the node name.
+		context.HostHostName = context.K8SNodeName
+		attributes.PutStr(elasticattr.HostHostName, context.K8SNodeName)
+	} else if context.K8SPodName != "" ||
+		context.K8SPodUID != "" ||
+		context.K8SNamespaceName != "" {
+		// kubernetes.* is set but kubernetes.node.name is not: don't set host.hostname
+		attributes.Remove(elasticattr.HostHostName)
+	}
+	// Mirror host.hostname into host.name when host.name is missing so downstream
+	// enrichment and routing keep the same fallback semantics as before.
+	if context.HostName == "" && context.HostHostName != "" {
+		context.HostName = context.HostHostName
+		attributes.PutStr(string(semconv.HostNameKey), context.HostHostName)
+	}
+	return context
 }
 
 // RemapLogRecordAttributesToECSLabels applies the apm-data OTLP fallback behaviour for
@@ -448,37 +513,6 @@ func getLabelAttributeValue(key string, value pcommon.Value) kv {
 		// apm-data's setLabel also silently drops these types.
 	}
 	return kv{}
-}
-
-func ApplyResourceConventions(resource pcommon.Resource) {
-	setHostnameFromKubernetes(resource)
-}
-
-// setHostnameFromKubernetes sets the host.hostname attribute based on kubernetes attributes for backwards compatibility with MIS and APM Server.
-func setHostnameFromKubernetes(resource pcommon.Resource) {
-	attrs := resource.Attributes()
-
-	hostName, hostNameExists := attrs.Get(string(semconv.HostNameKey))
-	k8sNodeName, k8sNodeNameExists := attrs.Get(string(semconv.K8SNodeNameKey))
-	k8sPodName, k8sPodNameExists := attrs.Get(string(semconv.K8SPodNameKey))
-	k8sPodUID, k8sPodUIDExists := attrs.Get(string(semconv.K8SPodUIDKey))
-	k8sNamespace, k8sNamespaceExists := attrs.Get(string(semconv.K8SNamespaceNameKey))
-
-	if k8sNodeNameExists && k8sNodeName.Str() != "" {
-		// kubernetes.node.name is set: set host.hostname to its value
-		attrs.PutStr(elasticattr.HostHostName, k8sNodeName.Str())
-	} else if (k8sPodNameExists && k8sPodName.Str() != "") ||
-		(k8sPodUIDExists && k8sPodUID.Str() != "") ||
-		(k8sNamespaceExists && k8sNamespace.Str() != "") {
-		// kubernetes.* is set but kubernetes.node.name is not: don't set host.hostname
-		attrs.Remove(elasticattr.HostHostName)
-	}
-
-	// If host.name is not set but host.hostname is, use hostname as name
-	hostHostname, hostHostnameExists := attrs.Get(elasticattr.HostHostName)
-	if (!hostNameExists || hostName.Str() == "") && hostHostnameExists && hostHostname.Str() != "" {
-		attrs.PutStr(string(semconv.HostNameKey), hostHostname.Str())
-	}
 }
 
 // sanitizeExistingLabelKey sanitizes reserved characters from the suffix of a

--- a/processor/elasticapmprocessor/internal/ecs/ecs_translation_test.go
+++ b/processor/elasticapmprocessor/internal/ecs/ecs_translation_test.go
@@ -965,7 +965,8 @@ func TestGetLabelAttributeValue(t *testing.T) {
 		})
 	}
 }
-func TestApplyResourceConventions(t *testing.T) {
+
+func TestTranslateResourceMetadataAppliesHostnameConventions(t *testing.T) {
 	testdata := map[string]struct {
 		inputAttrs    map[string]string
 		expectedAttrs map[string]string
@@ -1027,6 +1028,15 @@ func TestApplyResourceConventions(t *testing.T) {
 				"host.hostname": "host.hostname",
 			},
 		},
+		"host.name and host.hostname conventions": {
+			inputAttrs: map[string]string{
+				string(semconv.K8SNodeNameKey): "node-1",
+			},
+			expectedAttrs: map[string]string{
+				elasticattr.HostHostName:    "node-1",
+				string(semconv.HostNameKey): "node-1",
+			},
+		},
 	}
 
 	for _, td := range testdata {
@@ -1036,7 +1046,7 @@ func TestApplyResourceConventions(t *testing.T) {
 			attrs.PutStr(k, v)
 		}
 
-		ApplyResourceConventions(resource)
+		TranslateResourceMetadata(resource, false)
 
 		for k, expectedV := range td.expectedAttrs {
 			actualV, ok := attrs.Get(k)

--- a/processor/elasticapmprocessor/internal/enrichments/enricher.go
+++ b/processor/elasticapmprocessor/internal/enrichments/enricher.go
@@ -129,9 +129,8 @@ func ecsAPMConfig(cfg config.Config) config.Config {
 // resource. This is common across all signal types (traces, logs, metrics)
 // in ECS mode.
 func ecsPreProcessResource(ctx context.Context, resource pcommon.Resource, dataStreamType string, serviceNameInDataStreamDataset bool, hostIPEnabled bool, sanitizeExistingLabels bool) {
-	ecs.TranslateResourceMetadata(resource, sanitizeExistingLabels)
-	ecs.ApplyResourceConventions(resource)
-	routing.EncodeDataStream(resource, dataStreamType, serviceNameInDataStreamDataset)
+	resourceContext := ecs.TranslateResourceMetadata(resource, sanitizeExistingLabels)
+	routing.EncodeDataStream(resource, dataStreamType, serviceNameInDataStreamDataset, resourceContext)
 	if hostIPEnabled {
 		ecs.SetHostIP(ctx, resource.Attributes())
 	}

--- a/processor/elasticapmprocessor/internal/enrichments/metric_enricher.go
+++ b/processor/elasticapmprocessor/internal/enrichments/metric_enricher.go
@@ -21,6 +21,7 @@ import (
 	"context"
 
 	"go.opentelemetry.io/collector/pdata/pmetric"
+	semconv "go.opentelemetry.io/otel/semconv/v1.27.0"
 
 	"github.com/elastic/opentelemetry-collector-components/processor/elasticapmprocessor/internal/enrichments/config"
 	"github.com/elastic/opentelemetry-collector-components/processor/elasticapmprocessor/internal/routing"
@@ -46,7 +47,7 @@ func (e *ecsMetricEnricher) enrichResourceMetrics(ctx context.Context, rm pmetri
 
 	// Check if resource has a service name for routing decisions
 	hasServiceName := false
-	if serviceName, ok := resource.Attributes().Get(routing.ServiceNameAttributeKey); ok && serviceName.Str() != "" {
+	if serviceName, ok := resource.Attributes().Get(string(semconv.ServiceNameKey)); ok && serviceName.Str() != "" {
 		hasServiceName = true
 	}
 

--- a/processor/elasticapmprocessor/internal/routing/data_stream.go
+++ b/processor/elasticapmprocessor/internal/routing/data_stream.go
@@ -19,10 +19,12 @@ package routing // import "github.com/elastic/opentelemetry-collector-components
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/elastic/apm-data/model/modelprocessor"
 	"github.com/elastic/opentelemetry-collector-components/internal/elasticattr"
+	"github.com/elastic/opentelemetry-collector-components/processor/elasticapmprocessor/internal/ecs"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	semconv "go.opentelemetry.io/otel/semconv/v1.38.0"
 )
@@ -33,42 +35,26 @@ const (
 	DataStreamTypeMetrics = "metrics"
 	DataStreamTypeTraces  = "traces"
 
-	ServiceNameAttributeKey = "service.name"
-
 	NamespaceDefault = "default"
-
-	ServiceNameUnknownAttributeUnknonw = "unknown"
 )
 
-func EncodeDataStream(resource pcommon.Resource, dataStreamType string, serviceNameInDataset bool) {
-	if serviceNameInDataset {
-		encodeDataStreamWithServiceName(resource, dataStreamType)
-	} else {
-		encodeDataStreamDefault(resource, dataStreamType)
-	}
-}
-
-func encodeDataStreamDefault(resource pcommon.Resource, dataStreamType string) {
+func EncodeDataStream(resource pcommon.Resource, dataStreamType string, svcInDataset bool, resCtx ecs.ResourceAttrContext) {
 	attributes := resource.Attributes()
 	attributes.PutStr(elasticattr.DataStreamType, dataStreamType)
-	attributes.PutStr(elasticattr.DataStreamDataset, "apm")
-	if _, exists := attributes.Get(elasticattr.DataStreamNamespace); !exists {
+	if resCtx.DataStreamNamespace == "" {
 		attributes.PutStr(elasticattr.DataStreamNamespace, NamespaceDefault)
 	}
-}
-
-func encodeDataStreamWithServiceName(resource pcommon.Resource, dataStreamType string) {
-	attributes := resource.Attributes()
-
-	serviceName, ok := attributes.Get(ServiceNameAttributeKey)
-	if !ok || serviceName.Str() == "" {
-		serviceName = pcommon.NewValueStr(ServiceNameUnknownAttributeUnknonw)
-	}
-
-	attributes.PutStr(elasticattr.DataStreamType, dataStreamType)
-	attributes.PutStr(elasticattr.DataStreamDataset, "apm.app."+normalizeServiceName(serviceName.Str()))
-	if _, exists := attributes.Get(elasticattr.DataStreamNamespace); !exists {
-		attributes.PutStr(elasticattr.DataStreamNamespace, NamespaceDefault)
+	if resCtx.DataStreamDataset == "" {
+		dataset := "apm"
+		if svcInDataset {
+			// derive service name for encoding in dataset
+			serviceName := "unknown"
+			if resCtx.ServiceName != "" {
+				serviceName = resCtx.ServiceName
+			}
+			dataset = "apm.app." + normalizeServiceName(serviceName)
+		}
+		attributes.PutStr(elasticattr.DataStreamDataset, dataset)
 	}
 }
 
@@ -100,9 +86,40 @@ func IsErrorEvent(attributes pcommon.Map) bool {
 func EncodeErrorDataStream(attributes pcommon.Map, dataStreamType string) {
 	attributes.PutStr(elasticattr.DataStreamType, dataStreamType)
 	attributes.PutStr(elasticattr.DataStreamDataset, "apm.error")
-	if _, exists := attributes.Get(elasticattr.DataStreamNamespace); !exists {
+	if isStrKeyInAttributes(attributes, elasticattr.DataStreamNamespace) {
 		attributes.PutStr(elasticattr.DataStreamNamespace, NamespaceDefault)
 	}
+}
+
+// EncodeDataStreamMetricDataPoint determines if the metric represents an internal metric
+// and sets the appropriate data stream for a metric data point.
+// This implements the routing logic from apm-data's metricsetDataset function.
+// Returns true if the metric is routed to an internal data stream, false otherwise.
+func EncodeDataStreamMetricDataPoint(attributes pcommon.Map, metricName string, hasServiceName bool) bool {
+	// Check for special cases: transaction/span context, no service name, or service_summary
+	if hasTransactionSpanContext(attributes) || !hasServiceName || isServiceSummary(attributes) {
+		// Check if there's a metricset interval for interval-based routing
+		interval := getMetricsetInterval(attributes)
+		if interval != "" {
+			metricsetName := getMetricsetName(attributes)
+			if metricsetName == "" {
+				// Fallback to a generic name if metricset.name is missing
+				metricsetName = "metrics"
+			}
+			internalIntervalMetricDataStream(attributes, DataStreamTypeMetrics, metricsetName, interval)
+		} else {
+			internalMetricDataStream(attributes, DataStreamTypeMetrics)
+		}
+		return true
+	}
+
+	// Check if the metric name is recognized as an internal metric using apm-data conventions
+	if modelprocessor.IsInternalMetricName(metricName) && !isOTelRemapped(attributes) {
+		internalMetricDataStream(attributes, DataStreamTypeMetrics)
+		return true
+	}
+
+	return false
 }
 
 // hasTransactionSpanContext checks if the attributes contain transaction or span context.
@@ -157,7 +174,7 @@ func isServiceSummary(attributes pcommon.Map) bool {
 func internalMetricDataStream(attributes pcommon.Map, dataStreamType string) {
 	attributes.PutStr(elasticattr.DataStreamType, dataStreamType)
 	attributes.PutStr(elasticattr.DataStreamDataset, "apm.internal")
-	if _, exists := attributes.Get(elasticattr.DataStreamNamespace); !exists {
+	if isStrKeyInAttributes(attributes, elasticattr.DataStreamNamespace) {
 		attributes.PutStr(elasticattr.DataStreamNamespace, NamespaceDefault)
 	}
 }
@@ -166,15 +183,11 @@ func internalMetricDataStream(attributes pcommon.Map, dataStreamType string) {
 func internalIntervalMetricDataStream(attributes pcommon.Map, dataStreamType, metricsetName, interval string) {
 	attributes.PutStr(elasticattr.DataStreamType, dataStreamType)
 	attributes.PutStr(elasticattr.DataStreamDataset, fmt.Sprintf("apm.%s.%s", metricsetName, interval))
-	if _, exists := attributes.Get(elasticattr.DataStreamNamespace); !exists {
+	if isStrKeyInAttributes(attributes, elasticattr.DataStreamNamespace) {
 		attributes.PutStr(elasticattr.DataStreamNamespace, NamespaceDefault)
 	}
 }
 
-// EncodeDataStreamMetricDataPoint determines if the metric represents an internal metric
-// and sets the appropriate data stream for a metric data point.
-// This implements the routing logic from apm-data's metricsetDataset function.
-// Returns true if the metric is routed to an internal data stream, false otherwise.
 func normalizeServiceName(s string) string {
 	s = strings.ToLower(s)
 	return strings.Map(func(r rune) rune {
@@ -186,29 +199,25 @@ func normalizeServiceName(s string) string {
 	}, s)
 }
 
-func EncodeDataStreamMetricDataPoint(attributes pcommon.Map, metricName string, hasServiceName bool) bool {
-	// Check for special cases: transaction/span context, no service name, or service_summary
-	if hasTransactionSpanContext(attributes) || !hasServiceName || isServiceSummary(attributes) {
-		// Check if there's a metricset interval for interval-based routing
-		interval := getMetricsetInterval(attributes)
-		if interval != "" {
-			metricsetName := getMetricsetName(attributes)
-			if metricsetName == "" {
-				// Fallback to a generic name if metricset.name is missing
-				metricsetName = "metrics"
+func isOTelRemapped(attributes pcommon.Map) bool {
+	for _, key := range []string{"otel_remapped", "labels.otel_remapped"} {
+		if value, ok := attributes.Get(key); ok {
+			switch value.Type() {
+			case pcommon.ValueTypeBool:
+				if value.Bool() {
+					return true
+				}
+			case pcommon.ValueTypeStr:
+				if remapped, err := strconv.ParseBool(value.Str()); err == nil && remapped {
+					return true
+				}
 			}
-			internalIntervalMetricDataStream(attributes, DataStreamTypeMetrics, metricsetName, interval)
-		} else {
-			internalMetricDataStream(attributes, DataStreamTypeMetrics)
 		}
-		return true
 	}
-
-	// Check if the metric name is recognized as an internal metric using apm-data conventions
-	if modelprocessor.IsInternalMetricName(metricName) {
-		internalMetricDataStream(attributes, DataStreamTypeMetrics)
-		return true
-	}
-
 	return false
+}
+
+func isStrKeyInAttributes(attributes pcommon.Map, key string) bool {
+	value, exists := attributes.Get(key)
+	return !exists || (value.Type() == pcommon.ValueTypeStr && value.Str() == "")
 }

--- a/processor/elasticapmprocessor/internal/routing/data_stream_test.go
+++ b/processor/elasticapmprocessor/internal/routing/data_stream_test.go
@@ -20,195 +20,12 @@ package routing_test
 import (
 	"testing"
 
+	"github.com/elastic/opentelemetry-collector-components/processor/elasticapmprocessor/internal/ecs"
 	"github.com/elastic/opentelemetry-collector-components/processor/elasticapmprocessor/internal/routing"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	semconv "go.opentelemetry.io/otel/semconv/v1.38.0"
 )
-
-func TestDataStremaEncoderDefault(t *testing.T) {
-	resource := pcommon.NewResource()
-	routing.EncodeDataStream(resource, "logs", false)
-
-	attributes := resource.Attributes()
-
-	dataStreamType, ok := attributes.Get("data_stream.type")
-	assert.True(t, ok)
-	assert.Equal(t, "logs", dataStreamType.Str())
-
-	dataStreamDataset, ok := attributes.Get("data_stream.dataset")
-	assert.True(t, ok)
-	assert.Equal(t, "apm", dataStreamDataset.Str())
-
-	dataStreamNamespace, ok := attributes.Get("data_stream.namespace")
-	assert.True(t, ok)
-	assert.Equal(t, "default", dataStreamNamespace.Str())
-}
-
-func TestEncodeDataStreamWithServiceName(t *testing.T) {
-	// The normalizeServiceName function lowercases the input and then applies
-	// the regex [^a-zA-Z0-9_] to replace disallowed characters with "_".
-	// This aligns with apm-data's normalizeServiceName: hyphens, spaces,
-	// dots, and all other non-alphanumeric/non-underscore characters are
-	// replaced with "_".
-	tests := []struct {
-		name            string
-		serviceName     string
-		dataStreamType  string
-		expectedDataset string
-	}{
-		{
-			name:            "simple alphanumeric",
-			serviceName:     "myservice",
-			dataStreamType:  "metrics",
-			expectedDataset: "apm.app.myservice",
-		},
-		{
-			name:            "hyphen replaced",
-			serviceName:     "my-service",
-			dataStreamType:  "metrics",
-			expectedDataset: "apm.app.my_service",
-		},
-		{
-			name:            "dot replaced",
-			serviceName:     "my.service",
-			dataStreamType:  "metrics",
-			expectedDataset: "apm.app.my_service",
-		},
-		{
-			name:            "uppercase lowercased with hyphen replaced",
-			serviceName:     "My-Service",
-			dataStreamType:  "logs",
-			expectedDataset: "apm.app.my_service",
-		},
-		{
-			name:            "backslash replaced",
-			serviceName:     `my\service`,
-			dataStreamType:  "metrics",
-			expectedDataset: "apm.app.my_service",
-		},
-		{
-			name:            "forward slash replaced",
-			serviceName:     "my/service",
-			dataStreamType:  "metrics",
-			expectedDataset: "apm.app.my_service",
-		},
-		{
-			name:            "asterisk replaced",
-			serviceName:     "my*service",
-			dataStreamType:  "metrics",
-			expectedDataset: "apm.app.my_service",
-		},
-		{
-			name:            "question mark replaced",
-			serviceName:     "my?service",
-			dataStreamType:  "metrics",
-			expectedDataset: "apm.app.my_service",
-		},
-		{
-			name:            "double quote replaced",
-			serviceName:     `my"service`,
-			dataStreamType:  "metrics",
-			expectedDataset: "apm.app.my_service",
-		},
-		{
-			name:            "angle brackets replaced",
-			serviceName:     "my<service>name",
-			dataStreamType:  "metrics",
-			expectedDataset: "apm.app.my_service_name",
-		},
-		{
-			name:            "pipe replaced",
-			serviceName:     "my|service",
-			dataStreamType:  "metrics",
-			expectedDataset: "apm.app.my_service",
-		},
-		{
-			name:            "space replaced",
-			serviceName:     "my service",
-			dataStreamType:  "metrics",
-			expectedDataset: "apm.app.my_service",
-		},
-		{
-			name:            "comma replaced",
-			serviceName:     "my,service",
-			dataStreamType:  "metrics",
-			expectedDataset: "apm.app.my_service",
-		},
-		{
-			name:            "hash replaced",
-			serviceName:     "my#service",
-			dataStreamType:  "metrics",
-			expectedDataset: "apm.app.my_service",
-		},
-		{
-			name:            "colon replaced",
-			serviceName:     "my:service",
-			dataStreamType:  "metrics",
-			expectedDataset: "apm.app.my_service",
-		},
-		{
-			name:            "multiple special characters",
-			serviceName:     "My Service.v2-beta/rc#1",
-			dataStreamType:  "logs",
-			expectedDataset: "apm.app.my_service_v2_beta_rc_1",
-		},
-		{
-			name:            "all disallowed characters replaced",
-			serviceName:     `a\b/c*d?e"f<g>h|i,j#k:l.m`,
-			dataStreamType:  "metrics",
-			expectedDataset: "apm.app.a_b_c_d_e_f_g_h_i_j_k_l_m",
-		},
-		{
-			name:            "only alphanumeric and underscore preserved",
-			serviceName:     `a b-c_d0`,
-			dataStreamType:  "metrics",
-			expectedDataset: "apm.app.a_b_c_d0",
-		},
-		{
-			name:            "empty service name falls back to unknown",
-			serviceName:     "",
-			dataStreamType:  "metrics",
-			expectedDataset: "apm.app.unknown",
-		},
-		{
-			name:            "underscores preserved",
-			serviceName:     "my_service_name",
-			dataStreamType:  "metrics",
-			expectedDataset: "apm.app.my_service_name",
-		},
-		{
-			name:            "traces type",
-			serviceName:     "my-service",
-			dataStreamType:  "traces",
-			expectedDataset: "apm.app.my_service",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			resource := pcommon.NewResource()
-			attributes := resource.Attributes()
-			if tt.serviceName != "" {
-				attributes.PutStr("service.name", tt.serviceName)
-			}
-
-			routing.EncodeDataStream(resource, tt.dataStreamType, true)
-
-			dataStreamType, ok := attributes.Get("data_stream.type")
-			assert.True(t, ok)
-			assert.Equal(t, tt.dataStreamType, dataStreamType.Str())
-
-			dataStreamDataset, ok := attributes.Get("data_stream.dataset")
-			assert.True(t, ok)
-			assert.Equal(t, tt.expectedDataset, dataStreamDataset.Str())
-
-			dataStreamNamespace, ok := attributes.Get("data_stream.namespace")
-			assert.True(t, ok)
-			assert.Equal(t, "default", dataStreamNamespace.Str())
-		})
-	}
-}
 
 func TestIsErrorEvent(t *testing.T) {
 	tests := []struct {
@@ -294,106 +111,348 @@ func TestIsErrorEvent(t *testing.T) {
 	}
 }
 
-func TestDataStreamEncodersNamespaceBehavior(t *testing.T) {
+func TestDataStreamEncoders(t *testing.T) {
 	tests := []struct {
-		name              string
-		run               func() pcommon.Map
-		expectedType      string
-		expectedDataset   string
-		expectedNamespace string
+		name                string
+		attrs               map[string]any
+		svcInDataset        bool
+		isErrorEncode       bool
+		expectedType        string
+		expectedDataset     string
+		expectedNamespace   string
+		expectedServiceName string
 	}{
 		{
-			name: "EncodeDataStream preserves namespace without service name dataset",
-			run: func() pcommon.Map {
-				resource := pcommon.NewResource()
-				attributes := resource.Attributes()
-				attributes.PutStr("data_stream.namespace", "custom-ns")
-				routing.EncodeDataStream(resource, "traces", false)
-				return attributes
-			},
+			name:              "EncodeDataStream default encoder behavior",
+			expectedType:      "logs",
+			expectedDataset:   "apm",
+			expectedNamespace: "default",
+		},
+		{
+			name:              "EncodeDataStream preserves namespace without service name dataset",
+			attrs:             map[string]any{"data_stream.namespace": "custom-ns"},
 			expectedType:      "traces",
 			expectedDataset:   "apm",
 			expectedNamespace: "custom-ns",
 		},
 		{
-			name: "EncodeDataStream preserves namespace with service name dataset",
-			run: func() pcommon.Map {
-				resource := pcommon.NewResource()
-				attributes := resource.Attributes()
-				attributes.PutStr("service.name", "my-svc")
-				attributes.PutStr("data_stream.namespace", "prod")
-				routing.EncodeDataStream(resource, "logs", true)
-				return attributes
-			},
-			expectedType:      "logs",
-			expectedDataset:   "apm.app.my_svc",
-			expectedNamespace: "prod",
+			name:                "EncodeDataStream preserves namespace with service name dataset",
+			attrs:               map[string]any{"service.name": "my-svc", "data_stream.namespace": "prod"},
+			svcInDataset:        true,
+			expectedType:        "logs",
+			expectedDataset:     "apm.app.my_svc",
+			expectedNamespace:   "prod",
+			expectedServiceName: "my-svc",
 		},
 		{
-			name: "EncodeErrorDataStream preserves namespace",
-			run: func() pcommon.Map {
-				attributes := pcommon.NewMap()
-				attributes.PutStr("data_stream.namespace", "staging")
-				routing.EncodeErrorDataStream(attributes, "logs")
-				return attributes
-			},
+			name:              "EncodeErrorDataStream preserves namespace",
+			attrs:             map[string]any{"data_stream.namespace": "staging"},
+			isErrorEncode:     true,
 			expectedType:      "logs",
 			expectedDataset:   "apm.error",
 			expectedNamespace: "staging",
 		},
 		{
-			name: "EncodeDataStream defaults namespace without service name dataset",
-			run: func() pcommon.Map {
-				resource := pcommon.NewResource()
-				attributes := resource.Attributes()
-				routing.EncodeDataStream(resource, "traces", false)
-				return attributes
-			},
+			name:              "EncodeDataStream preserves existing type and dataset when both are already set",
+			attrs:             map[string]any{"data_stream.type": "custom-type", "data_stream.dataset": "custom-dataset"},
+			expectedType:      "custom-type",
+			expectedDataset:   "custom-dataset",
+			expectedNamespace: "default",
+		},
+		{
+			name:              "EncodeDataStream overwrites existing type when dataset is missing",
+			attrs:             map[string]any{"data_stream.type": "custom-type"},
 			expectedType:      "traces",
 			expectedDataset:   "apm",
 			expectedNamespace: "default",
 		},
 		{
-			name: "EncodeDataStream defaults namespace with service name dataset",
-			run: func() pcommon.Map {
-				resource := pcommon.NewResource()
-				attributes := resource.Attributes()
-				attributes.PutStr("service.name", "my-svc")
-				routing.EncodeDataStream(resource, "logs", true)
-				return attributes
-			},
-			expectedType:      "logs",
-			expectedDataset:   "apm.app.my_svc",
+			name:              "EncodeDataStream preserves existing dataset without service name dataset",
+			attrs:             map[string]any{"data_stream.dataset": "custom-dataset"},
+			expectedType:      "traces",
+			expectedDataset:   "custom-dataset",
 			expectedNamespace: "default",
 		},
 		{
-			name: "EncodeErrorDataStream defaults namespace",
-			run: func() pcommon.Map {
-				attributes := pcommon.NewMap()
-				routing.EncodeErrorDataStream(attributes, "logs")
-				return attributes
-			},
+			name:                "EncodeDataStream preserves existing dataset with service name dataset",
+			attrs:               map[string]any{"service.name": "my-svc", "data_stream.dataset": "custom-logs"},
+			svcInDataset:        true,
+			expectedType:        "logs",
+			expectedDataset:     "custom-logs",
+			expectedNamespace:   "default",
+			expectedServiceName: "my-svc",
+		},
+		{
+			name:              "EncodeErrorDataStream always overwrites existing dataset",
+			attrs:             map[string]any{"data_stream.dataset": "something-else"},
+			isErrorEncode:     true,
 			expectedType:      "logs",
 			expectedDataset:   "apm.error",
 			expectedNamespace: "default",
+		},
+		{
+			name:              "EncodeDataStream defaults namespace without service name dataset",
+			expectedType:      "traces",
+			expectedDataset:   "apm",
+			expectedNamespace: "default",
+		},
+		{
+			name:                "EncodeDataStream defaults namespace with service name dataset",
+			attrs:               map[string]any{"service.name": "my-svc"},
+			svcInDataset:        true,
+			expectedType:        "logs",
+			expectedDataset:     "apm.app.my_svc",
+			expectedNamespace:   "default",
+			expectedServiceName: "my-svc",
+		},
+		{
+			name:              "EncodeErrorDataStream defaults namespace",
+			isErrorEncode:     true,
+			expectedType:      "logs",
+			expectedDataset:   "apm.error",
+			expectedNamespace: "default",
+		},
+		{
+			name:              "EncodeDataStream defaults dataset without service name dataset when absent",
+			expectedType:      "traces",
+			expectedDataset:   "apm",
+			expectedNamespace: "default",
+		},
+		{
+			name:                "EncodeDataStream defaults dataset with service name dataset when absent",
+			attrs:               map[string]any{"service.name": "my-svc"},
+			svcInDataset:        true,
+			expectedType:        "logs",
+			expectedDataset:     "apm.app.my_svc",
+			expectedNamespace:   "default",
+			expectedServiceName: "my-svc",
+		},
+		{
+			name:                "EncodeDataStream with service name simple alphanumeric",
+			attrs:               map[string]any{"service.name": "myservice"},
+			svcInDataset:        true,
+			expectedType:        "metrics",
+			expectedDataset:     "apm.app.myservice",
+			expectedNamespace:   "default",
+			expectedServiceName: "myservice",
+		},
+		{
+			name:                "EncodeDataStream with service name hyphen replaced",
+			attrs:               map[string]any{"service.name": "my-service"},
+			svcInDataset:        true,
+			expectedType:        "metrics",
+			expectedDataset:     "apm.app.my_service",
+			expectedNamespace:   "default",
+			expectedServiceName: "my-service",
+		},
+		{
+			name:                "EncodeDataStream with service name dot replaced",
+			attrs:               map[string]any{"service.name": "my.service"},
+			svcInDataset:        true,
+			expectedType:        "metrics",
+			expectedDataset:     "apm.app.my_service",
+			expectedNamespace:   "default",
+			expectedServiceName: "my.service",
+		},
+		{
+			name:                "EncodeDataStream with service name uppercase lowercased",
+			attrs:               map[string]any{"service.name": "My-Service"},
+			svcInDataset:        true,
+			expectedType:        "logs",
+			expectedDataset:     "apm.app.my_service",
+			expectedNamespace:   "default",
+			expectedServiceName: "My-Service",
+		},
+		{
+			name:                "EncodeDataStream with service name backslash replaced",
+			attrs:               map[string]any{"service.name": `my\service`},
+			svcInDataset:        true,
+			expectedType:        "metrics",
+			expectedDataset:     "apm.app.my_service",
+			expectedNamespace:   "default",
+			expectedServiceName: `my\service`,
+		},
+		{
+			name:                "EncodeDataStream with service name forward slash replaced",
+			attrs:               map[string]any{"service.name": "my/service"},
+			svcInDataset:        true,
+			expectedType:        "metrics",
+			expectedDataset:     "apm.app.my_service",
+			expectedNamespace:   "default",
+			expectedServiceName: "my/service",
+		},
+		{
+			name:                "EncodeDataStream with service name asterisk replaced",
+			attrs:               map[string]any{"service.name": "my*service"},
+			svcInDataset:        true,
+			expectedType:        "metrics",
+			expectedDataset:     "apm.app.my_service",
+			expectedNamespace:   "default",
+			expectedServiceName: "my*service",
+		},
+		{
+			name:                "EncodeDataStream with service name question mark replaced",
+			attrs:               map[string]any{"service.name": "my?service"},
+			svcInDataset:        true,
+			expectedType:        "metrics",
+			expectedDataset:     "apm.app.my_service",
+			expectedNamespace:   "default",
+			expectedServiceName: "my?service",
+		},
+		{
+			name:                "EncodeDataStream with service name double quote replaced",
+			attrs:               map[string]any{"service.name": `my"service`},
+			svcInDataset:        true,
+			expectedType:        "metrics",
+			expectedDataset:     "apm.app.my_service",
+			expectedNamespace:   "default",
+			expectedServiceName: `my"service`,
+		},
+		{
+			name:                "EncodeDataStream with service name angle brackets replaced",
+			attrs:               map[string]any{"service.name": "my<service>name"},
+			svcInDataset:        true,
+			expectedType:        "metrics",
+			expectedDataset:     "apm.app.my_service_name",
+			expectedNamespace:   "default",
+			expectedServiceName: "my<service>name",
+		},
+		{
+			name:                "EncodeDataStream with service name pipe replaced",
+			attrs:               map[string]any{"service.name": "my|service"},
+			svcInDataset:        true,
+			expectedType:        "metrics",
+			expectedDataset:     "apm.app.my_service",
+			expectedNamespace:   "default",
+			expectedServiceName: "my|service",
+		},
+		{
+			name:                "EncodeDataStream with service name space replaced",
+			attrs:               map[string]any{"service.name": "my service"},
+			svcInDataset:        true,
+			expectedType:        "metrics",
+			expectedDataset:     "apm.app.my_service",
+			expectedNamespace:   "default",
+			expectedServiceName: "my service",
+		},
+		{
+			name:                "EncodeDataStream with service name comma replaced",
+			attrs:               map[string]any{"service.name": "my,service"},
+			svcInDataset:        true,
+			expectedType:        "metrics",
+			expectedDataset:     "apm.app.my_service",
+			expectedNamespace:   "default",
+			expectedServiceName: "my,service",
+		},
+		{
+			name:                "EncodeDataStream with service name hash replaced",
+			attrs:               map[string]any{"service.name": "my#service"},
+			svcInDataset:        true,
+			expectedType:        "metrics",
+			expectedDataset:     "apm.app.my_service",
+			expectedNamespace:   "default",
+			expectedServiceName: "my#service",
+		},
+		{
+			name:                "EncodeDataStream with service name colon replaced",
+			attrs:               map[string]any{"service.name": "my:service"},
+			svcInDataset:        true,
+			expectedType:        "metrics",
+			expectedDataset:     "apm.app.my_service",
+			expectedNamespace:   "default",
+			expectedServiceName: "my:service",
+		},
+		{
+			name:                "EncodeDataStream with service name multiple special characters",
+			attrs:               map[string]any{"service.name": "My Service.v2-beta/rc#1"},
+			svcInDataset:        true,
+			expectedType:        "logs",
+			expectedDataset:     "apm.app.my_service_v2_beta_rc_1",
+			expectedNamespace:   "default",
+			expectedServiceName: "My Service.v2-beta/rc#1",
+		},
+		{
+			name:                "EncodeDataStream with service name all disallowed characters replaced",
+			attrs:               map[string]any{"service.name": `a\b/c*d?e"f<g>h|i,j#k:l.m`},
+			svcInDataset:        true,
+			expectedType:        "metrics",
+			expectedDataset:     "apm.app.a_b_c_d_e_f_g_h_i_j_k_l_m",
+			expectedNamespace:   "default",
+			expectedServiceName: `a\b/c*d?e"f<g>h|i,j#k:l.m`,
+		},
+		{
+			name:                "EncodeDataStream with service name alphanumeric and underscore preserved",
+			attrs:               map[string]any{"service.name": "a b-c_d0"},
+			svcInDataset:        true,
+			expectedType:        "metrics",
+			expectedDataset:     "apm.app.a_b_c_d0",
+			expectedNamespace:   "default",
+			expectedServiceName: "a b-c_d0",
+		},
+		{
+			name:              "EncodeDataStream with service name empty falls back to unknown",
+			svcInDataset:      true,
+			expectedType:      "metrics",
+			expectedDataset:   "apm.app.unknown",
+			expectedNamespace: "default",
+		},
+		{
+			name:                "EncodeDataStream with service name underscores preserved",
+			attrs:               map[string]any{"service.name": "my_service_name"},
+			svcInDataset:        true,
+			expectedType:        "metrics",
+			expectedDataset:     "apm.app.my_service_name",
+			expectedNamespace:   "default",
+			expectedServiceName: "my_service_name",
+		},
+		{
+			name:                "EncodeDataStream with service name traces type",
+			attrs:               map[string]any{"service.name": "my-service"},
+			svcInDataset:        true,
+			expectedType:        "traces",
+			expectedDataset:     "apm.app.my_service",
+			expectedNamespace:   "default",
+			expectedServiceName: "my-service",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			attributes := tt.run()
+			testResource := pcommon.NewResource()
+			if len(tt.attrs) > 0 {
+				assert.NoError(t, testResource.Attributes().FromRaw(tt.attrs))
+			}
 
-			dataStreamType, ok := attributes.Get("data_stream.type")
+			if tt.isErrorEncode {
+				routing.EncodeErrorDataStream(testResource.Attributes(), tt.expectedType)
+			} else {
+				routing.EncodeDataStream(
+					testResource,
+					tt.expectedType,
+					tt.svcInDataset,
+					ecs.TranslateResourceMetadata(testResource, true),
+				)
+			}
+
+			resultAttrs := testResource.Attributes()
+
+			dataStreamType, ok := resultAttrs.Get("data_stream.type")
 			assert.True(t, ok)
 			assert.Equal(t, tt.expectedType, dataStreamType.Str())
 
-			dataStreamDataset, ok := attributes.Get("data_stream.dataset")
+			dataStreamDataset, ok := resultAttrs.Get("data_stream.dataset")
 			assert.True(t, ok)
 			assert.Equal(t, tt.expectedDataset, dataStreamDataset.Str())
 
-			dataStreamNamespace, ok := attributes.Get("data_stream.namespace")
+			dataStreamNamespace, ok := resultAttrs.Get("data_stream.namespace")
 			assert.True(t, ok)
 			assert.Equal(t, tt.expectedNamespace, dataStreamNamespace.Str())
+
+			if tt.expectedServiceName != "" {
+				serviceName, ok := resultAttrs.Get("service.name")
+				assert.True(t, ok)
+				assert.Equal(t, tt.expectedServiceName, serviceName.Str())
+			}
 		})
 	}
 }
@@ -426,6 +485,36 @@ func TestRouteMetricDataPoint(t *testing.T) {
 			hasServiceName:   true,
 			expectedDataset:  "",
 			expectedInternal: false,
+		},
+		{
+			name: "internal metric with otel_remapped is not routed to internal dataset",
+			setupFn: func(attrs pcommon.Map) {
+				attrs.PutStr("otel_remapped", "true")
+			},
+			metricName:       "golang.heap.allocations.active",
+			hasServiceName:   true,
+			expectedDataset:  "",
+			expectedInternal: false,
+		},
+		{
+			name: "internal metric with labels.otel_remapped is not routed to internal dataset",
+			setupFn: func(attrs pcommon.Map) {
+				attrs.PutStr("labels.otel_remapped", "true")
+			},
+			metricName:       "golang.heap.allocations.active",
+			hasServiceName:   true,
+			expectedDataset:  "",
+			expectedInternal: false,
+		},
+		{
+			name: "metric without service name still routes internal even when otel_remapped",
+			setupFn: func(attrs pcommon.Map) {
+				attrs.PutStr("otel_remapped", "true")
+			},
+			metricName:       "golang.heap.allocations.active",
+			hasServiceName:   false,
+			expectedDataset:  "apm.internal",
+			expectedInternal: true,
 		},
 		{
 			name: "metric without service name",

--- a/processor/elasticapmprocessor/processor_test.go
+++ b/processor/elasticapmprocessor/processor_test.go
@@ -217,6 +217,27 @@ func TestProcessor(t *testing.T) {
 			testType:    "metrics",
 			cfg:         apmConfig,
 		},
+		"ecs_span_custom_dataset": {
+			input:       "testdata/ecs/elastic_span_custom_dataset/input.yaml",
+			output:      "testdata/ecs/elastic_span_custom_dataset/output.yaml",
+			mappingMode: "ecs",
+			testType:    "traces",
+			cfg:         apmConfig,
+		},
+		"ecs_log_custom_dataset": {
+			input:       "testdata/ecs/elastic_log_custom_dataset/input.yaml",
+			output:      "testdata/ecs/elastic_log_custom_dataset/output.yaml",
+			mappingMode: "ecs",
+			testType:    "logs",
+			cfg:         apmConfig,
+		},
+		"ecs_metric_custom_dataset": {
+			input:       "testdata/ecs/elastic_metric_custom_dataset/input.yaml",
+			output:      "testdata/ecs/elastic_metric_custom_dataset/output.yaml",
+			mappingMode: "ecs",
+			testType:    "metrics",
+			cfg:         apmConfig,
+		},
 	}
 
 	factory := NewFactory()
@@ -1328,11 +1349,12 @@ func TestIsIntakeECS(t *testing.T) {
 }
 
 func TestECSMappingModeTriggersDataStreamRouting(t *testing.T) {
-	type consumeFn func(t *testing.T, ctx context.Context, factory processor.Factory, settings processor.Settings, cfg *Config) pcommon.Map
+	type consumeFn func(t *testing.T, ctx context.Context, factory processor.Factory, settings processor.Settings, cfg *Config, dataset string) pcommon.Map
 
 	tests := []struct {
 		name              string
 		consume           consumeFn
+		customDataset     string
 		mappingMode       string
 		expectedType      string
 		expectedDataset   string
@@ -1341,7 +1363,7 @@ func TestECSMappingModeTriggersDataStreamRouting(t *testing.T) {
 	}{
 		{
 			name:              "traces with ecs mapping mode",
-			consume:           consumeTraceResourceAttrs,
+			consume:           consumeTraceResourceAttrsWithDataset,
 			mappingMode:       "ecs",
 			expectedType:      "traces",
 			expectedDataset:   "apm",
@@ -1350,13 +1372,13 @@ func TestECSMappingModeTriggersDataStreamRouting(t *testing.T) {
 		},
 		{
 			name:              "traces without mapping mode",
-			consume:           consumeTraceResourceAttrs,
+			consume:           consumeTraceResourceAttrsWithDataset,
 			expectedNamespace: "custom-ns",
 			expectDataStream:  false,
 		},
 		{
 			name:              "logs with ecs mapping mode",
-			consume:           consumeLogResourceAttrs,
+			consume:           consumeLogResourceAttrsWithDataset,
 			mappingMode:       "ecs",
 			expectedType:      "logs",
 			expectedDataset:   "apm",
@@ -1365,13 +1387,13 @@ func TestECSMappingModeTriggersDataStreamRouting(t *testing.T) {
 		},
 		{
 			name:              "logs without mapping mode",
-			consume:           consumeLogResourceAttrs,
+			consume:           consumeLogResourceAttrsWithDataset,
 			expectedNamespace: "custom-ns",
 			expectDataStream:  false,
 		},
 		{
 			name:              "metrics with ecs mapping mode",
-			consume:           consumeMetricResourceAttrs,
+			consume:           consumeMetricResourceAttrsWithDataset,
 			mappingMode:       "ecs",
 			expectedType:      "metrics",
 			expectedDataset:   "apm",
@@ -1380,9 +1402,39 @@ func TestECSMappingModeTriggersDataStreamRouting(t *testing.T) {
 		},
 		{
 			name:              "metrics without mapping mode",
-			consume:           consumeMetricResourceAttrs,
+			consume:           consumeMetricResourceAttrsWithDataset,
 			expectedNamespace: "custom-ns",
 			expectDataStream:  false,
+		},
+		{
+			name:              "traces with ecs mapping mode preserve custom dataset",
+			consume:           consumeTraceResourceAttrsWithDataset,
+			customDataset:     "custom-traces-ds",
+			mappingMode:       "ecs",
+			expectedType:      "traces",
+			expectedDataset:   "custom-traces-ds",
+			expectedNamespace: "custom-ns",
+			expectDataStream:  true,
+		},
+		{
+			name:              "logs with ecs mapping mode preserve custom dataset",
+			consume:           consumeLogResourceAttrsWithDataset,
+			customDataset:     "custom-logs-ds",
+			mappingMode:       "ecs",
+			expectedType:      "logs",
+			expectedDataset:   "custom-logs-ds",
+			expectedNamespace: "custom-ns",
+			expectDataStream:  true,
+		},
+		{
+			name:              "metrics with ecs mapping mode preserve custom dataset",
+			consume:           consumeMetricResourceAttrsWithDataset,
+			customDataset:     "custom-metrics-ds",
+			mappingMode:       "ecs",
+			expectedType:      "metrics",
+			expectedDataset:   "custom-metrics-ds",
+			expectedNamespace: "custom-ns",
+			expectDataStream:  true,
 		},
 	}
 
@@ -1401,7 +1453,7 @@ func TestECSMappingModeTriggersDataStreamRouting(t *testing.T) {
 				})
 			}
 
-			attrs := tc.consume(t, ctx, factory, settings, cfg)
+			attrs := tc.consume(t, ctx, factory, settings, cfg, tc.customDataset)
 			dataStreamType, hasType := attrs.Get("data_stream.type")
 			dataStreamDataset, hasDataset := attrs.Get("data_stream.dataset")
 			dataStreamNamespace, hasNamespace := attrs.Get("data_stream.namespace")
@@ -1422,7 +1474,7 @@ func TestECSMappingModeTriggersDataStreamRouting(t *testing.T) {
 	}
 }
 
-func consumeTraceResourceAttrs(t *testing.T, ctx context.Context, factory processor.Factory, settings processor.Settings, cfg *Config) pcommon.Map {
+func consumeTraceResourceAttrsWithDataset(t *testing.T, ctx context.Context, factory processor.Factory, settings processor.Settings, cfg *Config, dataset string) pcommon.Map {
 	t.Helper()
 
 	next := &consumertest.TracesSink{}
@@ -1434,6 +1486,9 @@ func consumeTraceResourceAttrs(t *testing.T, ctx context.Context, factory proces
 	resource := resourceSpan.Resource()
 	resource.Attributes().PutStr("service.name", "test-service")
 	resource.Attributes().PutStr("data_stream.namespace", "custom-ns")
+	if dataset != "" {
+		resource.Attributes().PutStr("data_stream.dataset", dataset)
+	}
 	resource.Attributes().PutStr(string(semconv.TelemetrySDKNameKey), "opentelemetry")
 	scopeSpans := resourceSpan.ScopeSpans().AppendEmpty()
 	span := scopeSpans.Spans().AppendEmpty()
@@ -1445,7 +1500,7 @@ func consumeTraceResourceAttrs(t *testing.T, ctx context.Context, factory proces
 	return next.AllTraces()[0].ResourceSpans().At(0).Resource().Attributes()
 }
 
-func consumeLogResourceAttrs(t *testing.T, ctx context.Context, factory processor.Factory, settings processor.Settings, cfg *Config) pcommon.Map {
+func consumeLogResourceAttrsWithDataset(t *testing.T, ctx context.Context, factory processor.Factory, settings processor.Settings, cfg *Config, dataset string) pcommon.Map {
 	t.Helper()
 
 	next := &consumertest.LogsSink{}
@@ -1457,6 +1512,9 @@ func consumeLogResourceAttrs(t *testing.T, ctx context.Context, factory processo
 	resource := resourceLog.Resource()
 	resource.Attributes().PutStr("service.name", "test-service")
 	resource.Attributes().PutStr("data_stream.namespace", "custom-ns")
+	if dataset != "" {
+		resource.Attributes().PutStr("data_stream.dataset", dataset)
+	}
 	resource.Attributes().PutStr(string(semconv.TelemetrySDKNameKey), "opentelemetry")
 	resourceLog.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty().Body().SetStr("test-log")
 
@@ -1464,7 +1522,7 @@ func consumeLogResourceAttrs(t *testing.T, ctx context.Context, factory processo
 	return next.AllLogs()[0].ResourceLogs().At(0).Resource().Attributes()
 }
 
-func consumeMetricResourceAttrs(t *testing.T, ctx context.Context, factory processor.Factory, settings processor.Settings, cfg *Config) pcommon.Map {
+func consumeMetricResourceAttrsWithDataset(t *testing.T, ctx context.Context, factory processor.Factory, settings processor.Settings, cfg *Config, dataset string) pcommon.Map {
 	t.Helper()
 
 	next := &consumertest.MetricsSink{}
@@ -1476,6 +1534,9 @@ func consumeMetricResourceAttrs(t *testing.T, ctx context.Context, factory proce
 	resource := resourceMetric.Resource()
 	resource.Attributes().PutStr("service.name", "test-service")
 	resource.Attributes().PutStr("data_stream.namespace", "custom-ns")
+	if dataset != "" {
+		resource.Attributes().PutStr("data_stream.dataset", dataset)
+	}
 	resource.Attributes().PutStr(string(semconv.TelemetrySDKNameKey), "opentelemetry")
 	metric := resourceMetric.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
 	metric.SetName("custom.metric")

--- a/processor/elasticapmprocessor/testdata/ecs/elastic_log/input.yaml
+++ b/processor/elasticapmprocessor/testdata/ecs/elastic_log/input.yaml
@@ -325,9 +325,6 @@ resourceLogs:
           value:
             stringValue: exec-456
         # data_stream.* attributes
-        - key: data_stream.dataset
-          value:
-            stringValue: default
         - key: data_stream.namespace
           value:
             stringValue: default

--- a/processor/elasticapmprocessor/testdata/ecs/elastic_log_custom_dataset/input.yaml
+++ b/processor/elasticapmprocessor/testdata/ecs/elastic_log_custom_dataset/input.yaml
@@ -1,0 +1,32 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: agent.name
+          value:
+            stringValue: ElasticAPM
+        - key: agent.version
+          value:
+            stringValue: 1.0.0
+        - key: service.name
+          value:
+            stringValue: test-service
+        - key: data_stream.dataset
+          value:
+            stringValue: custom-logs
+        - key: data_stream.namespace
+          value:
+            stringValue: custom-ns
+    scopeLogs:
+      - scope: {}
+        logRecords:
+          - attributes:
+              - key: event.domain
+                value:
+                  stringValue: session
+            body:
+              stringValue: test log message
+            observedTimeUnixNano: "1581452773000000321"
+            timeUnixNano: "1581452773000000321"
+            severityNumber: 9
+            traceId: 7bba9f33312b3dbb8b2c2c62bb7abe2d
+            spanId: 86e39566e927d599

--- a/processor/elasticapmprocessor/testdata/ecs/elastic_log_custom_dataset/output.yaml
+++ b/processor/elasticapmprocessor/testdata/ecs/elastic_log_custom_dataset/output.yaml
@@ -1,0 +1,44 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: agent.name
+          value:
+            stringValue: ElasticAPM
+        - key: agent.version
+          value:
+            stringValue: 1.0.0
+        - key: service.name
+          value:
+            stringValue: test-service
+        - key: data_stream.dataset
+          value:
+            stringValue: custom-logs
+        - key: data_stream.namespace
+          value:
+            stringValue: custom-ns
+        - key: data_stream.type
+          value:
+            stringValue: logs
+        - key: host.ip
+          value:
+            stringValue: 1.2.3.4
+        - key: deployment.environment
+          value:
+            stringValue: unset
+        - key: telemetry.sdk.language
+          value:
+            stringValue: unknown
+    scopeLogs:
+      - logRecords:
+          - attributes:
+              - key: event.domain
+                value:
+                  stringValue: session
+            body:
+              stringValue: test log message
+            observedTimeUnixNano: "1581452773000000321"
+            severityNumber: 9
+            spanId: 86e39566e927d599
+            timeUnixNano: "1581452773000000321"
+            traceId: 7bba9f33312b3dbb8b2c2c62bb7abe2d
+        scope: {}

--- a/processor/elasticapmprocessor/testdata/ecs/elastic_metric/input.yaml
+++ b/processor/elasticapmprocessor/testdata/ecs/elastic_metric/input.yaml
@@ -322,9 +322,6 @@ resourceMetrics:
           value:
             stringValue: exec-456
         # data_stream.* attributes
-        - key: data_stream.dataset
-          value:
-            stringValue: default
         - key: data_stream.namespace
           value:
             stringValue: default

--- a/processor/elasticapmprocessor/testdata/ecs/elastic_metric_custom_dataset/input.yaml
+++ b/processor/elasticapmprocessor/testdata/ecs/elastic_metric_custom_dataset/input.yaml
@@ -1,0 +1,31 @@
+resourceMetrics:
+  - resource:
+      attributes:
+        - key: agent.name
+          value:
+            stringValue: ElasticAPM
+        - key: agent.version
+          value:
+            stringValue: 1.0.0
+        - key: service.name
+          value:
+            stringValue: test-service
+        - key: data_stream.dataset
+          value:
+            stringValue: custom-metrics
+        - key: data_stream.namespace
+          value:
+            stringValue: custom-ns
+    scopeMetrics:
+      - scope: {}
+        metrics:
+          - name: system.cpu.time
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 1.5
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: user
+                  timeUnixNano: "1581452773000000789"

--- a/processor/elasticapmprocessor/testdata/ecs/elastic_metric_custom_dataset/output.yaml
+++ b/processor/elasticapmprocessor/testdata/ecs/elastic_metric_custom_dataset/output.yaml
@@ -1,0 +1,46 @@
+resourceMetrics:
+  - resource:
+      attributes:
+        - key: agent.name
+          value:
+            stringValue: ElasticAPM
+        - key: agent.version
+          value:
+            stringValue: 1.0.0
+        - key: data_stream.dataset
+          value:
+            stringValue: custom-metrics
+        - key: data_stream.namespace
+          value:
+            stringValue: custom-ns
+        - key: data_stream.type
+          value:
+            stringValue: metrics
+        - key: deployment.environment
+          value:
+            stringValue: unset
+        - key: host.ip
+          value:
+            stringValue: 1.2.3.4
+        - key: metricset.name
+          value:
+            stringValue: app
+        - key: service.name
+          value:
+            stringValue: test-service
+        - key: telemetry.sdk.language
+          value:
+            stringValue: unknown
+    scopeMetrics:
+      - metrics:
+          - name: system.cpu.time
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 1.5
+                  attributes:
+                    - key: labels.state
+                      value:
+                        stringValue: user
+                  timeUnixNano: "1000000"
+        scope: {}

--- a/processor/elasticapmprocessor/testdata/ecs/elastic_span_custom_dataset/input.yaml
+++ b/processor/elasticapmprocessor/testdata/ecs/elastic_span_custom_dataset/input.yaml
@@ -1,0 +1,36 @@
+resourceSpans:
+  - resource:
+      attributes:
+        - key: agent.name
+          value:
+            stringValue: ElasticAPM
+        - key: agent.version
+          value:
+            stringValue: 1.0.0
+        - key: service.name
+          value:
+            stringValue: test-service
+        - key: data_stream.dataset
+          value:
+            stringValue: custom-traces
+        - key: data_stream.namespace
+          value:
+            stringValue: custom-ns
+    scopeSpans:
+      - scope: {}
+        spans:
+          - attributes:
+              - key: db.name
+                value:
+                  stringValue: main
+              - key: db.system
+                value:
+                  stringValue: mysql
+            endTimeUnixNano: "1581452773000000789"
+            kind: 3
+            name: SELECT
+            parentSpanId: a2fb4a1d1a96d312
+            spanId: 86e39566e927d599
+            startTimeUnixNano: "1581452772000000321"
+            status: {}
+            traceId: 7bba9f33312b3dbb8b2c2c62bb7abe2d

--- a/processor/elasticapmprocessor/testdata/ecs/elastic_span_custom_dataset/output.yaml
+++ b/processor/elasticapmprocessor/testdata/ecs/elastic_span_custom_dataset/output.yaml
@@ -1,0 +1,81 @@
+resourceSpans:
+  - resource:
+      attributes:
+        - key: agent.name
+          value:
+            stringValue: ElasticAPM
+        - key: agent.version
+          value:
+            stringValue: 1.0.0
+        - key: service.name
+          value:
+            stringValue: test-service
+        - key: data_stream.dataset
+          value:
+            stringValue: custom-traces
+        - key: data_stream.namespace
+          value:
+            stringValue: custom-ns
+        - key: data_stream.type
+          value:
+            stringValue: traces
+        - key: host.ip
+          value:
+            stringValue: 1.2.3.4
+        - key: deployment.environment
+          value:
+            stringValue: unset
+        - key: telemetry.sdk.language
+          value:
+            stringValue: unknown
+    scopeSpans:
+      - scope: {}
+        spans:
+          - attributes:
+              - key: db.name
+                value:
+                  stringValue: main
+              - key: db.system
+                value:
+                  stringValue: mysql
+              - key: timestamp.us
+                value:
+                  intValue: "1581452772000000"
+              - key: span.representative_count
+                value:
+                  doubleValue: 1
+              - key: span.type
+                value:
+                  stringValue: db
+              - key: span.subtype
+                value:
+                  stringValue: mysql
+              - key: event.outcome
+                value:
+                  stringValue: success
+              - key: event.success_count
+                value:
+                  intValue: "1"
+              - key: span.duration.us
+                value:
+                  intValue: "1000000"
+              - key: service.target.type
+                value:
+                  stringValue: mysql
+              - key: service.target.name
+                value:
+                  stringValue: main
+              - key: span.destination.service.resource
+                value:
+                  stringValue: mysql
+              - key: processor.event
+                value:
+                  stringValue: span
+            endTimeUnixNano: "1581452773000000789"
+            kind: 3
+            name: SELECT
+            parentSpanId: a2fb4a1d1a96d312
+            spanId: 86e39566e927d599
+            startTimeUnixNano: "1581452772000000321"
+            status: {}
+            traceId: 7bba9f33312b3dbb8b2c2c62bb7abe2d

--- a/processor/elasticapmprocessor/testdata/ecs/elastic_span_db/input.yaml
+++ b/processor/elasticapmprocessor/testdata/ecs/elastic_span_db/input.yaml
@@ -325,9 +325,6 @@ resourceSpans:
           value:
             stringValue: exec-456
         # data_stream.* attributes
-        - key: data_stream.dataset
-          value:
-            stringValue: default
         - key: data_stream.namespace
           value:
             stringValue: default


### PR DESCRIPTION
## Summary

Fix two `data_stream` routing divergences between MIS and mOTLP on the `.apm.` endpoint.

**Namespace preservation** (`data_stream.namespace`): mOTLP was unconditionally writing `"default"`,
ignoring any namespace set by the user as an OTLP resource attribute. All five encode functions
(`EncodeDataStream`, `EncodeErrorDataStream`, `internalMetricDataStream`,
`internalIntervalMetricDataStream`) now write `"default"` only when the attribute is absent.

**Dataset preservation** (`data_stream.dataset`): mOTLP was unconditionally overwriting
`data_stream.dataset` with the computed default (e.g. `"apm"`, `"apm.app.<service>"`), ignoring
any value set by the user. `EncodeDataStream` now reads existing resource attributes via
`ecs.TranslateResourceMetadata` (as `ResourceAttrContext`) before encoding and skips the write
when a dataset is already present. `EncodeErrorDataStream` retains its unconditional write of
`"apm.error"`, matching MIS behaviour.

## Tests

- `TestDataStreamEncoders` — unit tests for all encode functions covering namespace/dataset
  preservation, defaults, and service-name normalisation. Refactored to use `map[string]any`
  attrs and `Attributes().FromRaw()`.
- `TestECSMappingModeTriggersDataStreamRouting` — existing integration test validates namespace
  preservation end-to-end for all three signal types.
- Three new golden tests (`ecs_span_custom_dataset`, `ecs_log_custom_dataset`,
  `ecs_metric_custom_dataset`) validate dataset preservation through the full ECS pipeline for
  traces, logs, and metrics.
- Fixed three existing golden test inputs (`elastic_log`, `elastic_metric`, `elastic_span_db`)
  that carried a `data_stream.dataset: "default"` placeholder which was previously harmless but
  caused the new conditional logic to preserve `"default"` instead of computing the proper value.


Related to: https://github.com/elastic/hosted-otel-collector/issues/3324