### PR TITLE
otelbench: derive exporter flags from components

### DIFF
--- a/loadgen/cmd/otelbench/.chloggen/add-elasticsearch-exporter-flag.yaml
+++ b/loadgen/cmd/otelbench/.chloggen/add-elasticsearch-exporter-flag.yaml
@@ -4,6 +4,6 @@ note: Add `--exporter-elasticsearch` benchmark flag.
 
 component: otelbench
 
-issues: [1283]
+issues: [1287]
 
 subtext: Allows otelbench to benchmark collector configs that route generated telemetry through the Elasticsearch exporter.

--- a/loadgen/cmd/otelbench/.chloggen/add-elasticsearch-exporter-flag.yaml
+++ b/loadgen/cmd/otelbench/.chloggen/add-elasticsearch-exporter-flag.yaml
@@ -1,0 +1,9 @@
+change_type: enhancement
+
+note: Add `--exporter-elasticsearch` benchmark flag.
+
+component: otelbench
+
+issues: [1283]
+
+subtext: Allows otelbench to benchmark collector configs that route generated telemetry through the Elasticsearch exporter.

--- a/loadgen/cmd/otelbench/Makefile
+++ b/loadgen/cmd/otelbench/Makefile
@@ -1,6 +1,6 @@
 include ../../../Makefile.Common
 
-VERSION := v0.10.0
+VERSION := v0.10.1
 
 .PHONY: get-version
 get-version:

--- a/loadgen/cmd/otelbench/README.md
+++ b/loadgen/cmd/otelbench/README.md
@@ -22,6 +22,8 @@ Usage of ./otelbench:
         benchmark exporter otlp (default true)
   -exporter-otlphttp
         benchmark exporter otlphttp (default true)
+  -exporter-elasticsearch
+        benchmark exporter elasticsearch
   -header value
         extra headers in key=value format when sending data to the server. Can be repeated. e.g. -header X-FIRST-HEADER=foo -header X-SECOND-HEADER=bar
   -insecure

