### PR TITLE
Fix error log routing and propagate scope level ds attrs to error events

### DIFF
--- a/processor/elasticapmprocessor/internal/ecs/ecs_translation.go
+++ b/processor/elasticapmprocessor/internal/ecs/ecs_translation.go
@@ -35,6 +35,7 @@ import (
 // Supported ECS resource attributes
 const (
 	ecsAttrOpenCensusExporterVersion = "opencensus.exporterversion"
+	defaultServiceName               = "unknown"
 )
 
 // kv is a key-value pair for collecting deferred attribute insertions after a RemoveIf pass.
@@ -229,6 +230,16 @@ func TranslateResourceMetadata(resource pcommon.Resource, sanitizeExistingLabels
 	})
 	for _, l := range toAppend {
 		l.v.CopyTo(attributes.PutEmpty(l.k))
+	}
+
+	// Normalize service name to `unknown` if not present.
+	// See: https://github.com/elastic/apm-data/blob/66b89636fc3a2ad643f38c7bb6f0992452ba60a7/input/otlp/metadata.go#L399-L404
+	// `agent.{name, version} are normalized as per the apm-data logic in internal/enrichments/resource.go.
+	//
+	// TODO(lahsivjar): Can we unify all resource enrichments (including ECS) at one place?
+	if context.ServiceName == "" {
+		context.ServiceName = defaultServiceName
+		attributes.PutStr(string(semconv.ServiceNameKey), defaultServiceName)
 	}
 
 	// set host.name and host.hostname

