### PR TITLE
apikeyauth: add metadata conditions

### DIFF
--- a/extension/apikeyauthextension/authenticator.go
+++ b/extension/apikeyauthextension/authenticator.go
@@ -271,8 +271,12 @@ func getHeader(headers map[string][]string, titlecase, lowercase string) (string
 // hasPrivileges checks if the API Key is valid and has the required privileges.
 func (a *authenticator) hasPrivileges(ctx context.Context, authHeaderValue string) (bool, string, error) {
 	clientMetadata := client.FromContext(ctx).Metadata
-	applications := make([]types.ApplicationPrivilegesCheck, len(a.config.ApplicationPrivileges))
-	for i, app := range a.config.ApplicationPrivileges {
+	applications := make([]types.ApplicationPrivilegesCheck, 0, len(a.config.ApplicationPrivileges))
+	for _, app := range a.config.ApplicationPrivileges {
+		if !applicationPrivilegesApplies(clientMetadata, app) {
+			continue
+		}
+
 		// Start with static resources
 		resources := make([]string, len(app.Resources))
 		copy(resources, app.Resources)
@@ -281,6 +285,9 @@ func (a *authenticator) hasPrivileges(ctx context.Context, authHeaderValue strin
 		for _, dr := range app.DynamicResources {
 			values := clientMetadata.Get(dr.Metadata)
 			if len(values) == 0 {
+				if !dr.required() {
+					continue
+				}
 				return false, "", &metadataValidationError{
 					message: fmt.Sprintf("missing client metadata %q required for dynamic resource", dr.Metadata),
 				}
@@ -290,11 +297,14 @@ func (a *authenticator) hasPrivileges(ctx context.Context, authHeaderValue strin
 			}
 		}
 
-		applications[i] = types.ApplicationPrivilegesCheck{
+		if len(resources) == 0 {
+			continue
+		}
+		applications = append(applications, types.ApplicationPrivilegesCheck{
 			Application: app.Application,
 			Privileges:  app.Privileges,
 			Resources:   resources,
-		}
+		})
 	}
 	req := a.esClient.Security.HasPrivileges()
 	req.Header(authorizationHeader, authHeaderValue)
@@ -322,6 +332,32 @@ func (a *authenticator) hasPrivileges(ctx context.Context, authHeaderValue strin
 	return resp.HasAllRequested, resp.Username, nil
 }
 
+// applicationPrivilegesApplies reports whether an application privilege check
+// should be included for the given client metadata. A check applies only when
+// every key in app.RequireMetadata is present and every key in
+// app.ExcludeMetadata is absent from clientMetadata.
+//
+// For example, given:
+//
+//	app.RequireMetadata = []string{"x-tenant-id"}
+//	app.ExcludeMetadata = []string{"x-internal"}
+//
+// the check applies to a request carrying "x-tenant-id" but not "x-internal",
+// and is skipped for a request that omits "x-tenant-id" or carries "x-internal".
+func applicationPrivilegesApplies(clientMetadata client.Metadata, app ApplicationPrivilegesConfig) bool {
+	for _, metadataKey := range app.RequireMetadata {
+		if len(clientMetadata.Get(metadataKey)) == 0 {
+			return false
+		}
+	}
+	for _, metadataKey := range app.ExcludeMetadata {
+		if len(clientMetadata.Get(metadataKey)) != 0 {
+			return false
+		}
+	}
+	return true
+}
+
 // getCacheKey computes a cache key for the given API Key ID and headers.
 func (a *authenticator) getCacheKey(ctx context.Context, id string, headers map[string][]string) (string, error) {
 	var clientMetadata client.Metadata
@@ -337,9 +373,12 @@ func (a *authenticator) getCacheKey(ctx context.Context, id string, headers map[
 		key += " " + value
 	}
 	for _, metadataKey := range a.config.Cache.KeyMetadata {
-		values := clientMetadata.Get(metadataKey)
+		values := clientMetadata.Get(metadataKey.Metadata)
 		if len(values) == 0 {
-			return "", fmt.Errorf("error computing cache key: missing client metadata %q", metadataKey)
+			if metadataKey.required() {
+				return "", fmt.Errorf("error computing cache key: missing client metadata %q", metadataKey.Metadata)
+			}
+			continue
 		}
 		key += " " + values[0]
 	}

--- a/extension/apikeyauthextension/authenticator_test.go
+++ b/extension/apikeyauthextension/authenticator_test.go
@@ -221,33 +221,6 @@ func TestAuthenticator(t *testing.T) {
 	}
 }
 
-func TestAuthenticator_ApplicationPrivileges(t *testing.T) {
-	srv := newMockElasticsearch(t, func(w http.ResponseWriter, r *http.Request) {
-		var body hasprivileges.Request
-		assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
-		assert.Equal(t, hasprivileges.Request{
-			Application: []types.ApplicationPrivilegesCheck{{
-				Application: "my_app",
-				Resources:   []string{"the_resource"},
-				Privileges:  []string{"read", "write"},
-			}},
-		}, body)
-		assert.NoError(t, json.NewEncoder(w).Encode(successfulResponse))
-	})
-
-	config := createDefaultConfig().(*Config)
-	config.ApplicationPrivileges = []ApplicationPrivilegesConfig{{
-		Application: "my_app",
-		Resources:   []string{"the_resource"},
-		Privileges:  []string{"read", "write"},
-	}}
-	authenticator := newTestAuthenticator(t, srv, config)
-	_, err := authenticator.Authenticate(context.Background(), map[string][]string{
-		"Authorization": {"ApiKey " + base64.StdEncoding.EncodeToString([]byte("id:secret"))},
-	})
-	assert.NoError(t, err)
-}
-
 func TestAuthenticator_Caching(t *testing.T) {
 	var calls int
 	srv := newMockElasticsearch(t, func(w http.ResponseWriter, r *http.Request) {
@@ -763,7 +736,7 @@ func TestAuthenticator_CacheKeyMetadata(t *testing.T) {
 		calls++
 	})
 	config := createDefaultConfig().(*Config)
-	config.Cache.KeyMetadata = []string{"X-Tenant-Id"}
+	config.Cache.KeyMetadata = []MetadataKeyConfig{{Metadata: "X-Tenant-Id"}}
 	authenticator := newTestAuthenticator(t, srv, config)
 
 	// Missing X-Tenant-Id header should result in an error.
@@ -908,85 +881,201 @@ func TestAuthenticator_AuthorizationHeader(t *testing.T) {
 	}
 }
 
-func TestAuthenticator_DynamicResources(t *testing.T) {
-	srv := newMockElasticsearch(t, func(w http.ResponseWriter, r *http.Request) {
-		var body hasprivileges.Request
-		assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
-		assert.Equal(t, hasprivileges.Request{
-			Application: []types.ApplicationPrivilegesCheck{{
+func TestAuthenticator_ApplicationPrivileges(t *testing.T) {
+	authHeader := "ApiKey " + base64.StdEncoding.EncodeToString([]byte("id:secret"))
+
+	type step struct {
+		metadata map[string][]string
+		// want is the ES request expected for this call, or nil when the call
+		// is served from cache and issues no ES request.
+		want *hasprivileges.Request
+	}
+	cases := []struct {
+		name        string
+		apps        []ApplicationPrivilegesConfig
+		keyMetadata []MetadataKeyConfig
+		steps       []step
+	}{
+		{
+			name: "static resources only",
+			apps: []ApplicationPrivilegesConfig{{
 				Application: "my_app",
-				Resources:   []string{"static-resource", "resource:my-resource"},
-				Privileges:  []string{"write"},
+				Resources:   []string{"the_resource"},
+				Privileges:  []string{"read", "write"},
 			}},
-		}, body)
-		assert.NoError(t, json.NewEncoder(w).Encode(successfulResponse))
-	})
-
-	config := createDefaultConfig().(*Config)
-	config.ApplicationPrivileges = []ApplicationPrivilegesConfig{{
-		Application: "my_app",
-		Privileges:  []string{"write"},
-		Resources:   []string{"static-resource"},
-		DynamicResources: []DynamicResource{{
-			Metadata: "X-Resource-Name",
-			Format:   "resource:%s",
-		}},
-	}}
-	config.Cache.KeyMetadata = []string{"X-Resource-Name"}
-	authenticator := newTestAuthenticator(t, srv, config)
-
-	withMetadata := client.NewContext(context.Background(), client.Info{
-		Metadata: client.NewMetadata(map[string][]string{
-			"X-Resource-Name": {"my-resource"},
-		}),
-	})
-	ctx, err := authenticator.Authenticate(withMetadata, map[string][]string{
-		"Authorization": {"ApiKey " + base64.StdEncoding.EncodeToString([]byte("id:secret"))},
-	})
-	assert.NoError(t, err)
-	clientInfo := client.FromContext(ctx)
-	assert.Equal(t, user, clientInfo.Auth.GetAttribute("username"))
-	assert.Equal(t, "id", clientInfo.Auth.GetAttribute("api_key"))
-}
-
-func TestAuthenticator_DynamicResourcesMultipleValues(t *testing.T) {
-	srv := newMockElasticsearch(t, func(w http.ResponseWriter, r *http.Request) {
-		var body hasprivileges.Request
-		assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
-		assert.Equal(t, hasprivileges.Request{
-			Application: []types.ApplicationPrivilegesCheck{{
+			steps: []step{
+				{
+					metadata: map[string][]string{},
+					want: &hasprivileges.Request{Application: []types.ApplicationPrivilegesCheck{{
+						Application: "my_app",
+						Resources:   []string{"the_resource"},
+						Privileges:  []string{"read", "write"},
+					}}},
+				},
+			},
+		},
+		{
+			name: "required dynamic resource present",
+			apps: []ApplicationPrivilegesConfig{{
 				Application: "my_app",
-				Resources:   []string{"resource:my-resource", "resource:another-resource"},
 				Privileges:  []string{"write"},
+				Resources:   []string{"static-resource"},
+				DynamicResources: []DynamicResource{{
+					Metadata: "X-Resource-Name",
+					Format:   "resource:%s",
+				}},
 			}},
-		}, body)
-		assert.NoError(t, json.NewEncoder(w).Encode(successfulResponse))
-	})
+			keyMetadata: []MetadataKeyConfig{{Metadata: "X-Resource-Name"}},
+			steps: []step{
+				{
+					metadata: map[string][]string{"X-Resource-Name": {"my-resource"}},
+					want: &hasprivileges.Request{Application: []types.ApplicationPrivilegesCheck{{
+						Application: "my_app",
+						Resources:   []string{"static-resource", "resource:my-resource"},
+						Privileges:  []string{"write"},
+					}}},
+				},
+			},
+		},
+		{
+			name: "dynamic resource with multiple values",
+			apps: []ApplicationPrivilegesConfig{{
+				Application: "my_app",
+				Privileges:  []string{"write"},
+				DynamicResources: []DynamicResource{{
+					Metadata: "X-Resource-Name",
+					Format:   "resource:%s",
+				}},
+			}},
+			keyMetadata: []MetadataKeyConfig{{Metadata: "X-Resource-Name"}},
+			steps: []step{
+				{
+					metadata: map[string][]string{"X-Resource-Name": {"my-resource", "another-resource"}},
+					want: &hasprivileges.Request{Application: []types.ApplicationPrivilegesCheck{{
+						Application: "my_app",
+						Resources:   []string{"resource:my-resource", "resource:another-resource"},
+						Privileges:  []string{"write"},
+					}}},
+				},
+			},
+		},
+		{
+			name: "optional dynamic resource absent then present then cached",
+			apps: []ApplicationPrivilegesConfig{{
+				Application: "my_app",
+				Privileges:  []string{"write"},
+				Resources:   []string{"static-resource"},
+				DynamicResources: []DynamicResource{{
+					Metadata: "X-Resource-Name",
+					Format:   "resource:%s",
+					Required: ptr(false),
+				}},
+			}},
+			keyMetadata: []MetadataKeyConfig{{Metadata: "X-Resource-Name", Required: ptr(false)}},
+			steps: []step{
+				{
+					metadata: map[string][]string{},
+					want: &hasprivileges.Request{Application: []types.ApplicationPrivilegesCheck{{
+						Application: "my_app",
+						Resources:   []string{"static-resource"},
+						Privileges:  []string{"write"},
+					}}},
+				},
+				{
+					metadata: map[string][]string{"X-Resource-Name": {"my-resource"}},
+					want: &hasprivileges.Request{Application: []types.ApplicationPrivilegesCheck{{
+						Application: "my_app",
+						Resources:   []string{"static-resource", "resource:my-resource"},
+						Privileges:  []string{"write"},
+					}}},
+				},
+				{
+					metadata: map[string][]string{"X-Resource-Name": {"my-resource"}},
+					want:     nil,
+				},
+			},
+		},
+		{
+			name: "conditional require and exclude metadata",
+			apps: []ApplicationPrivilegesConfig{
+				{
+					ExcludeMetadata: []string{"X-Resource-Name"},
+					Application:     "apm",
+					Privileges:      []string{"event:write"},
+					Resources:       []string{"-"},
+				},
+				{
+					RequireMetadata: []string{"X-Resource-Name"},
+					Application:     "ingest",
+					Privileges:      []string{"write"},
+					DynamicResources: []DynamicResource{{
+						Metadata: "X-Resource-Name",
+						Format:   "source:%s",
+					}},
+				},
+			},
+			keyMetadata: []MetadataKeyConfig{
+				{Metadata: "X-Tenant-Id"},
+				{Metadata: "X-Resource-Name", Required: ptr(false)},
+			},
+			steps: []step{
+				{
+					metadata: map[string][]string{"X-Tenant-Id": {"deployment-1"}},
+					want: &hasprivileges.Request{Application: []types.ApplicationPrivilegesCheck{{
+						Application: "apm",
+						Resources:   []string{"-"},
+						Privileges:  []string{"event:write"},
+					}}},
+				},
+				{
+					metadata: map[string][]string{
+						"X-Tenant-Id":     {"deployment-1"},
+						"X-Resource-Name": {"otlp-01-deployment-1"},
+					},
+					want: &hasprivileges.Request{Application: []types.ApplicationPrivilegesCheck{{
+						Application: "ingest",
+						Resources:   []string{"source:otlp-01-deployment-1"},
+						Privileges:  []string{"write"},
+					}}},
+				},
+			},
+		},
+	}
 
-	config := createDefaultConfig().(*Config)
-	config.ApplicationPrivileges = []ApplicationPrivilegesConfig{{
-		Application: "my_app",
-		Privileges:  []string{"write"},
-		DynamicResources: []DynamicResource{{
-			Metadata: "X-Resource-Name",
-			Format:   "resource:%s",
-		}},
-	}}
-	config.Cache.KeyMetadata = []string{"X-Resource-Name"}
-	authenticator := newTestAuthenticator(t, srv, config)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var requests []hasprivileges.Request
+			srv := newMockElasticsearch(t, func(w http.ResponseWriter, r *http.Request) {
+				var body hasprivileges.Request
+				require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+				requests = append(requests, body)
+				require.NoError(t, json.NewEncoder(w).Encode(successfulResponse))
+			})
 
-	withMetadata := client.NewContext(context.Background(), client.Info{
-		Metadata: client.NewMetadata(map[string][]string{
-			"X-Resource-Name": {"my-resource", "another-resource"},
-		}),
-	})
-	ctx, err := authenticator.Authenticate(withMetadata, map[string][]string{
-		"Authorization": {"ApiKey " + base64.StdEncoding.EncodeToString([]byte("id:secret"))},
-	})
-	assert.NoError(t, err)
-	clientInfo := client.FromContext(ctx)
-	assert.Equal(t, user, clientInfo.Auth.GetAttribute("username"))
-	assert.Equal(t, "id", clientInfo.Auth.GetAttribute("api_key"))
+			config := createDefaultConfig().(*Config)
+			config.ApplicationPrivileges = tc.apps
+			config.Cache.KeyMetadata = tc.keyMetadata
+			authenticator := newTestAuthenticator(t, srv, config)
+
+			var want []hasprivileges.Request
+			for _, s := range tc.steps {
+				ctx := client.NewContext(context.Background(), client.Info{
+					Metadata: client.NewMetadata(s.metadata),
+				})
+				gotCtx, err := authenticator.Authenticate(ctx, map[string][]string{
+					"Authorization": {authHeader},
+				})
+				require.NoError(t, err)
+				clientInfo := client.FromContext(gotCtx)
+				require.Equal(t, user, clientInfo.Auth.GetAttribute("username"))
+				require.Equal(t, "id", clientInfo.Auth.GetAttribute("api_key"))
+				if s.want != nil {
+					want = append(want, *s.want)
+				}
+			}
+			require.Equal(t, want, requests)
+		})
+	}
 }
 
 func TestAuthenticator_DynamicResourcesMissingMetadata(t *testing.T) {
@@ -999,7 +1088,7 @@ func TestAuthenticator_DynamicResourcesMissingMetadata(t *testing.T) {
 			Format:   "resource:%s",
 		}},
 	}}
-	config.Cache.KeyMetadata = []string{"X-Resource-Name"}
+	config.Cache.KeyMetadata = []MetadataKeyConfig{{Metadata: "X-Resource-Name"}}
 	authenticator := newTestAuthenticator(t, newMockElasticsearch(t, newCannedHasPrivilegesHandler(successfulResponse)), config)
 
 	// Missing metadata should return an error, since it is required
@@ -1026,7 +1115,7 @@ func TestAuthenticator_DynamicResourcesMissingMetadataInHasPrivileges(t *testing
 	}}
 	// Don't include in cache key metadata to allow it to pass cache key check
 	// but fail in hasPrivileges
-	config.Cache.KeyMetadata = []string{}
+	config.Cache.KeyMetadata = []MetadataKeyConfig{}
 	authenticator := newTestAuthenticator(t, newMockElasticsearch(t, newCannedHasPrivilegesHandler(successfulResponse)), config)
 
 	// Missing metadata should return InvalidArgument (client error), not Unavailable

--- a/extension/apikeyauthextension/config.go
+++ b/extension/apikeyauthextension/config.go
@@ -103,6 +103,14 @@ type ClientRetryConfig struct {
 }
 
 type ApplicationPrivilegesConfig struct {
+	// RequireMetadata lists client metadata keys that must be present for
+	// this application privilege check to apply.
+	RequireMetadata []string `mapstructure:"require_metadata,omitempty"`
+
+	// ExcludeMetadata lists client metadata keys that must be absent for
+	// this application privilege check to apply.
+	ExcludeMetadata []string `mapstructure:"exclude_metadata,omitempty"`
+
 	// Application holds the name of the application for which
 	// privileges are defined, e.g. "apm".
 	Application string `mapstructure:"application"`
@@ -134,6 +142,17 @@ type DynamicResource struct {
 	// the metadata value. Must contain exactly one %s placeholder.
 	// Defaults to "%s" if empty.
 	Format string `mapstructure:"format"`
+
+	// Required controls whether missing Metadata is an error. Defaults to true.
+	Required *bool `mapstructure:"required,omitempty"`
+}
+
+type MetadataKeyConfig struct {
+	// Metadata holds the client metadata key to include in the cache key.
+	Metadata string `mapstructure:"metadata"`
+
+	// Required controls whether missing Metadata is an error. Defaults to true.
+	Required *bool `mapstructure:"required,omitempty"`
 }
 
 type CacheConfig struct {
@@ -144,9 +163,9 @@ type CacheConfig struct {
 
 	// KeyMetadata holds an optional set of client metadata keys to
 	// include in the cache key, for partitioning the API Key space.
-	// If any keys are missing from the client metadata, an error
+	// If any required keys are missing from the client metadata, an error
 	// will be returned.
-	KeyMetadata []string `mapstructure:"key_metadata,omitempty"`
+	KeyMetadata []MetadataKeyConfig `mapstructure:"key_metadata,omitempty"`
 
 	// PBKDF2Iterations defines the iteration count for PBKDF2
 	// for key derivation in cached API Keys.
@@ -223,6 +242,10 @@ func (cfg *ClientRetryConfig) Validate() error {
 	return nil
 }
 
+func (dr *DynamicResource) required() bool {
+	return dr.Required == nil || *dr.Required
+}
+
 // Unmarshal unmarshals the DynamicResource configuration.
 func (dr *DynamicResource) Unmarshal(conf *confmap.Conf) error {
 	if err := conf.Unmarshal(dr); err != nil {
@@ -261,18 +284,33 @@ func (dr *DynamicResource) Validate() error {
 	return nil
 }
 
+func (mk *MetadataKeyConfig) required() bool {
+	return mk.Required == nil || *mk.Required
+}
+
+// Validate validates the MetadataKeyConfig.
+func (mk *MetadataKeyConfig) Validate() error {
+	if mk.Metadata == "" {
+		return fmt.Errorf("metadata must be non-empty")
+	}
+	return nil
+}
+
 // Validate validates the Config.
 func (cfg *Config) Validate() error {
 	// Build a set of metadata keys in cache.key_metadata for quick lookup
 	keyMetadataSet := make(map[string]bool)
 	for _, key := range cfg.Cache.KeyMetadata {
-		keyMetadataSet[key] = true
+		keyMetadataSet[key.Metadata] = true
 	}
 	// Validate each application privilege config
 	for i, app := range cfg.ApplicationPrivileges {
 		// Check that dynamic resource metadata keys are in cache.key_metadata
 		for j, dr := range app.DynamicResources {
-			if dr.Metadata != "" && !keyMetadataSet[dr.Metadata] {
+			if dr.Metadata == "" {
+				continue
+			}
+			if !keyMetadataSet[dr.Metadata] {
 				return fmt.Errorf(""+
 					"application_privileges::%d::dynamic_resources::%d: "+
 					"dynamic resource metadata %q must be included in cache.key_metadata",

--- a/extension/apikeyauthextension/config_test.go
+++ b/extension/apikeyauthextension/config_test.go
@@ -80,9 +80,58 @@ func TestLoadConfig(t *testing.T) {
 						Format:   "%s",
 					}},
 				}}
-				config.Cache.KeyMetadata = []string{
-					"X-Resource-Name",
-					"X-Resource-Name-Default-Format",
+				config.Cache.KeyMetadata = []MetadataKeyConfig{
+					{Metadata: "X-Resource-Name"},
+					{Metadata: "X-Resource-Name-Default-Format"},
+				}
+				return config
+			}(),
+		},
+		{
+			id: component.NewIDWithName(metadata.Type, "optional_dynamic_resources"),
+			expected: func() *Config {
+				config := createDefaultConfig().(*Config)
+				config.ApplicationPrivileges = []ApplicationPrivilegesConfig{{
+					Application: "my_app",
+					Privileges:  []string{"write"},
+					Resources:   []string{"static-resource"},
+					DynamicResources: []DynamicResource{{
+						Metadata: "X-Resource-Name",
+						Format:   "resource:%s",
+						Required: ptr(false),
+					}},
+				}}
+				config.Cache.KeyMetadata = []MetadataKeyConfig{{
+					Metadata: "X-Resource-Name",
+					Required: ptr(false),
+				}}
+				return config
+			}(),
+		},
+		{
+			id: component.NewIDWithName(metadata.Type, "conditional_application_privileges"),
+			expected: func() *Config {
+				config := createDefaultConfig().(*Config)
+				config.ApplicationPrivileges = []ApplicationPrivilegesConfig{
+					{
+						ExcludeMetadata: []string{"X-Resource-Name"},
+						Application:     "apm",
+						Privileges:      []string{"event:write"},
+						Resources:       []string{"-"},
+					},
+					{
+						RequireMetadata: []string{"X-Resource-Name"},
+						Application:     "ingest",
+						Privileges:      []string{"write"},
+						DynamicResources: []DynamicResource{{
+							Metadata: "X-Resource-Name",
+							Format:   "source:%s",
+						}},
+					},
+				}
+				config.Cache.KeyMetadata = []MetadataKeyConfig{
+					{Metadata: "X-Tenant-Id"},
+					{Metadata: "X-Resource-Name", Required: ptr(false)},
 				}
 				return config
 			}(),
@@ -106,6 +155,10 @@ func TestLoadConfig(t *testing.T) {
 		{
 			id:                 component.NewIDWithName(metadata.Type, "dynamic_resources_empty_metadata"),
 			expectedErrMessage: `application_privileges::0::dynamic_resources::0: metadata must be non-empty`,
+		},
+		{
+			id:                 component.NewIDWithName(metadata.Type, "cache_key_metadata_empty"),
+			expectedErrMessage: `cache::key_metadata::0: metadata must be non-empty`,
 		},
 		{
 			id: component.NewIDWithName(metadata.Type, "custom_retry"),
@@ -244,4 +297,8 @@ func TestLoadConfig(t *testing.T) {
 		})
 	}
 
+}
+
+func ptr[T any](v T) *T {
+	return &v
 }

--- a/extension/apikeyauthextension/testdata/config.yaml
+++ b/extension/apikeyauthextension/testdata/config.yaml
@@ -20,7 +20,39 @@ apikeyauth/dynamic_resources:
           format: "resource:%s"
         - metadata: X-Resource-Name-Default-Format
   cache:
-    key_metadata: [X-Resource-Name, X-Resource-Name-Default-Format]
+    key_metadata:
+      - metadata: X-Resource-Name
+      - metadata: X-Resource-Name-Default-Format
+apikeyauth/optional_dynamic_resources:
+  application_privileges:
+    - application: my_app
+      privileges: [write]
+      resources: ['static-resource']
+      dynamic_resources:
+        - metadata: X-Resource-Name
+          format: "resource:%s"
+          required: false
+  cache:
+    key_metadata:
+      - metadata: X-Resource-Name
+        required: false
+apikeyauth/conditional_application_privileges:
+  application_privileges:
+    - exclude_metadata: [X-Resource-Name]
+      application: apm
+      privileges: [event:write]
+      resources: ['-']
+    - require_metadata: [X-Resource-Name]
+      application: ingest
+      privileges: [write]
+      dynamic_resources:
+        - metadata: X-Resource-Name
+          format: "source:%s"
+  cache:
+    key_metadata:
+      - metadata: X-Tenant-Id
+      - metadata: X-Resource-Name
+        required: false
 apikeyauth/dynamic_resources_missing_metadata:
   application_privileges:
     - application: my_app
@@ -42,7 +74,8 @@ apikeyauth/dynamic_resources_invalid_format:
         - metadata: X-Resource-Name
           format: "resource"
   cache:
-    key_metadata: [X-Resource-Name]
+    key_metadata:
+      - metadata: X-Resource-Name
 apikeyauth/dynamic_resources_multiple_format:
   application_privileges:
     - application: my_app
@@ -51,7 +84,8 @@ apikeyauth/dynamic_resources_multiple_format:
         - metadata: X-Resource-Name
           format: "resource:%s:%s"
   cache:
-    key_metadata: [X-Resource-Name]
+    key_metadata:
+      - metadata: X-Resource-Name
 apikeyauth/dynamic_resources_empty_metadata:
   application_privileges:
     - application: my_app
@@ -60,7 +94,12 @@ apikeyauth/dynamic_resources_empty_metadata:
         - metadata: ""
           format: "%s"
   cache:
-    key_metadata: [X-Resource-Name]
+    key_metadata:
+      - metadata: X-Resource-Name
+apikeyauth/cache_key_metadata_empty:
+  cache:
+    key_metadata:
+      - metadata: ""
 apikeyauth/custom_retry:
   elasticsearch_retry:
     enabled: true


### PR DESCRIPTION
Add support for conditional application privileges via `require_metadata`/`exclude_metadata` and for optional dynamic resources and cache-key metadata through a `required: false` flag, so privilege checks only apply when the relevant client metadata is present or absent, and consolidate the application-privilege request tests into a single table-driven test with added config validation coverage.

---

For @andrewvc PoC this:

```yaml
apikeyauth:
  cache:
    key_metadata: [x-elastic-target-id]
  application_privileges:
    - application: apm
      privileges: ["event:write"]
      resources: ["-"]

apikeyauth/sources:
  cache:
    key_metadata: [x-elastic-target-id, x-elastic-source-id]
  application_privileges:
    - application: ingest
      privileges: ["write"]
      dynamic_resources:
        - metadata: x-elastic-source-id
          format: "source:%s"

source_auth:
  sources: apikeyauth/sources
  fallback: apikeyauth

authmiddleware:
  auth: source_auth
```

Becomes:
```yaml
apikeyauth:
  cache:
    key_metadata:
      - metadata: x-elastic-target-id
      - metadata: x-elastic-source-id
        required: false
  application_privileges:
    - exclude_metadata: [x-elastic-source-id]
      application: apm
      privileges: ["event:write"]
      resources: ["-"]

    - require_metadata: [x-elastic-source-id]
      application: ingest
      privileges: ["write"]
      dynamic_resources:
        - metadata: x-elastic-source-id
          format: "source:%s"

authmiddleware:
  auth: apikeyauth
```