### PR TITLE
[receiver/elasticapmintake]Fix gaps as per apm-data handling with tests

### DIFF
--- a/receiver/elasticapmintakereceiver/internal/ndjsondecoder/metrics.go
+++ b/receiver/elasticapmintakereceiver/internal/ndjsondecoder/metrics.go
@@ -116,6 +116,8 @@ func AppendMetricset(sm pmetric.ScopeMetrics, ms *metricset) {
 			dp.SetTimestamp(ts)
 			dp.Attributes().PutStr(elasticattr.ProcessorEvent, "metric")
 			populateHistogramDP(dp, sample)
+		case "summary":
+			// apm-data maps "summary" to MetricType_METRIC_TYPE_SUMMARY (pdata Empty — no data points)
 		case "counter":
 			dp := m.SetEmptySum().DataPoints().AppendEmpty()
 			dp.SetTimestamp(ts)

--- a/receiver/elasticapmintakereceiver/internal/ndjsondecoder/stream.go
+++ b/receiver/elasticapmintakereceiver/internal/ndjsondecoder/stream.go
@@ -98,7 +98,17 @@ func HandleStream(
 				tx, appendErr = DecodeTransaction(dec)
 				if appendErr == nil {
 					svc := TransactionContextService(tx)
-					tags := tx.Context.Tags
+					// elastic.profiler_stack_trace_ids is extracted by AppendTransaction; exclude it from labels.
+					txOTelAttrs := tx.OTel.Attributes
+					if _, ok := txOTelAttrs["elastic.profiler_stack_trace_ids"]; ok {
+						txOTelAttrs = make(map[string]any, len(tx.OTel.Attributes)-1)
+						for k, v := range tx.OTel.Attributes {
+							if k != "elastic.profiler_stack_trace_ids" {
+								txOTelAttrs[k] = v
+							}
+						}
+					}
+					tags := mergeOTelLabels(tx.Context.Tags, txOTelAttrs)
 					target := routeTarget(&main, &shadows, tags, keyIndex, useBig)
 					extras := &eventResourceExtras{
 						request:     &tx.Context.Request,
@@ -115,7 +125,7 @@ func HandleStream(
 				sp, appendErr = DecodeSpan(dec)
 				if appendErr == nil {
 					svc := SpanContextService(sp)
-					tags := mergeOTelElasticLabels(sp.Context.Tags, sp.OTel.Attributes)
+					tags := mergeOTelLabels(sp.Context.Tags, sp.OTel.Attributes)
 					target := routeTarget(&main, &shadows, tags, keyIndex, useBig)
 					var extras *eventResourceExtras
 					if ip := validateIP(sp.Context.Destination.Address.Val); ip != "" {
@@ -812,26 +822,19 @@ func hashCloudOriginFields(o *contextCloudOrigin, h *xxhash.Digest) {
 	}
 }
 
-// mergeOTelElasticLabels returns a merged tags map that includes OTel attributes
-// whose keys start with "elastic.", transforming dots to underscores
-// (e.g. "elastic.foo.bar" → "elastic_foo_bar"). Returns tags unchanged when no
-// elastic.* OTel attributes exist; otherwise returns a new merged map.
-func mergeOTelElasticLabels(tags map[string]any, otelAttrs map[string]any) map[string]any {
-	var merged map[string]any
-	for k, v := range otelAttrs {
-		if !strings.HasPrefix(k, "elastic.") {
-			continue
-		}
-		if merged == nil {
-			merged = make(map[string]any, len(tags)+1)
-			for tk, tv := range tags {
-				merged[tk] = tv
-			}
-		}
-		merged[strings.ReplaceAll(k, ".", "_")] = v
-	}
-	if merged == nil {
+// mergeOTelLabels merges OTel attributes into tags, sanitizing keys by replacing
+// dots with underscores to match apm-data label key sanitization. Returns tags
+// unchanged when otelAttrs is empty; otherwise returns a new merged map.
+func mergeOTelLabels(tags map[string]any, otelAttrs map[string]any) map[string]any {
+	if len(otelAttrs) == 0 {
 		return tags
+	}
+	merged := make(map[string]any, len(tags)+len(otelAttrs))
+	for k, v := range tags {
+		merged[k] = v
+	}
+	for k, v := range otelAttrs {
+		merged[strings.ReplaceAll(k, ".", "_")] = v
 	}
 	return merged
 }

--- a/receiver/elasticapmintakereceiver/internal/ndjsondecoder/traces.go
+++ b/receiver/elasticapmintakereceiver/internal/ndjsondecoder/traces.go
@@ -157,6 +157,10 @@ func AppendSpan(ss ptrace.ScopeSpans, sp *span, txStart pcommon.Timestamp, logge
 		} else {
 			outcome = "unknown"
 		}
+		// OTel spans without explicit failure default to success (mirrors transaction OTel handling)
+		if sp.OTel.IsSet() && outcome == "unknown" {
+			outcome = "success"
+		}
 	}
 
 	// Status
@@ -789,22 +793,22 @@ func appendStacktraceFrame(fm pcommon.Map, f stacktraceFrame) {
 	if f.ColumnNumber.IsSet() {
 		fm.PutInt(elasticattr.SpanStacktraceFrameLineColumn, int64(f.ColumnNumber.Val))
 	}
-	if f.Filename.IsSet() {
+	if f.Filename.IsSet() && f.Filename.Val != "" {
 		fm.PutStr(elasticattr.SpanStacktraceFrameFilename, f.Filename.Val)
 	}
-	if f.Classname.IsSet() {
+	if f.Classname.IsSet() && f.Classname.Val != "" {
 		fm.PutStr(elasticattr.SpanStacktraceFrameClassname, f.Classname.Val)
 	}
-	if f.ContextLine.IsSet() {
+	if f.ContextLine.IsSet() && f.ContextLine.Val != "" {
 		fm.PutStr(elasticattr.SpanStacktraceFrameLineContext, f.ContextLine.Val)
 	}
-	if f.Module.IsSet() {
+	if f.Module.IsSet() && f.Module.Val != "" {
 		fm.PutStr(elasticattr.SpanStacktraceFrameModule, f.Module.Val)
 	}
-	if f.Function.IsSet() {
+	if f.Function.IsSet() && f.Function.Val != "" {
 		fm.PutStr(elasticattr.SpanStacktraceFrameFunction, f.Function.Val)
 	}
-	if f.AbsPath.IsSet() {
+	if f.AbsPath.IsSet() && f.AbsPath.Val != "" {
 		fm.PutStr(elasticattr.SpanStacktraceFrameAbsPath, f.AbsPath.Val)
 	}
 	if len(f.PreContext) > 0 {

--- a/receiver/elasticapmintakereceiver/receiver_test.go
+++ b/receiver/elasticapmintakereceiver/receiver_test.go
@@ -536,7 +536,7 @@ func TestErrors(t *testing.T) {
 		{"errors.ndjson", "errors_expected.yaml"},
 		{"error_context_tags.ndjson", "error_context_tags_expected.yaml"},                           // context.tags written as resource labels.*
 		{"error_transaction_sampled_false.ndjson", "error_transaction_sampled_false_expected.yaml"}, // error.transaction.sampled=false parity
-		{"error_empty_stacktrace_strings.ndjson", "error_empty_stacktrace_strings_expected.yaml"},   // Bug 3: empty-string stacktrace fields must not be written
+		{"error_empty_stacktrace_strings.ndjson", "error_empty_stacktrace_strings_expected.yaml"},   // empty-string stacktrace fields must not be written
 	}
 	factory := NewFactory()
 	testEndpoint := testutil.GetAvailableLocalAddress(t)
@@ -663,10 +663,10 @@ var inputFiles = []struct {
 	{"dropped_spans_stats_no_duration.ndjson", "dropped_spans_stats_no_duration_expected.yaml", nil},
 	{"transactions_xff_nat_ip.ndjson", "transactions_xff_nat_ip_expected.yaml", nil},
 	{"transaction_sampled_false.ndjson", "transaction_sampled_false_expected.yaml", nil},         // transaction.sampled=false parity
-	{"span_otel_custom_attrs.ndjson", "span_otel_custom_attrs_expected.yaml", nil},               // Bug 1: non-elastic.* OTel attrs on spans must propagate to labels.*
-	{"transaction_otel_custom_attrs.ndjson", "transaction_otel_custom_attrs_expected.yaml", nil}, // Bug 1: non-elastic.* OTel attrs on transactions must propagate to labels.*
-	{"span_empty_string_label.ndjson", "span_empty_string_label_expected.yaml", nil},             // Bug 2: empty-string tag value parity
-	{"span_empty_stacktrace_strings.ndjson", "span_empty_stacktrace_strings_expected.yaml", nil}, // Bug 3: empty-string stacktrace frame fields must not be written
+	{"span_otel_custom_attrs.ndjson", "span_otel_custom_attrs_expected.yaml", nil},               // OTel attrs on spans must propagate to labels.*
+	{"transaction_otel_custom_attrs.ndjson", "transaction_otel_custom_attrs_expected.yaml", nil}, // OTel attrs on transactions must propagate to labels.*
+	{"span_empty_string_label.ndjson", "span_empty_string_label_expected.yaml", nil},             // empty-string tag values are omitted from labels.*
+	{"span_empty_stacktrace_strings.ndjson", "span_empty_stacktrace_strings_expected.yaml", nil}, // empty-string stacktrace frame fields must not be written
 }
 
 func TestTransactionsAndSpans(t *testing.T) {

--- a/receiver/elasticapmintakereceiver/receiver_test.go
+++ b/receiver/elasticapmintakereceiver/receiver_test.go
@@ -534,6 +534,9 @@ func TestErrors(t *testing.T) {
 		outputExpectedYamlFileName string
 	}{
 		{"errors.ndjson", "errors_expected.yaml"},
+		{"error_context_tags.ndjson", "error_context_tags_expected.yaml"},                                 // context.tags written as resource labels.*
+		{"error_transaction_sampled_false.ndjson", "error_transaction_sampled_false_expected.yaml"},       // error.transaction.sampled=false parity
+		{"error_empty_stacktrace_strings.ndjson", "error_empty_stacktrace_strings_expected.yaml"},         // Bug 3: empty-string stacktrace fields must not be written
 	}
 	factory := NewFactory()
 	testEndpoint := testutil.GetAvailableLocalAddress(t)
@@ -568,6 +571,7 @@ func TestMetrics(t *testing.T) {
 	}{
 		{"metricsets.ndjson", "metricsets_expected.yaml", []string{"labels.tag1", "numeric_labels.tag2"}},
 		{"multiple_histogram_metrics_samples.ndjson", "multiple_histogram_metrics_samples_expected.yaml", nil},
+		{"metricset_summary_type.ndjson", "metricset_summary_type_expected.yaml", nil}, // "summary" metric type parity
 	}
 	factory := NewFactory()
 	testEndpoint := testutil.GetAvailableLocalAddress(t)
@@ -658,6 +662,11 @@ var inputFiles = []struct {
 	{"spans_representative_count.ndjson", "spans_representative_count_expected.yaml", nil},
 	{"dropped_spans_stats_no_duration.ndjson", "dropped_spans_stats_no_duration_expected.yaml", nil},
 	{"transactions_xff_nat_ip.ndjson", "transactions_xff_nat_ip_expected.yaml", nil},
+	{"transaction_sampled_false.ndjson", "transaction_sampled_false_expected.yaml", nil},            // transaction.sampled=false parity
+	{"span_otel_custom_attrs.ndjson", "span_otel_custom_attrs_expected.yaml", nil},                 // Bug 1: non-elastic.* OTel attrs on spans must propagate to labels.*
+	{"transaction_otel_custom_attrs.ndjson", "transaction_otel_custom_attrs_expected.yaml", nil},   // Bug 1: non-elastic.* OTel attrs on transactions must propagate to labels.*
+	{"span_empty_string_label.ndjson", "span_empty_string_label_expected.yaml", nil},               // Bug 2: empty-string tag value parity
+	{"span_empty_stacktrace_strings.ndjson", "span_empty_stacktrace_strings_expected.yaml", nil},   // Bug 3: empty-string stacktrace frame fields must not be written
 }
 
 func TestTransactionsAndSpans(t *testing.T) {

--- a/receiver/elasticapmintakereceiver/receiver_test.go
+++ b/receiver/elasticapmintakereceiver/receiver_test.go
@@ -534,9 +534,9 @@ func TestErrors(t *testing.T) {
 		outputExpectedYamlFileName string
 	}{
 		{"errors.ndjson", "errors_expected.yaml"},
-		{"error_context_tags.ndjson", "error_context_tags_expected.yaml"},                                 // context.tags written as resource labels.*
-		{"error_transaction_sampled_false.ndjson", "error_transaction_sampled_false_expected.yaml"},       // error.transaction.sampled=false parity
-		{"error_empty_stacktrace_strings.ndjson", "error_empty_stacktrace_strings_expected.yaml"},         // Bug 3: empty-string stacktrace fields must not be written
+		{"error_context_tags.ndjson", "error_context_tags_expected.yaml"},                           // context.tags written as resource labels.*
+		{"error_transaction_sampled_false.ndjson", "error_transaction_sampled_false_expected.yaml"}, // error.transaction.sampled=false parity
+		{"error_empty_stacktrace_strings.ndjson", "error_empty_stacktrace_strings_expected.yaml"},   // Bug 3: empty-string stacktrace fields must not be written
 	}
 	factory := NewFactory()
 	testEndpoint := testutil.GetAvailableLocalAddress(t)
@@ -662,11 +662,11 @@ var inputFiles = []struct {
 	{"spans_representative_count.ndjson", "spans_representative_count_expected.yaml", nil},
 	{"dropped_spans_stats_no_duration.ndjson", "dropped_spans_stats_no_duration_expected.yaml", nil},
 	{"transactions_xff_nat_ip.ndjson", "transactions_xff_nat_ip_expected.yaml", nil},
-	{"transaction_sampled_false.ndjson", "transaction_sampled_false_expected.yaml", nil},            // transaction.sampled=false parity
-	{"span_otel_custom_attrs.ndjson", "span_otel_custom_attrs_expected.yaml", nil},                 // Bug 1: non-elastic.* OTel attrs on spans must propagate to labels.*
-	{"transaction_otel_custom_attrs.ndjson", "transaction_otel_custom_attrs_expected.yaml", nil},   // Bug 1: non-elastic.* OTel attrs on transactions must propagate to labels.*
-	{"span_empty_string_label.ndjson", "span_empty_string_label_expected.yaml", nil},               // Bug 2: empty-string tag value parity
-	{"span_empty_stacktrace_strings.ndjson", "span_empty_stacktrace_strings_expected.yaml", nil},   // Bug 3: empty-string stacktrace frame fields must not be written
+	{"transaction_sampled_false.ndjson", "transaction_sampled_false_expected.yaml", nil},         // transaction.sampled=false parity
+	{"span_otel_custom_attrs.ndjson", "span_otel_custom_attrs_expected.yaml", nil},               // Bug 1: non-elastic.* OTel attrs on spans must propagate to labels.*
+	{"transaction_otel_custom_attrs.ndjson", "transaction_otel_custom_attrs_expected.yaml", nil}, // Bug 1: non-elastic.* OTel attrs on transactions must propagate to labels.*
+	{"span_empty_string_label.ndjson", "span_empty_string_label_expected.yaml", nil},             // Bug 2: empty-string tag value parity
+	{"span_empty_stacktrace_strings.ndjson", "span_empty_stacktrace_strings_expected.yaml", nil}, // Bug 3: empty-string stacktrace frame fields must not be written
 }
 
 func TestTransactionsAndSpans(t *testing.T) {

--- a/receiver/elasticapmintakereceiver/testdata/error_context_tags.ndjson
+++ b/receiver/elasticapmintakereceiver/testdata/error_context_tags.ndjson
@@ -1,0 +1,2 @@
+{"metadata": {"service": {"name": "test-service", "agent": {"name": "elastic-node", "version": "3.14.0"}, "language": {"name": "ecmascript", "version": "8"}, "runtime": {"name": "node", "version": "8.0.0"}}}}
+{"error": {"id": "aa00000000000001", "timestamp": 1494342245999999, "exception": {"type": "DbError", "message": "connection refused"}, "context": {"tags": {"env": "production", "region": "us-east-1"}}}}

--- a/receiver/elasticapmintakereceiver/testdata/error_context_tags_expected.yaml
+++ b/receiver/elasticapmintakereceiver/testdata/error_context_tags_expected.yaml
@@ -1,0 +1,64 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: service.name
+          value:
+            stringValue: test-service
+        - key: telemetry.sdk.language
+          value:
+            stringValue: ecmascript
+        - key: telemetry.sdk.version
+          value:
+            stringValue: "8"
+        - key: process.runtime.name
+          value:
+            stringValue: node
+        - key: process.runtime.version
+          value:
+            stringValue: 8.0.0
+        - key: telemetry.sdk.name
+          value:
+            stringValue: ElasticAPM
+        - key: agent.name
+          value:
+            stringValue: elastic-node
+        - key: agent.version
+          value:
+            stringValue: 3.14.0
+        - key: labels.env
+          value:
+            stringValue: production
+        - key: labels.region
+          value:
+            stringValue: us-east-1
+    scopeLogs:
+      - logRecords:
+          - attributes:
+              - key: processor.event
+                value:
+                  stringValue: error
+              - key: error.id
+                value:
+                  stringValue: aa00000000000001
+              - key: error.grouping_key
+                value:
+                  stringValue: 60b29d2f9dafe754
+              - key: timestamp.us
+                value:
+                  intValue: "1494342245999999"
+              - key: error.exception
+                value:
+                  arrayValue:
+                    values:
+                      - kvlistValue:
+                          values:
+                            - key: message
+                              value:
+                                stringValue: connection refused
+                            - key: type
+                              value:
+                                stringValue: DbError
+            body:
+              stringValue: connection refused
+            timeUnixNano: "1494342245999999000"
+        scope: {}

--- a/receiver/elasticapmintakereceiver/testdata/error_empty_stacktrace_strings.ndjson
+++ b/receiver/elasticapmintakereceiver/testdata/error_empty_stacktrace_strings.ndjson
@@ -1,0 +1,2 @@
+{"metadata": {"service": {"name": "test-service", "agent": {"name": "elastic-node", "version": "3.14.0"}, "language": {"name": "ecmascript", "version": "8"}, "runtime": {"name": "node", "version": "8.0.0"}}}}
+{"error": {"id": "aa00000000000001", "timestamp": 1494342245999999, "exception": {"type": "DbError", "message": "connection refused", "stacktrace": [{"lineno": 10, "filename": "server.js", "classname": "", "function": "handleReq", "module": ""}]}}}

--- a/receiver/elasticapmintakereceiver/testdata/error_empty_stacktrace_strings_expected.yaml
+++ b/receiver/elasticapmintakereceiver/testdata/error_empty_stacktrace_strings_expected.yaml
@@ -1,0 +1,76 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: service.name
+          value:
+            stringValue: test-service
+        - key: telemetry.sdk.language
+          value:
+            stringValue: ecmascript
+        - key: telemetry.sdk.version
+          value:
+            stringValue: "8"
+        - key: process.runtime.name
+          value:
+            stringValue: node
+        - key: process.runtime.version
+          value:
+            stringValue: 8.0.0
+        - key: telemetry.sdk.name
+          value:
+            stringValue: ElasticAPM
+        - key: agent.name
+          value:
+            stringValue: elastic-node
+        - key: agent.version
+          value:
+            stringValue: 3.14.0
+    scopeLogs:
+      - logRecords:
+          - attributes:
+              - key: processor.event
+                value:
+                  stringValue: error
+              - key: error.id
+                value:
+                  stringValue: aa00000000000001
+              - key: error.grouping_key
+                value:
+                  stringValue: 65d62bc8ca82d007
+              - key: timestamp.us
+                value:
+                  intValue: "1494342245999999"
+              - key: error.exception
+                value:
+                  arrayValue:
+                    values:
+                      - kvlistValue:
+                          values:
+                            - key: message
+                              value:
+                                stringValue: connection refused
+                            - key: type
+                              value:
+                                stringValue: DbError
+                            - key: stacktrace
+                              value:
+                                arrayValue:
+                                  values:
+                                    - kvlistValue:
+                                        values:
+                                          - key: exclude_from_grouping
+                                            value:
+                                              boolValue: false
+                                          - key: filename
+                                            value:
+                                              stringValue: server.js
+                                          - key: function
+                                            value:
+                                              stringValue: handleReq
+                                          - key: line.number
+                                            value:
+                                              intValue: "10"
+            body:
+              stringValue: connection refused
+            timeUnixNano: "1494342245999999000"
+        scope: {}

--- a/receiver/elasticapmintakereceiver/testdata/error_transaction_sampled_false.ndjson
+++ b/receiver/elasticapmintakereceiver/testdata/error_transaction_sampled_false.ndjson
@@ -1,0 +1,2 @@
+{"metadata": {"service": {"name": "test-service", "agent": {"name": "elastic-node", "version": "3.14.0"}, "language": {"name": "ecmascript", "version": "8"}, "runtime": {"name": "node", "version": "8.0.0"}}}}
+{"error": {"id": "aa00000000000001", "trace_id": "aa00000000000001aa00000000000001", "parent_id": "abcdef0123456789", "transaction_id": "bb00000000000001", "timestamp": 1494342245999999, "exception": {"type": "DbError", "message": "connection refused"}, "transaction": {"sampled": false, "type": "request", "name": "GET /api"}}}

--- a/receiver/elasticapmintakereceiver/testdata/error_transaction_sampled_false_expected.yaml
+++ b/receiver/elasticapmintakereceiver/testdata/error_transaction_sampled_false_expected.yaml
@@ -1,0 +1,72 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: service.name
+          value:
+            stringValue: test-service
+        - key: telemetry.sdk.language
+          value:
+            stringValue: ecmascript
+        - key: telemetry.sdk.version
+          value:
+            stringValue: "8"
+        - key: process.runtime.name
+          value:
+            stringValue: node
+        - key: process.runtime.version
+          value:
+            stringValue: 8.0.0
+        - key: telemetry.sdk.name
+          value:
+            stringValue: ElasticAPM
+        - key: agent.name
+          value:
+            stringValue: elastic-node
+        - key: agent.version
+          value:
+            stringValue: 3.14.0
+    scopeLogs:
+      - logRecords:
+          - attributes:
+              - key: processor.event
+                value:
+                  stringValue: error
+              - key: transaction.id
+                value:
+                  stringValue: bb00000000000001
+              - key: transaction.name
+                value:
+                  stringValue: GET /api
+              - key: transaction.type
+                value:
+                  stringValue: request
+              - key: error.id
+                value:
+                  stringValue: aa00000000000001
+              - key: parent.id
+                value:
+                  stringValue: abcdef0123456789
+              - key: error.grouping_key
+                value:
+                  stringValue: 60b29d2f9dafe754
+              - key: timestamp.us
+                value:
+                  intValue: "1494342245999999"
+              - key: error.exception
+                value:
+                  arrayValue:
+                    values:
+                      - kvlistValue:
+                          values:
+                            - key: message
+                              value:
+                                stringValue: connection refused
+                            - key: type
+                              value:
+                                stringValue: DbError
+            body:
+              stringValue: connection refused
+            spanId: bb00000000000001
+            timeUnixNano: "1494342245999999000"
+            traceId: aa00000000000001aa00000000000001
+        scope: {}

--- a/receiver/elasticapmintakereceiver/testdata/metricset_summary_type.ndjson
+++ b/receiver/elasticapmintakereceiver/testdata/metricset_summary_type.ndjson
@@ -1,0 +1,2 @@
+{"metadata": {"service": {"name": "test-service", "agent": {"name": "elastic-node", "version": "3.14.0"}, "language": {"name": "ecmascript", "version": "8"}, "runtime": {"name": "node", "version": "8.0.0"}}}}
+{"metricset": {"samples": {"response.latency": {"type": "summary", "value": 42.5}, "jvm.gc.time": {"type": "gauge", "value": 12.3}, "http.requests": {"type": "counter", "value": 100.0}}, "timestamp": 1496170421368000}}

--- a/receiver/elasticapmintakereceiver/testdata/metricset_summary_type_expected.yaml
+++ b/receiver/elasticapmintakereceiver/testdata/metricset_summary_type_expected.yaml
@@ -1,0 +1,52 @@
+resourceMetrics:
+  - resource:
+      attributes:
+        - key: agent.name
+          value:
+            stringValue: elastic-node
+        - key: agent.version
+          value:
+            stringValue: 3.14.0
+        - key: metricset.name
+          value:
+            stringValue: app
+        - key: process.runtime.name
+          value:
+            stringValue: node
+        - key: process.runtime.version
+          value:
+            stringValue: 8.0.0
+        - key: service.name
+          value:
+            stringValue: test-service
+        - key: telemetry.sdk.language
+          value:
+            stringValue: ecmascript
+        - key: telemetry.sdk.name
+          value:
+            stringValue: ElasticAPM
+        - key: telemetry.sdk.version
+          value:
+            stringValue: "8"
+    scopeMetrics:
+      - metrics:
+          - name: response.latency
+          - gauge:
+              dataPoints:
+                - asDouble: 12.3
+                  attributes:
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                  timeUnixNano: "1496170421368000000"
+            name: jvm.gc.time
+          - name: http.requests
+            sum:
+              dataPoints:
+                - asDouble: 100
+                  attributes:
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                  timeUnixNano: "1496170421368000000"
+        scope: {}

--- a/receiver/elasticapmintakereceiver/testdata/span_empty_stacktrace_strings.ndjson
+++ b/receiver/elasticapmintakereceiver/testdata/span_empty_stacktrace_strings.ndjson
@@ -1,0 +1,2 @@
+{"metadata": {"service": {"name": "test-service", "agent": {"name": "elastic-node", "version": "3.14.0"}, "language": {"name": "ecmascript", "version": "8"}, "runtime": {"name": "node", "version": "8.0.0"}}}}
+{"span": {"id": "abcdef0123456789", "trace_id": "aa00000000000001aa00000000000001", "parent_id": "bb00000000000001", "transaction_id": "bb00000000000001", "name": "test span", "type": "db.postgresql.query", "duration": 10.0, "timestamp": 1496170407154000, "stacktrace": [{"lineno": 42, "filename": "db.js", "classname": "", "function": "query", "module": ""}]}}

--- a/receiver/elasticapmintakereceiver/testdata/span_empty_stacktrace_strings_expected.yaml
+++ b/receiver/elasticapmintakereceiver/testdata/span_empty_stacktrace_strings_expected.yaml
@@ -1,0 +1,89 @@
+resourceSpans:
+  - resource:
+      attributes:
+        - key: service.name
+          value:
+            stringValue: test-service
+        - key: telemetry.sdk.language
+          value:
+            stringValue: ecmascript
+        - key: telemetry.sdk.version
+          value:
+            stringValue: "8"
+        - key: process.runtime.name
+          value:
+            stringValue: node
+        - key: process.runtime.version
+          value:
+            stringValue: 8.0.0
+        - key: telemetry.sdk.name
+          value:
+            stringValue: ElasticAPM
+        - key: agent.name
+          value:
+            stringValue: elastic-node
+        - key: agent.version
+          value:
+            stringValue: 3.14.0
+    scopeSpans:
+      - scope: {}
+        spans:
+          - attributes:
+              - key: timestamp.us
+                value:
+                  intValue: "1496170407154000"
+              - key: event.outcome
+                value:
+                  stringValue: unknown
+              - key: processor.event
+                value:
+                  stringValue: span
+              - key: span.duration.us
+                value:
+                  intValue: "10000"
+              - key: transaction.id
+                value:
+                  stringValue: bb00000000000001
+              - key: span.id
+                value:
+                  stringValue: abcdef0123456789
+              - key: span.name
+                value:
+                  stringValue: test span
+              - key: span.type
+                value:
+                  stringValue: db
+              - key: span.subtype
+                value:
+                  stringValue: postgresql
+              - key: span.action
+                value:
+                  stringValue: query
+              - key: span.representative_count
+                value:
+                  doubleValue: 1
+              - key: span.stacktrace
+                value:
+                  arrayValue:
+                    values:
+                      - kvlistValue:
+                          values:
+                            - key: line.number
+                              value:
+                                intValue: "42"
+                            - key: filename
+                              value:
+                                stringValue: db.js
+                            - key: function
+                              value:
+                                stringValue: query
+                            - key: exclude_from_grouping
+                              value:
+                                boolValue: false
+            endTimeUnixNano: "1496170407164000000"
+            name: test span
+            parentSpanId: bb00000000000001
+            spanId: abcdef0123456789
+            startTimeUnixNano: "1496170407154000000"
+            status: {}
+            traceId: aa00000000000001aa00000000000001

--- a/receiver/elasticapmintakereceiver/testdata/span_empty_string_label.ndjson
+++ b/receiver/elasticapmintakereceiver/testdata/span_empty_string_label.ndjson
@@ -1,0 +1,2 @@
+{"metadata": {"service": {"name": "test-service", "agent": {"name": "elastic-node", "version": "3.14.0"}, "language": {"name": "ecmascript", "version": "8"}, "runtime": {"name": "node", "version": "8.0.0"}}}}
+{"span": {"id": "abcdef0123456789", "trace_id": "aa00000000000001aa00000000000001", "parent_id": "bb00000000000001", "transaction_id": "bb00000000000001", "name": "test span", "type": "custom", "duration": 10.0, "timestamp": 1496170407154000, "context": {"tags": {"env": "", "region": "us-east"}}}}

--- a/receiver/elasticapmintakereceiver/testdata/span_empty_string_label_expected.yaml
+++ b/receiver/elasticapmintakereceiver/testdata/span_empty_string_label_expected.yaml
@@ -1,0 +1,68 @@
+resourceSpans:
+  - resource:
+      attributes:
+        - key: service.name
+          value:
+            stringValue: test-service
+        - key: telemetry.sdk.language
+          value:
+            stringValue: ecmascript
+        - key: telemetry.sdk.version
+          value:
+            stringValue: "8"
+        - key: process.runtime.name
+          value:
+            stringValue: node
+        - key: process.runtime.version
+          value:
+            stringValue: 8.0.0
+        - key: telemetry.sdk.name
+          value:
+            stringValue: ElasticAPM
+        - key: agent.name
+          value:
+            stringValue: elastic-node
+        - key: agent.version
+          value:
+            stringValue: 3.14.0
+        - key: labels.region
+          value:
+            stringValue: us-east
+    scopeSpans:
+      - scope: {}
+        spans:
+          - attributes:
+              - key: timestamp.us
+                value:
+                  intValue: "1496170407154000"
+              - key: event.outcome
+                value:
+                  stringValue: unknown
+              - key: processor.event
+                value:
+                  stringValue: span
+              - key: span.duration.us
+                value:
+                  intValue: "10000"
+              - key: transaction.id
+                value:
+                  stringValue: bb00000000000001
+              - key: span.id
+                value:
+                  stringValue: abcdef0123456789
+              - key: span.name
+                value:
+                  stringValue: test span
+              - key: span.type
+                value:
+                  stringValue: custom
+              - key: span.representative_count
+                value:
+                  doubleValue: 1
+            endTimeUnixNano: "1496170407164000000"
+            name: test span
+            parentSpanId: bb00000000000001
+            spanId: abcdef0123456789
+            startTimeUnixNano: "1496170407154000000"
+            status: {}
+            traceId: aa00000000000001aa00000000000001

--- a/receiver/elasticapmintakereceiver/testdata/span_otel_custom_attrs.ndjson
+++ b/receiver/elasticapmintakereceiver/testdata/span_otel_custom_attrs.ndjson
@@ -1,0 +1,2 @@
+{"metadata": {"service": {"name": "test-service", "agent": {"name": "elastic-node", "version": "3.14.0"}, "language": {"name": "ecmascript", "version": "8"}, "runtime": {"name": "node", "version": "8.0.0"}}}}
+{"span": {"id": "abcdef0123456789", "trace_id": "aa00000000000001aa00000000000001", "parent_id": "bb00000000000001", "transaction_id": "bb00000000000001", "name": "test span", "type": "custom", "duration": 10.0, "timestamp": 1496170407154000, "otel": {"attributes": {"custom_key": "custom_value"}, "span_kind": "INTERNAL"}}}

--- a/receiver/elasticapmintakereceiver/testdata/span_otel_custom_attrs_expected.yaml
+++ b/receiver/elasticapmintakereceiver/testdata/span_otel_custom_attrs_expected.yaml
@@ -1,0 +1,70 @@
+resourceSpans:
+  - resource:
+      attributes:
+        - key: service.name
+          value:
+            stringValue: test-service
+        - key: telemetry.sdk.language
+          value:
+            stringValue: ecmascript
+        - key: telemetry.sdk.version
+          value:
+            stringValue: "8"
+        - key: process.runtime.name
+          value:
+            stringValue: node
+        - key: process.runtime.version
+          value:
+            stringValue: 8.0.0
+        - key: telemetry.sdk.name
+          value:
+            stringValue: ElasticAPM
+        - key: agent.name
+          value:
+            stringValue: elastic-node
+        - key: agent.version
+          value:
+            stringValue: 3.14.0
+        - key: labels.custom_key
+          value:
+            stringValue: custom_value
+    scopeSpans:
+      - scope: {}
+        spans:
+          - attributes:
+              - key: timestamp.us
+                value:
+                  intValue: "1496170407154000"
+              - key: event.outcome
+                value:
+                  stringValue: success
+              - key: processor.event
+                value:
+                  stringValue: span
+              - key: span.duration.us
+                value:
+                  intValue: "10000"
+              - key: transaction.id
+                value:
+                  stringValue: bb00000000000001
+              - key: span.id
+                value:
+                  stringValue: abcdef0123456789
+              - key: span.name
+                value:
+                  stringValue: test span
+              - key: span.type
+                value:
+                  stringValue: custom
+              - key: span.representative_count
+                value:
+                  doubleValue: 1
+            endTimeUnixNano: "1496170407164000000"
+            kind: 1
+            name: test span
+            parentSpanId: bb00000000000001
+            spanId: abcdef0123456789
+            startTimeUnixNano: "1496170407154000000"
+            status:
+              code: 1
+            traceId: aa00000000000001aa00000000000001

--- a/receiver/elasticapmintakereceiver/testdata/transaction_otel_custom_attrs.ndjson
+++ b/receiver/elasticapmintakereceiver/testdata/transaction_otel_custom_attrs.ndjson
@@ -1,0 +1,2 @@
+{"metadata": {"service": {"name": "test-service", "agent": {"name": "elastic-node", "version": "3.14.0"}, "language": {"name": "ecmascript", "version": "8"}, "runtime": {"name": "node", "version": "8.0.0"}}}}
+{"transaction": {"id": "aa00000000000001", "trace_id": "aa00000000000001aa00000000000001", "name": "GET /api", "type": "request", "duration": 10.0, "timestamp": 1496170407154000, "span_count": {"started": 0}, "outcome": "success", "otel": {"attributes": {"custom_key": "custom_value"}, "span_kind": "SERVER"}}}

--- a/receiver/elasticapmintakereceiver/testdata/transaction_otel_custom_attrs_expected.yaml
+++ b/receiver/elasticapmintakereceiver/testdata/transaction_otel_custom_attrs_expected.yaml
@@ -1,0 +1,69 @@
+resourceSpans:
+  - resource:
+      attributes:
+        - key: service.name
+          value:
+            stringValue: test-service
+        - key: telemetry.sdk.language
+          value:
+            stringValue: ecmascript
+        - key: telemetry.sdk.version
+          value:
+            stringValue: "8"
+        - key: process.runtime.name
+          value:
+            stringValue: node
+        - key: process.runtime.version
+          value:
+            stringValue: 8.0.0
+        - key: telemetry.sdk.name
+          value:
+            stringValue: ElasticAPM
+        - key: agent.name
+          value:
+            stringValue: elastic-node
+        - key: agent.version
+          value:
+            stringValue: 3.14.0
+        - key: labels.custom_key
+          value:
+            stringValue: custom_value
+    scopeSpans:
+      - scope: {}
+        spans:
+          - attributes:
+              - key: timestamp.us
+                value:
+                  intValue: "1496170407154000"
+              - key: event.outcome
+                value:
+                  stringValue: success
+              - key: processor.event
+                value:
+                  stringValue: transaction
+              - key: transaction.duration.us
+                value:
+                  intValue: "10000"
+              - key: transaction.id
+                value:
+                  stringValue: aa00000000000001
+              - key: transaction.name
+                value:
+                  stringValue: GET /api
+              - key: transaction.type
+                value:
+                  stringValue: request
+              - key: transaction.sampled
+                value:
+                  boolValue: true
+              - key: transaction.span_count.started
+                value:
+                  intValue: "0"
+            endTimeUnixNano: "1496170407164000000"
+            kind: 2
+            name: GET /api
+            spanId: aa00000000000001
+            startTimeUnixNano: "1496170407154000000"
+            status:
+              code: 1
+            traceId: aa00000000000001aa00000000000001

--- a/receiver/elasticapmintakereceiver/testdata/transaction_sampled_false.ndjson
+++ b/receiver/elasticapmintakereceiver/testdata/transaction_sampled_false.ndjson
@@ -1,0 +1,2 @@
+{"metadata": {"service": {"name": "test-service", "agent": {"name": "elastic-node", "version": "3.14.0"}, "language": {"name": "ecmascript", "version": "8"}, "runtime": {"name": "node", "version": "8.0.0"}}}}
+{"transaction": {"id": "aa00000000000001", "trace_id": "aa00000000000001aa00000000000001", "name": "GET /api", "type": "request", "duration": 10.0, "timestamp": 1496170407154000, "sampled": false, "span_count": {"started": 0}, "outcome": "success"}}

--- a/receiver/elasticapmintakereceiver/testdata/transaction_sampled_false_expected.yaml
+++ b/receiver/elasticapmintakereceiver/testdata/transaction_sampled_false_expected.yaml
@@ -1,0 +1,62 @@
+resourceSpans:
+  - resource:
+      attributes:
+        - key: service.name
+          value:
+            stringValue: test-service
+        - key: telemetry.sdk.language
+          value:
+            stringValue: ecmascript
+        - key: telemetry.sdk.version
+          value:
+            stringValue: "8"
+        - key: process.runtime.name
+          value:
+            stringValue: node
+        - key: process.runtime.version
+          value:
+            stringValue: 8.0.0
+        - key: telemetry.sdk.name
+          value:
+            stringValue: ElasticAPM
+        - key: agent.name
+          value:
+            stringValue: elastic-node
+        - key: agent.version
+          value:
+            stringValue: 3.14.0
+    scopeSpans:
+      - scope: {}
+        spans:
+          - attributes:
+              - key: timestamp.us
+                value:
+                  intValue: "1496170407154000"
+              - key: event.outcome
+                value:
+                  stringValue: success
+              - key: processor.event
+                value:
+                  stringValue: transaction
+              - key: transaction.duration.us
+                value:
+                  intValue: "10000"
+              - key: transaction.id
+                value:
+                  stringValue: aa00000000000001
+              - key: transaction.name
+                value:
+                  stringValue: GET /api
+              - key: transaction.type
+                value:
+                  stringValue: request
+              - key: transaction.span_count.started
+                value:
+                  intValue: "0"
+            endTimeUnixNano: "1496170407164000000"
+            name: GET /api
+            spanId: aa00000000000001
+            startTimeUnixNano: "1496170407154000000"
+            status:
+              code: 1
+            traceId: aa00000000000001aa00000000000001


### PR DESCRIPTION
Related to: https://github.com/elastic/hosted-otel-collector/issues/3362

A few more gaps were identified with apm-data handling when running data-accuracy tests and the PR fixes them.