### PR TITLE
bump mutlimod version

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -1,6 +1,6 @@
 module-sets:
   edot-base:
-    version: v0.59.0
+    version: v0.62.0
     modules:
       - github.com/elastic/opentelemetry-collector-components/receiver/elasticapmintakereceiver
       - github.com/elastic/opentelemetry-collector-components/receiver/loadgenreceiver


### PR DESCRIPTION
Bump version of mutlimod to latest used for the `make push-tags` command.