### PR TITLE
Fix otelbench bump workflow path filter

### DIFF
--- a/.github/workflows/bump_otelbench.yaml
+++ b/.github/workflows/bump_otelbench.yaml
@@ -11,7 +11,7 @@ on:
     branches:
       - main
     paths:
-      - ./loadgen/cmd/otelbench/Makefile
+      - loadgen/cmd/otelbench/Makefile
 
 permissions:
   contents: read


### PR DESCRIPTION
This fixes the otelbench bump workflow path filter so changes to `loadgen/cmd/otelbench/Makefile` on `main` trigger the workflow.

The previous path used a leading `./`, which did not match the changed file path from PR #1283, so the otelbench changelog bump did not run after the version update merged.

Made with [Cursor](https://cursor.com)