--- a/loadgen/cmd/otelbench/components.go
+++ b/loadgen/cmd/otelbench/components.go
@@ -18,6 +18,8 @@
 package main
 
 import (
+	"sort"
+
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor"
@@ -36,6 +38,16 @@ import (
 	"github.com/elastic/opentelemetry-collector-components/processor/ratelimitprocessor"
 	"github.com/elastic/opentelemetry-collector-components/receiver/loadgenreceiver"
 )
+
+var defaultBenchmarkExporters = map[string]bool{
+	"otlp":     true,
+	"otlphttp": true,
+}
+
+var nonBenchmarkExporters = map[string]struct{}{
+	"debug": {},
+	"nop":   {},
+}
 
 func components(logsDone, metricsDone, tracesDone, profilesDone chan loadgenreceiver.Stats) (otelcol.Factories, error) {
 	var err error
@@ -86,4 +98,22 @@ func components(logsDone, metricsDone, tracesDone, profilesDone chan loadgenrece
 	factories.Telemetry = otelconftelemetry.NewFactory()
 
 	return factories, err
+}
+
+func benchmarkExporterNames() ([]string, error) {
+	factories, err := components(nil, nil, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	exporterNames := make([]string, 0, len(factories.Exporters))
+	for exporterType := range factories.Exporters {
+		name := exporterType.String()
+		if _, skip := nonBenchmarkExporters[name]; skip {
+			continue
+		}
+		exporterNames = append(exporterNames, name)
+	}
+	sort.Strings(exporterNames)
+	return exporterNames, nil
 }

--- a/loadgen/cmd/otelbench/flags.go
+++ b/loadgen/cmd/otelbench/flags.go
@@ -46,9 +46,7 @@ var Config struct {
 	Profiles bool
 	Mixed    bool
 
-	ExporterOTLP     bool
-	ExporterOTLPHTTP bool
-	ExporterPRW      bool
+	Exporters map[string]bool
 
 	ConcurrencyList  []int
 	Shuffle          bool
@@ -58,6 +56,24 @@ var Config struct {
 	ProfilesDataPath string
 
 	Telemetry TelemetryConfig
+}
+
+type exporterFlagValue struct {
+	exporters map[string]bool
+	name      string
+}
+
+func (f exporterFlagValue) String() string {
+	return strconv.FormatBool(f.exporters[f.name])
+}
+
+func (f exporterFlagValue) Set(value string) error {
+	enabled, err := strconv.ParseBool(value)
+	if err != nil {
+		return err
+	}
+	f.exporters[f.name] = enabled
+	return nil
 }
 
 type TelemetryConfig struct {
@@ -133,9 +149,22 @@ func Init() error {
 
 	flag.StringVar(&Config.CollectorConfigPath, "config", "", "path to collector config yaml. If empty, the config.yaml embedded in the binary will be used.")
 
-	flag.BoolVar(&Config.ExporterOTLP, "exporter-otlp", true, "benchmark exporter otlp")
-	flag.BoolVar(&Config.ExporterOTLPHTTP, "exporter-otlphttp", true, "benchmark exporter otlphttp")
-	flag.BoolVar(&Config.ExporterPRW, "exporter-prometheusremotewrite", false, "benchmark exporter prometheusremotewrite")
+	exporters, err := benchmarkExporterNames()
+	if err != nil {
+		return err
+	}
+	Config.Exporters = make(map[string]bool, len(exporters))
+	for _, name := range exporters {
+		Config.Exporters[name] = defaultBenchmarkExporters[name]
+		flag.Var(
+			exporterFlagValue{
+				exporters: Config.Exporters,
+				name:      name,
+			},
+			"exporter-"+name,
+			"benchmark exporter "+name,
+		)
+	}
 
 	flag.BoolVar(&Config.Logs, "logs", true, "benchmark logs")
 	flag.BoolVar(&Config.Metrics, "metrics", true, "benchmark metrics")

--- a/loadgen/cmd/otelbench/go.mod
+++ b/loadgen/cmd/otelbench/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter v0.154.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter v0.152.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.152.0
+	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/component v1.60.0
 	go.opentelemetry.io/collector/confmap v1.60.0
 	go.opentelemetry.io/collector/confmap/provider/envprovider v1.60.0
@@ -141,7 +142,6 @@ require (
 	github.com/shirou/gopsutil/v4 v4.26.5 // indirect
 	github.com/spf13/cobra v1.10.2 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
-	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/tidwall/gjson v1.19.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect

--- a/loadgen/cmd/otelbench/main.go
+++ b/loadgen/cmd/otelbench/main.go
@@ -60,14 +60,18 @@ func getSignals() (signals []string) {
 
 // getExporters returns a slice of exporter names to be benchmarked according to Config
 func getExporters() (exporters []string) {
-	if Config.ExporterOTLP {
-		exporters = append(exporters, "otlp")
+	exporterNames, err := benchmarkExporterNames()
+	if err != nil {
+		panic(err)
 	}
-	if Config.ExporterOTLPHTTP {
-		exporters = append(exporters, "otlphttp")
-	}
-	if Config.ExporterPRW {
-		exporters = append(exporters, "prometheusremotewrite")
+	for _, name := range exporterNames {
+		enabled := defaultBenchmarkExporters[name]
+		if Config.Exporters != nil {
+			enabled = Config.Exporters[name]
+		}
+		if enabled {
+			exporters = append(exporters, name)
+		}
 	}
 	return
 }

--- a/loadgen/cmd/otelbench/main_test.go
+++ b/loadgen/cmd/otelbench/main_test.go
@@ -11,7 +11,7 @@
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied. See the License for the
+// KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
 

--- a/loadgen/cmd/otelbench/main_test.go
+++ b/loadgen/cmd/otelbench/main_test.go
@@ -1,0 +1,73 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package main
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitRegistersBenchmarkExporterFlags(t *testing.T) {
+	oldCommandLine := flag.CommandLine
+	flag.CommandLine = flag.NewFlagSet(t.Name(), flag.ContinueOnError)
+	t.Cleanup(func() {
+		flag.CommandLine = oldCommandLine
+		Config.Exporters = nil
+	})
+
+	require.NoError(t, Init())
+
+	cases := []struct {
+		name         string
+		defaultValue string
+	}{
+		{
+			name:         "exporter-elasticsearch",
+			defaultValue: "false",
+		},
+		{
+			name:         "exporter-otlp",
+			defaultValue: "true",
+		},
+		{
+			name:         "exporter-otlphttp",
+			defaultValue: "true",
+		},
+		{
+			name:         "exporter-prometheusremotewrite",
+			defaultValue: "false",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := flag.Lookup(tc.name)
+			require.NotNil(t, f)
+			require.Equal(t, tc.defaultValue, f.DefValue)
+			require.Equal(t, tc.defaultValue, f.Value.String())
+		})
+	}
+
+	require.Nil(t, flag.Lookup("exporter-debug"))
+	require.Nil(t, flag.Lookup("exporter-nop"))
+
+	require.NoError(t, flag.Set("exporter-elasticsearch", "true"))
+	require.True(t, Config.Exporters["elasticsearch"])
+}


### PR DESCRIPTION
This adds Elasticsearch exporter benchmarking support **without making exporter flags a second source of truth.** I do this after forgetting to add the flag in https://github.com/elastic/opentelemetry-collector-components/pull/1283 and rendering that version useless (same as v0.9.0).

The benchmarkable exporter flags are now derived from the factories registered in components(), with debug and nop excluded because they are utility exporters rather than benchmark targets.