--- a/processor/elasticapmprocessor/internal/ecs/ecs_translation_test.go
+++ b/processor/elasticapmprocessor/internal/ecs/ecs_translation_test.go
@@ -131,6 +131,11 @@ func TestTranslateResourceMetadata(t *testing.T) {
 			wantKey:  string(semconv.TelemetrySDKLanguageKey),
 		},
 		{
+			name:    "missing service.name should default to unknown",
+			wantKey: string(semconv.ServiceNameKey),
+			wantVal: "unknown",
+		},
+		{
 			name:     "supported service version truncated",
 			inputKey: string(semconv.ServiceVersionKey),
 			inputVal: strings.Repeat("a", int(ecsKeywordMaxLength)+1),

--- a/processor/elasticapmprocessor/internal/enrichments/enricher.go
+++ b/processor/elasticapmprocessor/internal/enrichments/enricher.go
@@ -71,8 +71,9 @@ func (e *Enricher) EnrichResourceSpans(resSpan ptrace.ResourceSpans) {
 }
 
 // EnrichResourceLogs enriches a single ResourceLogs with the current enricher
-// configuration.
-func (e *Enricher) EnrichResourceLogs(resLog plog.ResourceLogs) {
+// configuration. resourceNamespace is the namespace from the resource context
+// and is propagated to error log events that have no explicit namespace set.
+func (e *Enricher) EnrichResourceLogs(resLog plog.ResourceLogs, resourceNamespace string) {
 	resource := resLog.Resource()
 	EnrichResource(resource, e.Config.Resource)
 	resourceAttrs := resource.Attributes().AsRaw()
@@ -82,7 +83,7 @@ func (e *Enricher) EnrichResourceLogs(resLog plog.ResourceLogs) {
 		EnrichScope(scopeLog.Scope(), e.Config)
 		logRecords := scopeLog.LogRecords()
 		for k := 0; k < logRecords.Len(); k++ {
-			EnrichLog(resourceAttrs, logRecords.At(k), e.Config, e.remapToECSLabels)
+			EnrichLog(resourceAttrs, logRecords.At(k), e.Config, e.remapToECSLabels, resourceNamespace)
 		}
 	}
 }
@@ -128,12 +129,13 @@ func ecsAPMConfig(cfg config.Config) config.Config {
 // ecsPreProcessResource runs the shared ECS pre-processing pipeline on a
 // resource. This is common across all signal types (traces, logs, metrics)
 // in ECS mode.
-func ecsPreProcessResource(ctx context.Context, resource pcommon.Resource, dataStreamType string, serviceNameInDataStreamDataset bool, hostIPEnabled bool, sanitizeExistingLabels bool) {
+func ecsPreProcessResource(ctx context.Context, resource pcommon.Resource, dataStreamType string, serviceNameInDataStreamDataset bool, hostIPEnabled bool, sanitizeExistingLabels bool) ecs.ResourceAttrContext {
 	resourceContext := ecs.TranslateResourceMetadata(resource, sanitizeExistingLabels)
 	routing.EncodeDataStream(resource, dataStreamType, serviceNameInDataStreamDataset, resourceContext)
 	if hostIPEnabled {
 		ecs.SetHostIP(ctx, resource.Attributes())
 	}
+	return resourceContext
 }
 
 // NewEnricher creates a new instance of Enricher. remapToECSLabels

--- a/processor/elasticapmprocessor/internal/enrichments/enricher.go
+++ b/processor/elasticapmprocessor/internal/enrichments/enricher.go
@@ -27,6 +27,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 
+	"github.com/elastic/opentelemetry-collector-components/internal/elasticattr"
 	"github.com/elastic/opentelemetry-collector-components/processor/elasticapmprocessor/internal/ecs"
 	"github.com/elastic/opentelemetry-collector-components/processor/elasticapmprocessor/internal/enrichments/config"
 	"github.com/elastic/opentelemetry-collector-components/processor/elasticapmprocessor/internal/routing"
@@ -81,9 +82,13 @@ func (e *Enricher) EnrichResourceLogs(resLog plog.ResourceLogs, resourceNamespac
 	for j := 0; j < scopeLogs.Len(); j++ {
 		scopeLog := scopeLogs.At(j)
 		EnrichScope(scopeLog.Scope(), e.Config)
+		ns := resourceNamespace
+		if v, ok := scopeLog.Scope().Attributes().Get(elasticattr.DataStreamNamespace); ok && v.Str() != "" {
+			ns = v.Str()
+		}
 		logRecords := scopeLog.LogRecords()
 		for k := 0; k < logRecords.Len(); k++ {
-			EnrichLog(resourceAttrs, logRecords.At(k), e.Config, e.remapToECSLabels, resourceNamespace)
+			EnrichLog(resourceAttrs, logRecords.At(k), e.Config, e.remapToECSLabels, ns)
 		}
 	}
 }

--- a/processor/elasticapmprocessor/internal/enrichments/log.go
+++ b/processor/elasticapmprocessor/internal/enrichments/log.go
@@ -36,7 +36,7 @@ const (
 	emptyExceptionMsg = "[EMPTY]"
 )
 
-func EnrichLog(resourceAttrs map[string]any, log plog.LogRecord, cfg config.Config, remapToECSLabels bool) {
+func EnrichLog(resourceAttrs map[string]any, log plog.LogRecord, cfg config.Config, remapToECSLabels bool, resourceNamespace string) {
 	if remapToECSLabels {
 		ecs.RemapLogRecordAttributesToECSLabels(log.Attributes())
 	}
@@ -46,12 +46,13 @@ func EnrichLog(resourceAttrs map[string]any, log plog.LogRecord, cfg config.Conf
 		mobile.EnrichLogEvent(ctx, log, cfg)
 	}
 
-	if routing.IsErrorEvent(log.Attributes()) {
+	isErrorEvent := routing.IsErrorEvent(log.Attributes())
+	if isErrorEvent {
 		EnrichLogError(log, cfg)
 	}
 
-	if ctx.Action == "crash" || routing.IsErrorEvent(log.Attributes()) {
-		routing.EncodeErrorDataStream(log.Attributes(), routing.DataStreamTypeLogs)
+	if ctx.Action == "crash" || isErrorEvent {
+		routing.EncodeErrorDataStream(log.Attributes(), routing.DataStreamTypeLogs, resourceNamespace)
 	}
 }
 

--- a/processor/elasticapmprocessor/internal/enrichments/log_enricher.go
+++ b/processor/elasticapmprocessor/internal/enrichments/log_enricher.go
@@ -41,8 +41,8 @@ type ecsLogEnricher struct {
 }
 
 func (e *ecsLogEnricher) enrichResourceLogs(ctx context.Context, rl plog.ResourceLogs) {
-	ecsPreProcessResource(ctx, rl.Resource(), routing.DataStreamTypeLogs, e.serviceNameInDataStreamDataset, e.hostIPEnabled, e.sanitizeExistingLabels)
-	e.enricher.EnrichResourceLogs(rl)
+	resCtx := ecsPreProcessResource(ctx, rl.Resource(), routing.DataStreamTypeLogs, e.serviceNameInDataStreamDataset, e.hostIPEnabled, e.sanitizeExistingLabels)
+	e.enricher.EnrichResourceLogs(rl, resCtx.DataStreamNamespace)
 }
 
 // APMLogEnricher handles elastic APM intake log events in ECS mode.
@@ -101,7 +101,7 @@ type DefaultLogEnricher struct {
 }
 
 func (e *DefaultLogEnricher) EnrichResourceLogs(_ context.Context, rl plog.ResourceLogs) {
-	e.enricher.EnrichResourceLogs(rl)
+	e.enricher.EnrichResourceLogs(rl, "")
 }
 
 // NewDefaultLogEnricher creates a LogEnricher for non-ECS log events.

--- a/processor/elasticapmprocessor/internal/enrichments/metric_enricher.go
+++ b/processor/elasticapmprocessor/internal/enrichments/metric_enricher.go
@@ -21,7 +21,6 @@ import (
 	"context"
 
 	"go.opentelemetry.io/collector/pdata/pmetric"
-	semconv "go.opentelemetry.io/otel/semconv/v1.27.0"
 
 	"github.com/elastic/opentelemetry-collector-components/processor/elasticapmprocessor/internal/enrichments/config"
 	"github.com/elastic/opentelemetry-collector-components/processor/elasticapmprocessor/internal/routing"
@@ -43,13 +42,8 @@ type ecsMetricEnricher struct {
 
 func (e *ecsMetricEnricher) enrichResourceMetrics(ctx context.Context, rm pmetric.ResourceMetrics) {
 	resource := rm.Resource()
-	ecsPreProcessResource(ctx, resource, routing.DataStreamTypeMetrics, e.serviceNameInDataStreamDataset, e.hostIPEnabled, e.sanitizeExistingLabels)
-
-	// Check if resource has a service name for routing decisions
-	hasServiceName := false
-	if serviceName, ok := resource.Attributes().Get(string(semconv.ServiceNameKey)); ok && serviceName.Str() != "" {
-		hasServiceName = true
-	}
+	resCtx := ecsPreProcessResource(ctx, resource, routing.DataStreamTypeMetrics, e.serviceNameInDataStreamDataset, e.hostIPEnabled, e.sanitizeExistingLabels)
+	hasServiceName := resCtx.ServiceName != ""
 
 	// Route internal metrics to appropriate data streams if needed.
 	routeMetricsToDataStream(rm.ScopeMetrics(), hasServiceName)

--- a/processor/elasticapmprocessor/internal/enrichments/trace_enricher.go
+++ b/processor/elasticapmprocessor/internal/enrichments/trace_enricher.go
@@ -22,6 +22,7 @@ import (
 
 	"go.opentelemetry.io/collector/pdata/ptrace"
 
+	"github.com/elastic/opentelemetry-collector-components/internal/elasticattr"
 	"github.com/elastic/opentelemetry-collector-components/processor/elasticapmprocessor/internal/enrichments/config"
 	"github.com/elastic/opentelemetry-collector-components/processor/elasticapmprocessor/internal/routing"
 )
@@ -52,13 +53,18 @@ func (e *ecsTraceEnricher) enrichResourceSpans(ctx context.Context, rs ptrace.Re
 func routeErrorSpanEvents(rs ptrace.ResourceSpans, resourceNamespace string) {
 	scopeSpans := rs.ScopeSpans()
 	for j := 0; j < scopeSpans.Len(); j++ {
-		spans := scopeSpans.At(j).Spans()
+		ss := scopeSpans.At(j)
+		ns := resourceNamespace
+		if v, ok := ss.Scope().Attributes().Get(elasticattr.DataStreamNamespace); ok && v.Str() != "" {
+			ns = v.Str()
+		}
+		spans := ss.Spans()
 		for k := 0; k < spans.Len(); k++ {
 			events := spans.At(k).Events()
 			for l := 0; l < events.Len(); l++ {
 				event := events.At(l)
 				if routing.IsErrorEvent(event.Attributes()) {
-					routing.EncodeErrorDataStream(event.Attributes(), routing.DataStreamTypeTraces, resourceNamespace)
+					routing.EncodeErrorDataStream(event.Attributes(), routing.DataStreamTypeTraces, ns)
 				}
 			}
 		}

--- a/processor/elasticapmprocessor/internal/enrichments/trace_enricher.go
+++ b/processor/elasticapmprocessor/internal/enrichments/trace_enricher.go
@@ -41,14 +41,15 @@ type ecsTraceEnricher struct {
 
 func (e *ecsTraceEnricher) enrichResourceSpans(ctx context.Context, rs ptrace.ResourceSpans) {
 	// Traces signal never need to be routed to service-specific datasets
-	ecsPreProcessResource(ctx, rs.Resource(), routing.DataStreamTypeTraces, false, e.hostIPEnabled, e.sanitizeExistingLabels)
-	routeErrorSpanEvents(rs)
+	resCtx := ecsPreProcessResource(ctx, rs.Resource(), routing.DataStreamTypeTraces, false, e.hostIPEnabled, e.sanitizeExistingLabels)
+	routeErrorSpanEvents(rs, resCtx.DataStreamNamespace)
 	e.enricher.EnrichResourceSpans(rs)
 }
 
 // routeErrorSpanEvents iterates through spans to find errors in span
 // events and overrides the resource-level data stream for error events.
-func routeErrorSpanEvents(rs ptrace.ResourceSpans) {
+// resourceNamespace is propagated to events that have no explicit namespace set.
+func routeErrorSpanEvents(rs ptrace.ResourceSpans, resourceNamespace string) {
 	scopeSpans := rs.ScopeSpans()
 	for j := 0; j < scopeSpans.Len(); j++ {
 		spans := scopeSpans.At(j).Spans()
@@ -57,7 +58,7 @@ func routeErrorSpanEvents(rs ptrace.ResourceSpans) {
 			for l := 0; l < events.Len(); l++ {
 				event := events.At(l)
 				if routing.IsErrorEvent(event.Attributes()) {
-					routing.EncodeErrorDataStream(event.Attributes(), routing.DataStreamTypeTraces)
+					routing.EncodeErrorDataStream(event.Attributes(), routing.DataStreamTypeTraces, resourceNamespace)
 				}
 			}
 		}

--- a/processor/elasticapmprocessor/internal/routing/data_stream.go
+++ b/processor/elasticapmprocessor/internal/routing/data_stream.go
@@ -88,7 +88,7 @@ func IsErrorEvent(attributes pcommon.Map) bool {
 func EncodeErrorDataStream(attributes pcommon.Map, dataStreamType, namespace string) {
 	attributes.PutStr(elasticattr.DataStreamType, dataStreamType)
 	attributes.PutStr(elasticattr.DataStreamDataset, "apm.error")
-	if isStrKeyInAttributes(attributes, elasticattr.DataStreamNamespace) {
+	if isStrKeyMissingOrEmpty(attributes, elasticattr.DataStreamNamespace) {
 		if namespace == "" {
 			namespace = NamespaceDefault
 		}
@@ -179,7 +179,7 @@ func isServiceSummary(attributes pcommon.Map) bool {
 func internalMetricDataStream(attributes pcommon.Map, dataStreamType string) {
 	attributes.PutStr(elasticattr.DataStreamType, dataStreamType)
 	attributes.PutStr(elasticattr.DataStreamDataset, "apm.internal")
-	if isStrKeyInAttributes(attributes, elasticattr.DataStreamNamespace) {
+	if isStrKeyMissingOrEmpty(attributes, elasticattr.DataStreamNamespace) {
 		attributes.PutStr(elasticattr.DataStreamNamespace, NamespaceDefault)
 	}
 }
@@ -188,7 +188,7 @@ func internalMetricDataStream(attributes pcommon.Map, dataStreamType string) {
 func internalIntervalMetricDataStream(attributes pcommon.Map, dataStreamType, metricsetName, interval string) {
 	attributes.PutStr(elasticattr.DataStreamType, dataStreamType)
 	attributes.PutStr(elasticattr.DataStreamDataset, fmt.Sprintf("apm.%s.%s", metricsetName, interval))
-	if isStrKeyInAttributes(attributes, elasticattr.DataStreamNamespace) {
+	if isStrKeyMissingOrEmpty(attributes, elasticattr.DataStreamNamespace) {
 		attributes.PutStr(elasticattr.DataStreamNamespace, NamespaceDefault)
 	}
 }
@@ -222,7 +222,7 @@ func isOTelRemapped(attributes pcommon.Map) bool {
 	return false
 }
 
-func isStrKeyInAttributes(attributes pcommon.Map, key string) bool {
+func isStrKeyMissingOrEmpty(attributes pcommon.Map, key string) bool {
 	value, exists := attributes.Get(key)
 	return !exists || (value.Type() == pcommon.ValueTypeStr && value.Str() == "")
 }

--- a/processor/elasticapmprocessor/internal/routing/data_stream.go
+++ b/processor/elasticapmprocessor/internal/routing/data_stream.go
@@ -83,11 +83,16 @@ func IsErrorEvent(attributes pcommon.Map) bool {
 // EncodeErrorDataStream sets the data stream attributes for error logs and span events.
 // Error logs should always be routed to the "apm.error" dataset regardless of service name.
 // Error span events should also be routed to the "apm.error" dataset.
-func EncodeErrorDataStream(attributes pcommon.Map, dataStreamType string) {
+// namespace is used as the fallback when no namespace is already set on attributes;
+// if empty, NamespaceDefault is used.
+func EncodeErrorDataStream(attributes pcommon.Map, dataStreamType, namespace string) {
 	attributes.PutStr(elasticattr.DataStreamType, dataStreamType)
 	attributes.PutStr(elasticattr.DataStreamDataset, "apm.error")
 	if isStrKeyInAttributes(attributes, elasticattr.DataStreamNamespace) {
-		attributes.PutStr(elasticattr.DataStreamNamespace, NamespaceDefault)
+		if namespace == "" {
+			namespace = NamespaceDefault
+		}
+		attributes.PutStr(elasticattr.DataStreamNamespace, namespace)
 	}
 }
 

--- a/processor/elasticapmprocessor/internal/routing/data_stream_test.go
+++ b/processor/elasticapmprocessor/internal/routing/data_stream_test.go
@@ -424,7 +424,7 @@ func TestDataStreamEncoders(t *testing.T) {
 			}
 
 			if tt.isErrorEncode {
-				routing.EncodeErrorDataStream(testResource.Attributes(), tt.expectedType)
+				routing.EncodeErrorDataStream(testResource.Attributes(), tt.expectedType, "")
 			} else {
 				routing.EncodeDataStream(
 					testResource,

--- a/processor/elasticapmprocessor/processor_test.go
+++ b/processor/elasticapmprocessor/processor_test.go
@@ -231,6 +231,27 @@ func TestProcessor(t *testing.T) {
 			testType:    "traces",
 			cfg:         defaultCfg,
 		},
+		"ecs_log_exception_scope_namespace": {
+			input:       "testdata/ecs/elastic_error/logs_otlp_exception_scope_namespace_input.yaml",
+			output:      "testdata/ecs/elastic_error/logs_otlp_exception_scope_namespace_output.yaml",
+			mappingMode: "ecs",
+			testType:    "logs",
+			cfg:         apmConfig,
+		},
+		"ecs_span_exception_scope_namespace": {
+			input:       "testdata/ecs/elastic_error/span_otlp_exception_scope_namespace_input.yaml",
+			output:      "testdata/ecs/elastic_error/span_otlp_exception_scope_namespace_output.yaml",
+			mappingMode: "ecs",
+			testType:    "traces",
+			cfg:         defaultCfg,
+		},
+		"ecs_log_exception_record_beats_scope": {
+			input:       "testdata/ecs/elastic_error/logs_otlp_exception_record_beats_scope_input.yaml",
+			output:      "testdata/ecs/elastic_error/logs_otlp_exception_record_beats_scope_output.yaml",
+			mappingMode: "ecs",
+			testType:    "logs",
+			cfg:         apmConfig,
+		},
 		"ecs_log_custom_dataset": {
 			input:       "testdata/ecs/elastic_log_custom_dataset/input.yaml",
 			output:      "testdata/ecs/elastic_log_custom_dataset/output.yaml",

--- a/processor/elasticapmprocessor/processor_test.go
+++ b/processor/elasticapmprocessor/processor_test.go
@@ -224,6 +224,13 @@ func TestProcessor(t *testing.T) {
 			testType:    "traces",
 			cfg:         apmConfig,
 		},
+		"ecs_span_exception_resource_namespace": {
+			input:       "testdata/ecs/elastic_error/span_otlp_exception_custom_namespace_input.yaml",
+			output:      "testdata/ecs/elastic_error/span_otlp_exception_custom_namespace_output.yaml",
+			mappingMode: "ecs",
+			testType:    "traces",
+			cfg:         defaultCfg,
+		},
 		"ecs_log_custom_dataset": {
 			input:       "testdata/ecs/elastic_log_custom_dataset/input.yaml",
 			output:      "testdata/ecs/elastic_log_custom_dataset/output.yaml",

--- a/processor/elasticapmprocessor/testdata/ecs/elastic_error/logs_otlp_exception_record_beats_scope_input.yaml
+++ b/processor/elasticapmprocessor/testdata/ecs/elastic_error/logs_otlp_exception_record_beats_scope_input.yaml
@@ -1,0 +1,29 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: service.name
+          value:
+            stringValue: test-service
+    scopeLogs:
+      - scope:
+          attributes:
+            - key: data_stream.namespace
+              value:
+                stringValue: scope-ns
+        logRecords:
+          - attributes:
+              - key: exception.message
+                value:
+                  stringValue: "Null pointer exception"
+              - key: exception.type
+                value:
+                  stringValue: "java.lang.NullPointerException"
+              - key: error.id
+                value:
+                  stringValue: "error-record-beats-scope-123"
+              - key: data_stream.namespace
+                value:
+                  stringValue: record-ns
+            body:
+              stringValue: "Application error occurred"
+            timeUnixNano: "1000000000"

--- a/processor/elasticapmprocessor/testdata/ecs/elastic_error/logs_otlp_exception_record_beats_scope_output.yaml
+++ b/processor/elasticapmprocessor/testdata/ecs/elastic_error/logs_otlp_exception_record_beats_scope_output.yaml
@@ -1,0 +1,80 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: service.name
+          value:
+            stringValue: test-service
+        - key: data_stream.type
+          value:
+            stringValue: logs
+        - key: data_stream.namespace
+          value:
+            stringValue: default
+        - key: data_stream.dataset
+          value:
+            stringValue: apm.app.test_service
+        - key: host.ip
+          value:
+            stringValue: 1.2.3.4
+        - key: agent.name
+          value:
+            stringValue: otlp
+        - key: agent.version
+          value:
+            stringValue: unknown
+        - key: deployment.environment
+          value:
+            stringValue: unset
+        - key: telemetry.sdk.language
+          value:
+            stringValue: unknown
+    scopeLogs:
+      - logRecords:
+          - attributes:
+              - key: exception.message
+                value:
+                  stringValue: Null pointer exception
+              - key: exception.type
+                value:
+                  stringValue: java.lang.NullPointerException
+              - key: error.id
+                value:
+                  stringValue: error-record-beats-scope-123
+              - key: data_stream.namespace
+                value:
+                  stringValue: record-ns
+              - key: error.exception.handled
+                value:
+                  boolValue: true
+              - key: error.exception.message
+                value:
+                  stringValue: Null pointer exception
+              - key: error.exception.type
+                value:
+                  stringValue: java.lang.NullPointerException
+              - key: error.grouping_key
+                value:
+                  stringValue: 4c6181a8cf51525c92c036b3d01f6338
+              - key: timestamp.us
+                value:
+                  intValue: "1000000"
+              - key: event.kind
+                value:
+                  stringValue: event
+              - key: event.type
+                value:
+                  stringValue: error
+              - key: data_stream.type
+                value:
+                  stringValue: logs
+              - key: data_stream.dataset
+                value:
+                  stringValue: apm.error
+            body:
+              stringValue: Application error occurred
+            timeUnixNano: "1000000000"
+        scope:
+          attributes:
+            - key: data_stream.namespace
+              value:
+                stringValue: scope-ns

--- a/processor/elasticapmprocessor/testdata/ecs/elastic_error/logs_otlp_exception_scope_namespace_input.yaml
+++ b/processor/elasticapmprocessor/testdata/ecs/elastic_error/logs_otlp_exception_scope_namespace_input.yaml
@@ -1,0 +1,26 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: service.name
+          value:
+            stringValue: test-service
+    scopeLogs:
+      - scope:
+          attributes:
+            - key: data_stream.namespace
+              value:
+                stringValue: scope-ns
+        logRecords:
+          - attributes:
+              - key: exception.message
+                value:
+                  stringValue: "Null pointer exception"
+              - key: exception.type
+                value:
+                  stringValue: "java.lang.NullPointerException"
+              - key: error.id
+                value:
+                  stringValue: "error-scope-ns-123"
+            body:
+              stringValue: "Application error occurred"
+            timeUnixNano: "1000000000"

--- a/processor/elasticapmprocessor/testdata/ecs/elastic_error/logs_otlp_exception_scope_namespace_output.yaml
+++ b/processor/elasticapmprocessor/testdata/ecs/elastic_error/logs_otlp_exception_scope_namespace_output.yaml
@@ -1,0 +1,80 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: service.name
+          value:
+            stringValue: test-service
+        - key: data_stream.type
+          value:
+            stringValue: logs
+        - key: data_stream.namespace
+          value:
+            stringValue: default
+        - key: data_stream.dataset
+          value:
+            stringValue: apm.app.test_service
+        - key: host.ip
+          value:
+            stringValue: 1.2.3.4
+        - key: agent.name
+          value:
+            stringValue: otlp
+        - key: agent.version
+          value:
+            stringValue: unknown
+        - key: deployment.environment
+          value:
+            stringValue: unset
+        - key: telemetry.sdk.language
+          value:
+            stringValue: unknown
+    scopeLogs:
+      - logRecords:
+          - attributes:
+              - key: exception.message
+                value:
+                  stringValue: Null pointer exception
+              - key: exception.type
+                value:
+                  stringValue: java.lang.NullPointerException
+              - key: error.id
+                value:
+                  stringValue: error-scope-ns-123
+              - key: error.exception.handled
+                value:
+                  boolValue: true
+              - key: error.exception.message
+                value:
+                  stringValue: Null pointer exception
+              - key: error.exception.type
+                value:
+                  stringValue: java.lang.NullPointerException
+              - key: error.grouping_key
+                value:
+                  stringValue: 4c6181a8cf51525c92c036b3d01f6338
+              - key: timestamp.us
+                value:
+                  intValue: "1000000"
+              - key: event.kind
+                value:
+                  stringValue: event
+              - key: event.type
+                value:
+                  stringValue: error
+              - key: data_stream.type
+                value:
+                  stringValue: logs
+              - key: data_stream.dataset
+                value:
+                  stringValue: apm.error
+              - key: data_stream.namespace
+                value:
+                  stringValue: scope-ns
+            body:
+              stringValue: Application error occurred
+            timeUnixNano: "1000000000"
+        scope:
+          attributes:
+            - key: data_stream.namespace
+              value:
+                stringValue: scope-ns

--- a/processor/elasticapmprocessor/testdata/ecs/elastic_error/span_otlp_exception_custom_namespace_input.yaml
+++ b/processor/elasticapmprocessor/testdata/ecs/elastic_error/span_otlp_exception_custom_namespace_input.yaml
@@ -1,0 +1,69 @@
+resourceSpans:
+  - resource:
+      attributes:
+        - key: service.name
+          value:
+            stringValue: test-service
+        - key: data_stream.namespace
+          value:
+            stringValue: production
+        - key: labels.my_value
+          value:
+            stringValue: foo
+        - key: labels.other.value
+          value:
+            stringValue: foo
+        - key: numeric_labels.foo
+          value:
+            doubleValue: 42.0
+        - key: numeric_labels.http.status.code
+          value:
+            doubleValue: 200
+    scopeSpans:
+      - scope: {}
+        spans:
+          - name: process-order
+            spanId: "1234567890abcdef"
+            traceId: "fedcba0987654321fedcba0987654321"
+            startTimeUnixNano: "1000000000"
+            endTimeUnixNano: "2000000000"
+            kind: 1
+            attributes:
+              - key: http.method
+                value:
+                  stringValue: POST
+            events:
+              - name: exception
+                timeUnixNano: "1500000000"
+                attributes:
+                  - key: exception.message
+                    value:
+                      stringValue: "Null pointer exception"
+                  - key: exception.type
+                    value:
+                      stringValue: "java.lang.NullPointerException"
+                  - key: exception.stacktrace
+                    value:
+                      stringValue: "at com.example.MyClass.method(MyClass.java:42)"
+                  - key: error.id
+                    value:
+                      stringValue: "abcdef1234567890abcdef1234567890"
+              - name: regular-event
+                timeUnixNano: "1600000000"
+                attributes:
+                  - key: event.info
+                    value:
+                      stringValue: "This is a regular event"
+          - name: successful-span
+            spanId: "abcdef1234567890"
+            traceId: "fedcba0987654321fedcba0987654321"
+            startTimeUnixNano: "3000000000"
+            endTimeUnixNano: "4000000000"
+            kind: 1
+            events:
+              - name: info
+                timeUnixNano: "3500000000"
+                attributes:
+                  - key: event.message
+                    value:
+                      stringValue: "Operation completed successfully"

--- a/processor/elasticapmprocessor/testdata/ecs/elastic_error/span_otlp_exception_custom_namespace_output.yaml
+++ b/processor/elasticapmprocessor/testdata/ecs/elastic_error/span_otlp_exception_custom_namespace_output.yaml
@@ -1,0 +1,198 @@
+resourceSpans:
+  - resource:
+      attributes:
+        - key: service.name
+          value:
+            stringValue: test-service
+        - key: data_stream.namespace
+          value:
+            stringValue: production
+        - key: labels.labels_my_value
+          value:
+            stringValue: foo
+        - key: labels.labels_other_value
+          value:
+            stringValue: foo
+        - key: numeric_labels.numeric_labels_foo
+          value:
+            doubleValue: 42
+        - key: numeric_labels.numeric_labels_http_status_code
+          value:
+            doubleValue: 200
+        - key: data_stream.type
+          value:
+            stringValue: traces
+        - key: data_stream.dataset
+          value:
+            stringValue: apm
+        - key: agent.name
+          value:
+            stringValue: otlp
+        - key: agent.version
+          value:
+            stringValue: unknown
+        - key: deployment.environment
+          value:
+            stringValue: unset
+        - key: telemetry.sdk.language
+          value:
+            stringValue: unknown
+    scopeSpans:
+      - scope: {}
+        spans:
+          - attributes:
+              - key: http.method
+                value:
+                  stringValue: POST
+              - key: timestamp.us
+                value:
+                  intValue: "1000000"
+              - key: transaction.sampled
+                value:
+                  boolValue: true
+              - key: transaction.id
+                value:
+                  stringValue: 1234567890abcdef
+              - key: transaction.root
+                value:
+                  boolValue: true
+              - key: transaction.name
+                value:
+                  stringValue: process-order
+              - key: processor.event
+                value:
+                  stringValue: transaction
+              - key: transaction.representative_count
+                value:
+                  doubleValue: 1
+              - key: transaction.duration.us
+                value:
+                  intValue: "1000000"
+              - key: transaction.type
+                value:
+                  stringValue: request
+              - key: transaction.result
+                value:
+                  stringValue: Success
+              - key: event.outcome
+                value:
+                  stringValue: success
+              - key: event.success_count
+                value:
+                  intValue: "1"
+            endTimeUnixNano: "2000000000"
+            events:
+              - attributes:
+                  - key: exception.message
+                    value:
+                      stringValue: Null pointer exception
+                  - key: exception.type
+                    value:
+                      stringValue: java.lang.NullPointerException
+                  - key: exception.stacktrace
+                    value:
+                      stringValue: at com.example.MyClass.method(MyClass.java:42)
+                  - key: error.id
+                    value:
+                      stringValue: abcdef1234567890abcdef1234567890
+                  - key: data_stream.type
+                    value:
+                      stringValue: traces
+                  - key: data_stream.dataset
+                    value:
+                      stringValue: apm.error
+                  - key: data_stream.namespace
+                    value:
+                      stringValue: production
+                  - key: timestamp.us
+                    value:
+                      intValue: "1500000"
+                  - key: processor.event
+                    value:
+                      stringValue: error
+                  - key: error.exception.handled
+                    value:
+                      boolValue: true
+                  - key: error.grouping_key
+                    value:
+                      stringValue: 6e0443a38c7580540e896d8960390713
+                  - key: error.grouping_name
+                    value:
+                      stringValue: Null pointer exception
+                  - key: transaction.sampled
+                    value:
+                      boolValue: true
+                  - key: transaction.type
+                    value:
+                      stringValue: request
+                name: exception
+                timeUnixNano: "1500000000"
+              - attributes:
+                  - key: event.info
+                    value:
+                      stringValue: This is a regular event
+                  - key: timestamp.us
+                    value:
+                      intValue: "1600000"
+                name: regular-event
+                timeUnixNano: "1600000000"
+            kind: 1
+            name: process-order
+            spanId: 1234567890abcdef
+            startTimeUnixNano: "1000000000"
+            status: {}
+            traceId: fedcba0987654321fedcba0987654321
+          - attributes:
+              - key: timestamp.us
+                value:
+                  intValue: "3000000"
+              - key: transaction.sampled
+                value:
+                  boolValue: true
+              - key: transaction.id
+                value:
+                  stringValue: abcdef1234567890
+              - key: transaction.root
+                value:
+                  boolValue: true
+              - key: transaction.name
+                value:
+                  stringValue: successful-span
+              - key: processor.event
+                value:
+                  stringValue: transaction
+              - key: transaction.representative_count
+                value:
+                  doubleValue: 1
+              - key: transaction.duration.us
+                value:
+                  intValue: "1000000"
+              - key: transaction.type
+                value:
+                  stringValue: unknown
+              - key: transaction.result
+                value:
+                  stringValue: Success
+              - key: event.outcome
+                value:
+                  stringValue: success
+              - key: event.success_count
+                value:
+                  intValue: "1"
+            endTimeUnixNano: "4000000000"
+            events:
+              - attributes:
+                  - key: event.message
+                    value:
+                      stringValue: Operation completed successfully
+                  - key: timestamp.us
+                    value:
+                      intValue: "3500000"
+                name: info
+                timeUnixNano: "3500000000"
+            kind: 1
+            name: successful-span
+            spanId: abcdef1234567890
+            startTimeUnixNano: "3000000000"
+            status: {}
+            traceId: fedcba0987654321fedcba0987654321

--- a/processor/elasticapmprocessor/testdata/ecs/elastic_error/span_otlp_exception_scope_namespace_input.yaml
+++ b/processor/elasticapmprocessor/testdata/ecs/elastic_error/span_otlp_exception_scope_namespace_input.yaml
@@ -1,0 +1,32 @@
+resourceSpans:
+  - resource:
+      attributes:
+        - key: service.name
+          value:
+            stringValue: test-service
+    scopeSpans:
+      - scope:
+          attributes:
+            - key: data_stream.namespace
+              value:
+                stringValue: scope-ns
+        spans:
+          - name: process-order
+            spanId: "1234567890abcdef"
+            traceId: "fedcba0987654321fedcba0987654321"
+            startTimeUnixNano: "1000000000"
+            endTimeUnixNano: "2000000000"
+            kind: 1
+            events:
+              - name: exception
+                timeUnixNano: "1500000000"
+                attributes:
+                  - key: exception.message
+                    value:
+                      stringValue: "Null pointer exception"
+                  - key: exception.type
+                    value:
+                      stringValue: "java.lang.NullPointerException"
+                  - key: error.id
+                    value:
+                      stringValue: "abcdef1234567890abcdef1234567891"

--- a/processor/elasticapmprocessor/testdata/ecs/elastic_error/span_otlp_exception_scope_namespace_output.yaml
+++ b/processor/elasticapmprocessor/testdata/ecs/elastic_error/span_otlp_exception_scope_namespace_output.yaml
@@ -1,0 +1,121 @@
+resourceSpans:
+  - resource:
+      attributes:
+        - key: service.name
+          value:
+            stringValue: test-service
+        - key: data_stream.type
+          value:
+            stringValue: traces
+        - key: data_stream.namespace
+          value:
+            stringValue: default
+        - key: data_stream.dataset
+          value:
+            stringValue: apm
+        - key: agent.name
+          value:
+            stringValue: otlp
+        - key: agent.version
+          value:
+            stringValue: unknown
+        - key: deployment.environment
+          value:
+            stringValue: unset
+        - key: telemetry.sdk.language
+          value:
+            stringValue: unknown
+    scopeSpans:
+      - scope:
+          attributes:
+            - key: data_stream.namespace
+              value:
+                stringValue: scope-ns
+        spans:
+          - attributes:
+              - key: timestamp.us
+                value:
+                  intValue: "1000000"
+              - key: transaction.sampled
+                value:
+                  boolValue: true
+              - key: transaction.id
+                value:
+                  stringValue: 1234567890abcdef
+              - key: transaction.root
+                value:
+                  boolValue: true
+              - key: transaction.name
+                value:
+                  stringValue: process-order
+              - key: processor.event
+                value:
+                  stringValue: transaction
+              - key: transaction.representative_count
+                value:
+                  doubleValue: 1
+              - key: transaction.duration.us
+                value:
+                  intValue: "1000000"
+              - key: transaction.type
+                value:
+                  stringValue: unknown
+              - key: transaction.result
+                value:
+                  stringValue: Success
+              - key: event.outcome
+                value:
+                  stringValue: success
+              - key: event.success_count
+                value:
+                  intValue: "1"
+            endTimeUnixNano: "2000000000"
+            events:
+              - attributes:
+                  - key: exception.message
+                    value:
+                      stringValue: Null pointer exception
+                  - key: exception.type
+                    value:
+                      stringValue: java.lang.NullPointerException
+                  - key: error.id
+                    value:
+                      stringValue: abcdef1234567890abcdef1234567891
+                  - key: data_stream.type
+                    value:
+                      stringValue: traces
+                  - key: data_stream.dataset
+                    value:
+                      stringValue: apm.error
+                  - key: data_stream.namespace
+                    value:
+                      stringValue: scope-ns
+                  - key: timestamp.us
+                    value:
+                      intValue: "1500000"
+                  - key: processor.event
+                    value:
+                      stringValue: error
+                  - key: error.exception.handled
+                    value:
+                      boolValue: true
+                  - key: error.grouping_key
+                    value:
+                      stringValue: 6e0443a38c7580540e896d8960390713
+                  - key: error.grouping_name
+                    value:
+                      stringValue: Null pointer exception
+                  - key: transaction.sampled
+                    value:
+                      boolValue: true
+                  - key: transaction.type
+                    value:
+                      stringValue: unknown
+                name: exception
+                timeUnixNano: "1500000000"
+            kind: 1
+            name: process-order
+            spanId: 1234567890abcdef
+            startTimeUnixNano: "1000000000"
+            status: {}
+            traceId: fedcba0987654321fedcba0987654321

--- a/processor/elasticapmprocessor/testdata/ecs/elastic_hostname/spans_output.yaml
+++ b/processor/elasticapmprocessor/testdata/ecs/elastic_hostname/spans_output.yaml
@@ -4,18 +4,21 @@ resourceSpans:
         - key: host.hostname
           value:
             stringValue: hostname-1
+        - key: service.name
+          value:
+            stringValue: unknown
         - key: host.name
           value:
             stringValue: hostname-1
         - key: data_stream.type
           value:
             stringValue: traces
-        - key: data_stream.dataset
-          value:
-            stringValue: apm
         - key: data_stream.namespace
           value:
             stringValue: default
+        - key: data_stream.dataset
+          value:
+            stringValue: apm
         - key: agent.name
           value:
             stringValue: otlp

--- a/processor/elasticapmprocessor/testdata/ecs/intake/traces_txn_db_output.yaml
+++ b/processor/elasticapmprocessor/testdata/ecs/intake/traces_txn_db_output.yaml
@@ -10,15 +10,18 @@ resourceSpans:
         - key: labels.resource_optional
           value:
             stringValue: bar
+        - key: service.name
+          value:
+            stringValue: unknown
         - key: data_stream.type
           value:
             stringValue: traces
-        - key: data_stream.dataset
-          value:
-            stringValue: apm
         - key: data_stream.namespace
           value:
             stringValue: default
+        - key: data_stream.dataset
+          value:
+            stringValue: apm
         - key: host.ip
           value:
             stringValue: 1.2.3.4

--- a/processor/elasticapmprocessor/testdata/ecs/txn_db/output.yaml
+++ b/processor/elasticapmprocessor/testdata/ecs/txn_db/output.yaml
@@ -7,15 +7,18 @@ resourceSpans:
         - key: labels.resource_optional
           value:
             stringValue: bar
+        - key: service.name
+          value:
+            stringValue: unknown
         - key: data_stream.type
           value:
             stringValue: traces
-        - key: data_stream.dataset
-          value:
-            stringValue: apm
         - key: data_stream.namespace
           value:
             stringValue: default
+        - key: data_stream.dataset
+          value:
+            stringValue: apm
         - key: host.ip
           value:
             stringValue: 1.2.3.4


### PR DESCRIPTION
The PR fixes the following issues identified for the OTLP data ingested via MIS:

1. Resource-level namespace not stamped on error events (always wrote "default") — Fixed. EncodeErrorDataStream now accepts and uses the resource namespace as fallback.
2. Scope-level namespace not stamped on error events — Fixed. Both routeErrorSpanEvents (traces) and EnrichResourceLogs (logs) now resolve namespace per scope before calling EncodeErrorDataStream.
3. Scope-level namespace not propagated for non-error signals (log records, spans, metric data points) — Found to not be a gap. The ES exporter's routeRecord reads namespace as recordAttr → scopeAttr → resourceAttr for all signal types. No processor change needed.
4. service.name defaulting missing (caused 3 pre-existing test failures) — Fixed in ecs_translation.go, matching apm-data behavior.

Related to: https://github.com/elastic/hosted-otel-collector/issues/3336