### PR TITLE
[receiver/elasticintake]Allow semaphore to be disabled

### DIFF
--- a/receiver/elasticapmintakereceiver/config.go
+++ b/receiver/elasticapmintakereceiver/config.go
@@ -34,7 +34,8 @@ type Config struct {
 	BatchSize int `mapstructure:"batch_size"`
 
 	// MaxConcurrentDecoders is the maximum number of intake requests whose bodies
-	// can be decoded concurrently.
+	// can be decoded concurrently. Zero disables the limit entirely (no
+	// concurrency gating).
 	MaxConcurrentDecoders int `mapstructure:"max_concurrent_decoders"`
 
 	// MaxEventSize is the maximum allowed event size, in bytes.
@@ -62,8 +63,8 @@ func (cfg *Config) Validate() error {
 	if cfg.BatchSize <= 0 {
 		return fmt.Errorf("batch_size must be positive")
 	}
-	if cfg.MaxConcurrentDecoders <= 0 {
-		return fmt.Errorf("max_concurrent_decoders must be positive")
+	if cfg.MaxConcurrentDecoders < 0 {
+		return fmt.Errorf("max_concurrent_decoders must not be negative (0 disables the limit)")
 	}
 	if cfg.MaxEventSize <= 0 {
 		return fmt.Errorf("max_event_size must be positive")

--- a/receiver/elasticapmintakereceiver/config_test.go
+++ b/receiver/elasticapmintakereceiver/config_test.go
@@ -86,6 +86,14 @@ func TestLoadConfig(t *testing.T) {
 			}(),
 		},
 		{
+			id: component.NewIDWithName(metadata.Type, "disabled_max_concurrent_decoders"),
+			expected: func() *Config {
+				cfg := expectedDefaultConfig()
+				cfg.MaxConcurrentDecoders = 0
+				return cfg
+			}(),
+		},
+		{
 			id: component.NewIDWithName(metadata.Type, "custom_max_event_size"),
 			expected: func() *Config {
 				cfg := expectedDefaultConfig()
@@ -99,7 +107,7 @@ func TestLoadConfig(t *testing.T) {
 		},
 		{
 			id:                   component.NewIDWithName(metadata.Type, "invalid_max_concurrent_decoders"),
-			validateErrorMessage: "max_concurrent_decoders must be positive",
+			validateErrorMessage: "max_concurrent_decoders must not be negative",
 		},
 		{
 			id:                   component.NewIDWithName(metadata.Type, "invalid_max_event_size"),

--- a/receiver/elasticapmintakereceiver/receiver.go
+++ b/receiver/elasticapmintakereceiver/receiver.go
@@ -172,7 +172,12 @@ func (r *elasticAPMIntakeReceiver) newRootHandler() http.HandlerFunc {
 }
 
 func (r *elasticAPMIntakeReceiver) newElasticAPMEventsHandler(ctxFunc func(*http.Request) context.Context) http.HandlerFunc {
-	sem := semaphore.NewWeighted(int64(r.cfg.MaxConcurrentDecoders))
+	// A zero MaxConcurrentDecoders disables the limit: sem stays nil and the
+	// per-request acquire/release below is skipped entirely.
+	var sem *semaphore.Weighted
+	if r.cfg.MaxConcurrentDecoders > 0 {
+		sem = semaphore.NewWeighted(int64(r.cfg.MaxConcurrentDecoders))
+	}
 
 	return func(w http.ResponseWriter, req *http.Request) {
 		statusCode := http.StatusAccepted
@@ -193,16 +198,18 @@ func (r *elasticAPMIntakeReceiver) newElasticAPMEventsHandler(ctxFunc func(*http
 			}
 		}
 
-		if err := sem.Acquire(ctx, 1); err != nil {
-			processError(err, true)
-			if statusCode >= http.StatusBadRequest {
-				w.Header().Set("Connection", "close")
+		if sem != nil {
+			if err := sem.Acquire(ctx, 1); err != nil {
+				processError(err, true)
+				if statusCode >= http.StatusBadRequest {
+					w.Header().Set("Connection", "close")
+				}
+				w.WriteHeader(statusCode)
+				_ = json.NewEncoder(w).Encode(&result)
+				return
 			}
-			w.WriteHeader(statusCode)
-			_ = json.NewEncoder(w).Encode(&result)
-			return
+			defer sem.Release(1)
 		}
-		defer sem.Release(1)
 
 		consumer := ndjsondecoder.BatchConsumer(func(ctx context.Context, ld *plog.Logs, md *pmetric.Metrics, td *ptrace.Traces) error {
 			return errors.Join(r.consumeOTel(ctx, ld, md, td)...)

--- a/receiver/elasticapmintakereceiver/receiver_test.go
+++ b/receiver/elasticapmintakereceiver/receiver_test.go
@@ -860,6 +860,32 @@ func TestEventsHandlerUsesConfiguredBatchSize(t *testing.T) {
 	})
 }
 
+func TestEventsHandlerZeroMaxConcurrentDecodersDisablesLimit(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	cfg.MaxConcurrentDecoders = 0
+
+	rcvr, err := newElasticAPMIntakeReceiver(
+		func(context.Context, component.Host) (agentcfg.Fetcher, error) { return nil, nil },
+		cfg,
+		receivertest.NewNopSettings(metadata.Type),
+	)
+	require.NoError(t, err)
+
+	nextTraces := new(consumertest.TracesSink)
+	rcvr.nextTraces = nextTraces
+
+	handler := rcvr.newElasticAPMEventsHandler(func(req *http.Request) context.Context {
+		return withECSMappingMode(req.Context(), false)
+	})
+	req := httptest.NewRequest(http.MethodPost, intakeV2EventsPath, bytes.NewReader(generateTransactionPayload(1)))
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusAccepted, rec.Code)
+	require.Len(t, nextTraces.AllTraces(), 1)
+}
+
 func TestEventsHandler_ContextCanceledWithUnknownRPCError(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 	cfg.BatchSize = 1

--- a/receiver/elasticapmintakereceiver/testdata/config.yaml
+++ b/receiver/elasticapmintakereceiver/testdata/config.yaml
@@ -6,6 +6,9 @@ elasticapmintake/custom_batch_size:
 elasticapmintake/custom_max_concurrent_decoders:
   max_concurrent_decoders: 256
 
+elasticapmintake/disabled_max_concurrent_decoders:
+  max_concurrent_decoders: 0
+
 elasticapmintake/custom_max_event_size:
   max_event_size: 2048
 
@@ -13,7 +16,7 @@ elasticapmintake/invalid_batch_size:
   batch_size: 0
 
 elasticapmintake/invalid_max_concurrent_decoders:
-  max_concurrent_decoders: 0
+  max_concurrent_decoders: -1
 
 elasticapmintake/invalid_max_event_size:
   max_event_size: 0


### PR DESCRIPTION
The PR allows disabling the semaphore by setting `0` concurrent decoders.

Related to: https://github.com/elastic/hosted-otel-collector/issues/3362