### PR TITLE
connector/elasticapmconnector: derive agent.name for metrics and logs signals

### DIFF
--- a/connector/elasticapmconnector/config.go
+++ b/connector/elasticapmconnector/config.go
@@ -242,10 +242,10 @@ func (cfg Config) signaltometricsConfig() *signaltometricsconfig.Config {
 			{Key: "telemetry.sdk.language"}, // service.language.name
 			{Key: "data_stream.namespace", Optional: true},
 
-			// agent.name is set via elasticapmprocessor for traces. For
-			// metrics and logs it is derived in connector.go from
-			// telemetry.sdk.* attributes (see setAgentName), so this
-			// default is only reached when neither has run.
+			// agent.name is set via elasticapmprocessor for traces, and
+			// via setAgentName in connector.go for metrics and logs,
+			// both of which always set a value (defaulting to "otlp").
+			// This "unknown" default is only reached if neither has run.
 			{
 				Key:          "agent.name",
 				DefaultValue: "unknown",

--- a/connector/elasticapmconnector/config.go
+++ b/connector/elasticapmconnector/config.go
@@ -242,9 +242,10 @@ func (cfg Config) signaltometricsConfig() *signaltometricsconfig.Config {
 			{Key: "telemetry.sdk.language"}, // service.language.name
 			{Key: "data_stream.namespace", Optional: true},
 
-			// agent.name is set via elasticapmprocessor for traces,
-			// but not for other signals. Default to "unknown" for the
-			// others.
+			// agent.name is set via elasticapmprocessor for traces. For
+			// metrics and logs it is derived in connector.go from
+			// telemetry.sdk.* attributes (see setAgentName), so this
+			// default is only reached when neither has run.
 			{
 				Key:          "agent.name",
 				DefaultValue: "unknown",

--- a/connector/elasticapmconnector/connector.go
+++ b/connector/elasticapmconnector/connector.go
@@ -181,9 +181,13 @@ func (e *logsResourceEnricher) Capabilities() consumer.Capabilities {
 
 // setAgentName derives the agent.name resource attribute from
 // telemetry.sdk.name, telemetry.sdk.language and telemetry.distro.name,
-// the same way elasticapmprocessor does for traces. It is a no-op if
-// agent.name is already set, e.g. by a classic Elastic APM agent, or if
-// none of the telemetry.* attributes are present.
+// the same way elasticapmprocessor does for traces (see setAgentName in
+// processor/elasticapmprocessor/internal/enrichments/resource.go; keep the
+// two in sync). It is a no-op if agent.name is already set, e.g. by a
+// classic Elastic APM agent. Otherwise it always sets a value, defaulting
+// to "otlp" when no telemetry.* attributes are present, so that a service
+// never ends up with a different agent.name on its traces than on its
+// metrics/logs-derived aggregates.
 func setAgentName(resource pcommon.Resource) {
 	attrs := resource.Attributes()
 	if _, ok := attrs.Get("agent.name"); ok {
@@ -202,9 +206,6 @@ func setAgentName(resource pcommon.Resource) {
 		}
 		return true
 	})
-	if sdkName == "" && sdkLanguage == "" && distroName == "" {
-		return
-	}
 
 	agentName := "otlp"
 	if sdkName != "" {

--- a/connector/elasticapmconnector/connector.go
+++ b/connector/elasticapmconnector/connector.go
@@ -19,10 +19,14 @@ package elasticapmconnector // import "github.com/elastic/opentelemetry-collecto
 
 import (
 	"context"
+	"fmt"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/connector"
 	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/processor"
 
@@ -80,12 +84,24 @@ func (c *elasticapmConnector) Shutdown(ctx context.Context) error {
 
 func (c *elasticapmConnector) newLogsConsumer(ctx context.Context) (consumer.Logs, error) {
 	set := c.signaltometricsSettings()
-	return signaltometricsFactory.CreateLogsToMetrics(ctx, set, c.cfg.signaltometricsConfig(), c.lsminterval)
+	baseConsumer, err := signaltometricsFactory.CreateLogsToMetrics(ctx, set, c.cfg.signaltometricsConfig(), c.lsminterval)
+	if err != nil {
+		return nil, err
+	}
+	// Wrap the base consumer to derive agent.name, since it isn't set by
+	// elasticapmprocessor for the logs signal.
+	return &logsResourceEnricher{next: baseConsumer}, nil
 }
 
 func (c *elasticapmConnector) newMetricsConsumer(ctx context.Context) (consumer.Metrics, error) {
 	set := c.signaltometricsSettings()
-	return signaltometricsFactory.CreateMetricsToMetrics(ctx, set, c.cfg.signaltometricsConfig(), c.lsminterval)
+	baseConsumer, err := signaltometricsFactory.CreateMetricsToMetrics(ctx, set, c.cfg.signaltometricsConfig(), c.lsminterval)
+	if err != nil {
+		return nil, err
+	}
+	// Wrap the base consumer to derive agent.name, since it isn't set by
+	// elasticapmprocessor for the metrics signal.
+	return &metricsResourceEnricher{next: baseConsumer}, nil
 }
 
 func (c *elasticapmConnector) newTracesToMetrics(ctx context.Context) (consumer.Traces, error) {
@@ -125,6 +141,86 @@ func (e *spanEnricher) ConsumeTraces(ctx context.Context, td ptrace.Traces) erro
 
 func (e *spanEnricher) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: true}
+}
+
+// metricsResourceEnricher wraps a metrics consumer to derive the agent.name
+// resource attribute, mirroring what elasticapmprocessor does for traces.
+type metricsResourceEnricher struct {
+	next consumer.Metrics
+}
+
+func (e *metricsResourceEnricher) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
+	rms := md.ResourceMetrics()
+	for i := 0; i < rms.Len(); i++ {
+		setAgentName(rms.At(i).Resource())
+	}
+	return e.next.ConsumeMetrics(ctx, md)
+}
+
+func (e *metricsResourceEnricher) Capabilities() consumer.Capabilities {
+	return consumer.Capabilities{MutatesData: true}
+}
+
+// logsResourceEnricher wraps a logs consumer to derive the agent.name
+// resource attribute, mirroring what elasticapmprocessor does for traces.
+type logsResourceEnricher struct {
+	next consumer.Logs
+}
+
+func (e *logsResourceEnricher) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
+	rls := ld.ResourceLogs()
+	for i := 0; i < rls.Len(); i++ {
+		setAgentName(rls.At(i).Resource())
+	}
+	return e.next.ConsumeLogs(ctx, ld)
+}
+
+func (e *logsResourceEnricher) Capabilities() consumer.Capabilities {
+	return consumer.Capabilities{MutatesData: true}
+}
+
+// setAgentName derives the agent.name resource attribute from
+// telemetry.sdk.name, telemetry.sdk.language and telemetry.distro.name,
+// the same way elasticapmprocessor does for traces. It is a no-op if
+// agent.name is already set, e.g. by a classic Elastic APM agent, or if
+// none of the telemetry.* attributes are present.
+func setAgentName(resource pcommon.Resource) {
+	attrs := resource.Attributes()
+	if _, ok := attrs.Get("agent.name"); ok {
+		return
+	}
+
+	var sdkName, sdkLanguage, distroName string
+	attrs.Range(func(k string, v pcommon.Value) bool {
+		switch k {
+		case "telemetry.sdk.name":
+			sdkName = v.Str()
+		case "telemetry.sdk.language":
+			sdkLanguage = v.Str()
+		case "telemetry.distro.name":
+			distroName = v.Str()
+		}
+		return true
+	})
+	if sdkName == "" && sdkLanguage == "" && distroName == "" {
+		return
+	}
+
+	agentName := "otlp"
+	if sdkName != "" {
+		agentName = sdkName
+	}
+	switch {
+	case distroName != "":
+		lang := "unknown"
+		if sdkLanguage != "" {
+			lang = sdkLanguage
+		}
+		agentName = fmt.Sprintf("%s/%s/%s", agentName, lang, distroName)
+	case sdkLanguage != "":
+		agentName = fmt.Sprintf("%s/%s", agentName, sdkLanguage)
+	}
+	attrs.PutStr("agent.name", agentName)
 }
 
 func (c *elasticapmConnector) signaltometricsSettings() connector.Settings {

--- a/connector/elasticapmconnector/connector.go
+++ b/connector/elasticapmconnector/connector.go
@@ -88,8 +88,9 @@ func (c *elasticapmConnector) newLogsConsumer(ctx context.Context) (consumer.Log
 	if err != nil {
 		return nil, err
 	}
-	// Wrap the base consumer to derive agent.name, since it isn't set by
-	// elasticapmprocessor for the logs signal.
+	// Wrap the base consumer to derive agent.name: the connector may be used
+	// without elasticapmprocessor in the pipeline, or with skip_enrichment
+	// enabled, in which case agent.name is not set upstream for this signal.
 	return &logsResourceEnricher{next: baseConsumer}, nil
 }
 
@@ -99,8 +100,9 @@ func (c *elasticapmConnector) newMetricsConsumer(ctx context.Context) (consumer.
 	if err != nil {
 		return nil, err
 	}
-	// Wrap the base consumer to derive agent.name, since it isn't set by
-	// elasticapmprocessor for the metrics signal.
+	// Wrap the base consumer to derive agent.name: the connector may be used
+	// without elasticapmprocessor in the pipeline, or with skip_enrichment
+	// enabled, in which case agent.name is not set upstream for this signal.
 	return &metricsResourceEnricher{next: baseConsumer}, nil
 }
 
@@ -144,7 +146,7 @@ func (e *spanEnricher) Capabilities() consumer.Capabilities {
 }
 
 // metricsResourceEnricher wraps a metrics consumer to derive the agent.name
-// resource attribute, mirroring what elasticapmprocessor does for traces.
+// resource attribute via agentname.Derive before aggregation.
 type metricsResourceEnricher struct {
 	next consumer.Metrics
 }
@@ -162,7 +164,7 @@ func (e *metricsResourceEnricher) Capabilities() consumer.Capabilities {
 }
 
 // logsResourceEnricher wraps a logs consumer to derive the agent.name
-// resource attribute, mirroring what elasticapmprocessor does for traces.
+// resource attribute via agentname.Derive before aggregation.
 type logsResourceEnricher struct {
 	next consumer.Logs
 }

--- a/connector/elasticapmconnector/connector.go
+++ b/connector/elasticapmconnector/connector.go
@@ -179,19 +179,26 @@ func (e *logsResourceEnricher) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: true}
 }
 
+const (
+	attrAgentName   = "agent.name"
+	attrSDKName     = "telemetry.sdk.name"
+	attrSDKLanguage = "telemetry.sdk.language"
+	attrDistroName  = "telemetry.distro.name"
+)
+
 // setAgentName derives the agent.name resource attribute using agentname.Derive.
 // It is a no-op if agent.name is already set, e.g. by a classic Elastic APM agent,
 // preserving the existing value (including empty string) to match the behaviour of
 // the attribute.PutStr guard used by elasticapmprocessor.
 func setAgentName(resource pcommon.Resource) {
 	attrs := resource.Attributes()
-	if _, ok := attrs.Get("agent.name"); ok {
+	if _, ok := attrs.Get(attrAgentName); ok {
 		return
 	}
-	sdkName, _ := attrs.Get("telemetry.sdk.name")
-	sdkLanguage, _ := attrs.Get("telemetry.sdk.language")
-	distroName, _ := attrs.Get("telemetry.distro.name")
-	attrs.PutStr("agent.name", agentname.Derive(sdkName.Str(), sdkLanguage.Str(), distroName.Str()))
+	sdkName, _ := attrs.Get(attrSDKName)
+	sdkLanguage, _ := attrs.Get(attrSDKLanguage)
+	distroName, _ := attrs.Get(attrDistroName)
+	attrs.PutStr(attrAgentName, agentname.Derive(sdkName.Str(), sdkLanguage.Str(), distroName.Str()))
 }
 
 func (c *elasticapmConnector) signaltometricsSettings() connector.Settings {

--- a/connector/elasticapmconnector/connector.go
+++ b/connector/elasticapmconnector/connector.go
@@ -19,7 +19,6 @@ package elasticapmconnector // import "github.com/elastic/opentelemetry-collecto
 
 import (
 	"context"
-	"fmt"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/connector"
@@ -32,6 +31,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/connector/signaltometricsconnector"
 
+	"github.com/elastic/opentelemetry-collector-components/internal/agentname"
 	"github.com/elastic/opentelemetry-collector-components/processor/lsmintervalprocessor"
 )
 
@@ -179,49 +179,19 @@ func (e *logsResourceEnricher) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: true}
 }
 
-// setAgentName derives the agent.name resource attribute from
-// telemetry.sdk.name, telemetry.sdk.language and telemetry.distro.name,
-// the same way elasticapmprocessor does for traces (see setAgentName in
-// processor/elasticapmprocessor/internal/enrichments/resource.go; keep the
-// two in sync). It is a no-op if agent.name is already set, e.g. by a
-// classic Elastic APM agent. Otherwise it always sets a value, defaulting
-// to "otlp" when no telemetry.* attributes are present, so that a service
-// never ends up with a different agent.name on its traces than on its
-// metrics/logs-derived aggregates.
+// setAgentName derives the agent.name resource attribute using agentname.Derive.
+// It is a no-op if agent.name is already set, e.g. by a classic Elastic APM agent,
+// preserving the existing value (including empty string) to match the behaviour of
+// the attribute.PutStr guard used by elasticapmprocessor.
 func setAgentName(resource pcommon.Resource) {
 	attrs := resource.Attributes()
 	if _, ok := attrs.Get("agent.name"); ok {
 		return
 	}
-
-	var sdkName, sdkLanguage, distroName string
-	attrs.Range(func(k string, v pcommon.Value) bool {
-		switch k {
-		case "telemetry.sdk.name":
-			sdkName = v.Str()
-		case "telemetry.sdk.language":
-			sdkLanguage = v.Str()
-		case "telemetry.distro.name":
-			distroName = v.Str()
-		}
-		return true
-	})
-
-	agentName := "otlp"
-	if sdkName != "" {
-		agentName = sdkName
-	}
-	switch {
-	case distroName != "":
-		lang := "unknown"
-		if sdkLanguage != "" {
-			lang = sdkLanguage
-		}
-		agentName = fmt.Sprintf("%s/%s/%s", agentName, lang, distroName)
-	case sdkLanguage != "":
-		agentName = fmt.Sprintf("%s/%s", agentName, sdkLanguage)
-	}
-	attrs.PutStr("agent.name", agentName)
+	sdkName, _ := attrs.Get("telemetry.sdk.name")
+	sdkLanguage, _ := attrs.Get("telemetry.sdk.language")
+	distroName, _ := attrs.Get("telemetry.distro.name")
+	attrs.PutStr("agent.name", agentname.Derive(sdkName.Str(), sdkLanguage.Str(), distroName.Str()))
 }
 
 func (c *elasticapmConnector) signaltometricsSettings() connector.Settings {

--- a/connector/elasticapmconnector/go.mod
+++ b/connector/elasticapmconnector/go.mod
@@ -3,6 +3,7 @@ module github.com/elastic/opentelemetry-collector-components/connector/elasticap
 go 1.25.0
 
 require (
+	github.com/elastic/opentelemetry-collector-components/internal/agentname v0.0.0
 	github.com/elastic/opentelemetry-collector-components/internal/sharedcomponent v0.0.0-20250220025958-386ba0c4bced
 	github.com/elastic/opentelemetry-collector-components/processor/lsmintervalprocessor v0.62.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/connector/signaltometricsconnector v0.156.0
@@ -114,6 +115,8 @@ require (
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/elastic/opentelemetry-collector-components/internal/agentname => ../../internal/agentname
 
 replace github.com/elastic/opentelemetry-collector-components/internal/sharedcomponent => ../../internal/sharedcomponent
 

--- a/connector/elasticapmconnector/resource_enricher_test.go
+++ b/connector/elasticapmconnector/resource_enricher_test.go
@@ -18,10 +18,15 @@
 package elasticapmconnector
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
 )
 
 func TestSetAgentName(t *testing.T) {
@@ -57,6 +62,23 @@ func TestSetAgentName(t *testing.T) {
 			},
 			expected: "opentelemetry/unknown/elastic",
 		},
+		"distro name without sdk name": {
+			attrs: map[string]string{
+				"telemetry.sdk.language": "java",
+				"telemetry.distro.name":  "elastic",
+			},
+			expected: "otlp/java/elastic",
+		},
+		"sdk name only": {
+			attrs: map[string]string{
+				"telemetry.sdk.name": "opentelemetry",
+			},
+			expected: "opentelemetry",
+		},
+		"no telemetry attributes defaults to otlp": {
+			attrs:    map[string]string{},
+			expected: "otlp",
+		},
 		"already set is preserved": {
 			attrs: map[string]string{
 				"agent.name":             "my-custom-agent",
@@ -64,8 +86,11 @@ func TestSetAgentName(t *testing.T) {
 			},
 			expected: "my-custom-agent",
 		},
-		"no telemetry attributes is a no-op": {
-			attrs:    map[string]string{},
+		"already set to empty string is preserved": {
+			attrs: map[string]string{
+				"agent.name":             "",
+				"telemetry.sdk.language": "go",
+			},
 			expected: "",
 		},
 	} {
@@ -78,12 +103,82 @@ func TestSetAgentName(t *testing.T) {
 			setAgentName(resource)
 
 			got, ok := resource.Attributes().Get("agent.name")
-			if tc.expected == "" {
-				assert.False(t, ok)
-				return
-			}
-			assert.True(t, ok)
+			assert.True(t, ok, "agent.name should always be set")
 			assert.Equal(t, tc.expected, got.Str())
 		})
 	}
+}
+
+func TestMetricsResourceEnricher_MultipleResources(t *testing.T) {
+	md := pmetric.NewMetrics()
+	rm1 := md.ResourceMetrics().AppendEmpty()
+	rm1.Resource().Attributes().PutStr("telemetry.sdk.language", "go")
+	rm2 := md.ResourceMetrics().AppendEmpty()
+	rm2.Resource().Attributes().PutStr("agent.name", "my-custom-agent")
+
+	var got pmetric.Metrics
+	sink := &metricsSinkFunc{fn: func(_ context.Context, md pmetric.Metrics) error {
+		got = md
+		return nil
+	}}
+	enricher := &metricsResourceEnricher{next: sink}
+	require.NoError(t, enricher.ConsumeMetrics(context.Background(), md))
+
+	rms := got.ResourceMetrics()
+	require.Equal(t, 2, rms.Len())
+	name1, ok := rms.At(0).Resource().Attributes().Get("agent.name")
+	require.True(t, ok)
+	assert.Equal(t, "otlp/go", name1.Str())
+	name2, ok := rms.At(1).Resource().Attributes().Get("agent.name")
+	require.True(t, ok)
+	assert.Equal(t, "my-custom-agent", name2.Str())
+}
+
+func TestLogsResourceEnricher_MultipleResources(t *testing.T) {
+	ld := plog.NewLogs()
+	rl1 := ld.ResourceLogs().AppendEmpty()
+	rl1.Resource().Attributes().PutStr("telemetry.sdk.language", "go")
+	rl2 := ld.ResourceLogs().AppendEmpty()
+	rl2.Resource().Attributes().PutStr("agent.name", "my-custom-agent")
+
+	var got plog.Logs
+	sink := &logsSinkFunc{fn: func(_ context.Context, ld plog.Logs) error {
+		got = ld
+		return nil
+	}}
+	enricher := &logsResourceEnricher{next: sink}
+	require.NoError(t, enricher.ConsumeLogs(context.Background(), ld))
+
+	rls := got.ResourceLogs()
+	require.Equal(t, 2, rls.Len())
+	name1, ok := rls.At(0).Resource().Attributes().Get("agent.name")
+	require.True(t, ok)
+	assert.Equal(t, "otlp/go", name1.Str())
+	name2, ok := rls.At(1).Resource().Attributes().Get("agent.name")
+	require.True(t, ok)
+	assert.Equal(t, "my-custom-agent", name2.Str())
+}
+
+type metricsSinkFunc struct {
+	fn func(context.Context, pmetric.Metrics) error
+}
+
+func (s *metricsSinkFunc) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
+	return s.fn(ctx, md)
+}
+
+func (s *metricsSinkFunc) Capabilities() consumer.Capabilities {
+	return consumer.Capabilities{MutatesData: false}
+}
+
+type logsSinkFunc struct {
+	fn func(context.Context, plog.Logs) error
+}
+
+func (s *logsSinkFunc) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
+	return s.fn(ctx, ld)
+}
+
+func (s *logsSinkFunc) Capabilities() consumer.Capabilities {
+	return consumer.Capabilities{MutatesData: false}
 }

--- a/connector/elasticapmconnector/resource_enricher_test.go
+++ b/connector/elasticapmconnector/resource_enricher_test.go
@@ -1,0 +1,89 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package elasticapmconnector
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+func TestSetAgentName(t *testing.T) {
+	for name, tc := range map[string]struct {
+		attrs    map[string]string
+		expected string
+	}{
+		"sdk name and language": {
+			attrs: map[string]string{
+				"telemetry.sdk.name":     "opentelemetry",
+				"telemetry.sdk.language": "nodejs",
+			},
+			expected: "opentelemetry/nodejs",
+		},
+		"language only": {
+			attrs: map[string]string{
+				"telemetry.sdk.language": "go",
+			},
+			expected: "otlp/go",
+		},
+		"distro name": {
+			attrs: map[string]string{
+				"telemetry.sdk.name":     "opentelemetry",
+				"telemetry.sdk.language": "java",
+				"telemetry.distro.name":  "elastic",
+			},
+			expected: "opentelemetry/java/elastic",
+		},
+		"distro name without language": {
+			attrs: map[string]string{
+				"telemetry.sdk.name":    "opentelemetry",
+				"telemetry.distro.name": "elastic",
+			},
+			expected: "opentelemetry/unknown/elastic",
+		},
+		"already set is preserved": {
+			attrs: map[string]string{
+				"agent.name":             "my-custom-agent",
+				"telemetry.sdk.language": "go",
+			},
+			expected: "my-custom-agent",
+		},
+		"no telemetry attributes is a no-op": {
+			attrs:    map[string]string{},
+			expected: "",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			resource := pcommon.NewResource()
+			for k, v := range tc.attrs {
+				resource.Attributes().PutStr(k, v)
+			}
+
+			setAgentName(resource)
+
+			got, ok := resource.Attributes().Get("agent.name")
+			if tc.expected == "" {
+				assert.False(t, ok)
+				return
+			}
+			assert.True(t, ok)
+			assert.Equal(t, tc.expected, got.Str())
+		})
+	}
+}

--- a/connector/elasticapmconnector/testdata/logs/service_summary/aggregated_metrics.yaml
+++ b/connector/elasticapmconnector/testdata/logs/service_summary/aggregated_metrics.yaml
@@ -3,7 +3,7 @@ resourceMetrics:
       attributes:
         - key: agent.name
           value:
-            stringValue: unknown
+            stringValue: otlp/go
         - key: deployment.environment
           value:
             stringValue: qa
@@ -33,6 +33,7 @@ resourceMetrics:
                     - key: processor.event
                       value:
                         stringValue: metric
+                  timeUnixNano: "1000000"
           - name: service_summary
             sum:
               aggregationTemporality: 1
@@ -51,6 +52,7 @@ resourceMetrics:
                     - key: processor.event
                       value:
                         stringValue: metric
+                  timeUnixNano: "1000000"
           - name: service_summary
             sum:
               aggregationTemporality: 1
@@ -69,5 +71,6 @@ resourceMetrics:
                     - key: processor.event
                       value:
                         stringValue: metric
+                  timeUnixNano: "1000000"
         scope:
           name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/signaltometricsconnector

--- a/connector/elasticapmconnector/testdata/logs/service_summary_custom_attrs/aggregated_metrics.yaml
+++ b/connector/elasticapmconnector/testdata/logs/service_summary_custom_attrs/aggregated_metrics.yaml
@@ -3,19 +3,19 @@ resourceMetrics:
       attributes:
         - key: agent.name
           value:
-            stringValue: unknown
+            stringValue: otlp/go
         - key: deployment.environment
           value:
             stringValue: qa
+        - key: foo
+          value:
+            stringValue: bar
         - key: service.name
           value:
             stringValue: foo
         - key: telemetry.sdk.language
           value:
             stringValue: go
-        - key: foo
-          value:
-            stringValue: bar
     scopeMetrics:
       - metrics:
           - name: service_summary
@@ -36,6 +36,7 @@ resourceMetrics:
                     - key: processor.event
                       value:
                         stringValue: metric
+                  timeUnixNano: "1000000"
           - name: service_summary
             sum:
               aggregationTemporality: 1
@@ -54,6 +55,7 @@ resourceMetrics:
                     - key: processor.event
                       value:
                         stringValue: metric
+                  timeUnixNano: "1000000"
           - name: service_summary
             sum:
               aggregationTemporality: 1
@@ -72,5 +74,6 @@ resourceMetrics:
                     - key: processor.event
                       value:
                         stringValue: metric
+                  timeUnixNano: "1000000"
         scope:
           name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/signaltometricsconnector

--- a/connector/elasticapmconnector/testdata/logs/service_summary_no_overflow/aggregated_metrics.yaml
+++ b/connector/elasticapmconnector/testdata/logs/service_summary_no_overflow/aggregated_metrics.yaml
@@ -3,7 +3,7 @@ resourceMetrics:
       attributes:
         - key: agent.name
           value:
-            stringValue: unknown
+            stringValue: otlp/go
         - key: deployment.environment
           value:
             stringValue: qa
@@ -33,6 +33,7 @@ resourceMetrics:
                     - key: processor.event
                       value:
                         stringValue: metric
+                  timeUnixNano: "1000000"
           - name: service_summary
             sum:
               aggregationTemporality: 1
@@ -51,6 +52,7 @@ resourceMetrics:
                     - key: processor.event
                       value:
                         stringValue: metric
+                  timeUnixNano: "1000000"
           - name: service_summary
             sum:
               aggregationTemporality: 1
@@ -69,5 +71,6 @@ resourceMetrics:
                     - key: processor.event
                       value:
                         stringValue: metric
+                  timeUnixNano: "1000000"
         scope:
           name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/signaltometricsconnector

--- a/connector/elasticapmconnector/testdata/logs/service_summary_overflow/aggregated_metrics.yaml
+++ b/connector/elasticapmconnector/testdata/logs/service_summary_overflow/aggregated_metrics.yaml
@@ -1,139 +1,145 @@
 resourceMetrics:
   - resource:
       attributes:
-        - key: service.name
-          value:
-            stringValue: foo
-        - key: deployment.environment
-          value:
-            stringValue: qa
-        - key: telemetry.sdk.language
-          value:
-            stringValue: go
-        - key: agent.name
-          value:
-            stringValue: unknown
-    scopeMetrics:
-      - scope:
-          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/signaltometricsconnector
-        metrics:
-          - name: service_summary
-            sum:
-              aggregationTemporality: 1
-              dataPoints:
-                - asInt: 1
-                  attributes:
-                    - key: data_stream.dataset
-                      value:
-                        stringValue: service_summary.1m
-                    - key: metricset.name
-                      value:
-                        stringValue: service_summary
-                    - key: metricset.interval
-                      value:
-                        stringValue: "1m"
-                    - key: processor.event
-                      value:
-                        stringValue: metric
-          - name: service_summary
-            sum:
-              aggregationTemporality: 1
-              dataPoints:
-                - asInt: 1
-                  attributes:
-                    - key: data_stream.dataset
-                      value:
-                        stringValue: service_summary.10m
-                    - key: metricset.name
-                      value:
-                        stringValue: service_summary
-                    - key: metricset.interval
-                      value:
-                        stringValue: "10m"
-                    - key: processor.event
-                      value:
-                        stringValue: metric
-          - name: service_summary
-            sum:
-              aggregationTemporality: 1
-              dataPoints:
-                - asInt: 1
-                  attributes:
-                    - key: data_stream.dataset
-                      value:
-                        stringValue: service_summary.60m
-                    - key: metricset.name
-                      value:
-                        stringValue: service_summary
-                    - key: metricset.interval
-                      value:
-                        stringValue: "60m"
-                    - key: processor.event
-                      value:
-                        stringValue: metric
-  - resource:
-      attributes:
-        - key: service.name
-          value:
-            stringValue: "_other"
         - key: overflow
           value:
             stringValue: resource
+        - key: service.name
+          value:
+            stringValue: _other
     scopeMetrics:
-      - scope:
-          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/signaltometricsconnector
-        metrics:
+      - metrics:
           - name: service_summary
             sum:
               aggregationTemporality: 1
               dataPoints:
-                - asInt: 1
+                - asInt: "1"
                   attributes:
                     - key: data_stream.dataset
                       value:
                         stringValue: service_summary.1m
+                    - key: metricset.interval
+                      value:
+                        stringValue: 1m
                     - key: metricset.name
                       value:
                         stringValue: service_summary
-                    - key: metricset.interval
-                      value:
-                        stringValue: "1m"
                     - key: processor.event
                       value:
                         stringValue: metric
+                  timeUnixNano: "1000000"
           - name: service_summary
             sum:
               aggregationTemporality: 1
               dataPoints:
-                - asInt: 1
+                - asInt: "1"
                   attributes:
                     - key: data_stream.dataset
                       value:
                         stringValue: service_summary.10m
+                    - key: metricset.interval
+                      value:
+                        stringValue: 10m
                     - key: metricset.name
                       value:
                         stringValue: service_summary
-                    - key: metricset.interval
-                      value:
-                        stringValue: "10m"
                     - key: processor.event
                       value:
                         stringValue: metric
+                  timeUnixNano: "1000000"
           - name: service_summary
             sum:
               aggregationTemporality: 1
               dataPoints:
-                - asInt: 1
+                - asInt: "1"
                   attributes:
                     - key: data_stream.dataset
                       value:
                         stringValue: service_summary.60m
+                    - key: metricset.interval
+                      value:
+                        stringValue: 60m
                     - key: metricset.name
                       value:
                         stringValue: service_summary
-                    - key: metricset.interval
-                      value:
-                        stringValue: "60m"
                     - key: processor.event
                       value:
                         stringValue: metric
+                  timeUnixNano: "1000000"
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/signaltometricsconnector
+  - resource:
+      attributes:
+        - key: agent.name
+          value:
+            stringValue: otlp/go
+        - key: deployment.environment
+          value:
+            stringValue: qa
+        - key: service.name
+          value:
+            stringValue: foo
+        - key: telemetry.sdk.language
+          value:
+            stringValue: go
+    scopeMetrics:
+      - metrics:
+          - name: service_summary
+            sum:
+              aggregationTemporality: 1
+              dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: data_stream.dataset
+                      value:
+                        stringValue: service_summary.1m
+                    - key: metricset.interval
+                      value:
+                        stringValue: 1m
+                    - key: metricset.name
+                      value:
+                        stringValue: service_summary
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                  timeUnixNano: "1000000"
+          - name: service_summary
+            sum:
+              aggregationTemporality: 1
+              dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: data_stream.dataset
+                      value:
+                        stringValue: service_summary.10m
+                    - key: metricset.interval
+                      value:
+                        stringValue: 10m
+                    - key: metricset.name
+                      value:
+                        stringValue: service_summary
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                  timeUnixNano: "1000000"
+          - name: service_summary
+            sum:
+              aggregationTemporality: 1
+              dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: data_stream.dataset
+                      value:
+                        stringValue: service_summary.60m
+                    - key: metricset.interval
+                      value:
+                        stringValue: 60m
+                    - key: metricset.name
+                      value:
+                        stringValue: service_summary
+                    - key: processor.event
+                      value:
+                        stringValue: metric
+                  timeUnixNano: "1000000"
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/signaltometricsconnector

--- a/connector/elasticapmconnector/testdata/metrics/service_summary/aggregated_metrics.yaml
+++ b/connector/elasticapmconnector/testdata/metrics/service_summary/aggregated_metrics.yaml
@@ -3,7 +3,7 @@ resourceMetrics:
       attributes:
         - key: agent.name
           value:
-            stringValue: unknown
+            stringValue: otlp/go
         - key: deployment.environment
           value:
             stringValue: qa

--- a/connector/elasticapmconnector/testdata/metrics/service_summary_custom_attrs/aggregated_metrics.yaml
+++ b/connector/elasticapmconnector/testdata/metrics/service_summary_custom_attrs/aggregated_metrics.yaml
@@ -3,19 +3,19 @@ resourceMetrics:
       attributes:
         - key: agent.name
           value:
-            stringValue: unknown
+            stringValue: otlp/go
         - key: deployment.environment
           value:
             stringValue: qa
+        - key: foo
+          value:
+            stringValue: bar
         - key: service.name
           value:
             stringValue: foo
         - key: telemetry.sdk.language
           value:
             stringValue: go
-        - key: foo
-          value:
-            stringValue: bar
     scopeMetrics:
       - metrics:
           - name: service_summary

--- a/connector/elasticapmconnector/testdata/metrics/service_summary_no_overflow/aggregated_metrics.yaml
+++ b/connector/elasticapmconnector/testdata/metrics/service_summary_no_overflow/aggregated_metrics.yaml
@@ -3,7 +3,7 @@ resourceMetrics:
       attributes:
         - key: agent.name
           value:
-            stringValue: unknown
+            stringValue: otlp/go
         - key: deployment.environment
           value:
             stringValue: qa

--- a/connector/elasticapmconnector/testdata/metrics/service_summary_overflow/aggregated_metrics.yaml
+++ b/connector/elasticapmconnector/testdata/metrics/service_summary_overflow/aggregated_metrics.yaml
@@ -1,18 +1,12 @@
 resourceMetrics:
   - resource:
       attributes:
-        - key: deployment.environment
+        - key: overflow
           value:
-            stringValue: qa
+            stringValue: resource
         - key: service.name
           value:
-            stringValue: foo
-        - key: telemetry.sdk.language
-          value:
-            stringValue: go
-        - key: agent.name
-          value:
-            stringValue: unknown
+            stringValue: _other
     scopeMetrics:
       - metrics:
           - name: service_summary
@@ -76,12 +70,18 @@ resourceMetrics:
           name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/signaltometricsconnector
   - resource:
       attributes:
+        - key: agent.name
+          value:
+            stringValue: otlp/go
+        - key: deployment.environment
+          value:
+            stringValue: qa
         - key: service.name
           value:
-            stringValue: "_other"
-        - key: overflow
+            stringValue: foo
+        - key: telemetry.sdk.language
           value:
-            stringValue: resource
+            stringValue: go
     scopeMetrics:
       - metrics:
           - name: service_summary

--- a/distributions/elastic-components/manifest.yaml
+++ b/distributions/elastic-components/manifest.yaml
@@ -95,4 +95,5 @@ replaces:
   - github.com/elastic/opentelemetry-collector-components/receiver/entityanalyticsreceiver => ../receiver/entityanalyticsreceiver
   - github.com/elastic/opentelemetry-collector-components/receiver/akamaisiemreceiver => ../receiver/akamaisiemreceiver
   - github.com/elastic/opentelemetry-collector-components/processor/elastictraceprocessor => ../processor/elastictraceprocessor
+  - github.com/elastic/opentelemetry-collector-components/internal/agentname => ../internal/agentname
   - github.com/elastic/opentelemetry-collector-components/internal/elasticattr => ../internal/elasticattr

--- a/internal/agentname/Makefile
+++ b/internal/agentname/Makefile
@@ -1,0 +1,1 @@
+include ../../Makefile.Common

--- a/internal/agentname/agentname.go
+++ b/internal/agentname/agentname.go
@@ -1,0 +1,46 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package agentname derives the Elastic APM agent.name resource attribute
+// from OTel SDK telemetry resource attributes.
+package agentname // import "github.com/elastic/opentelemetry-collector-components/internal/agentname"
+
+import "fmt"
+
+// Derive computes the agent.name value from the three OTel SDK telemetry
+// resource attributes. It returns "otlp" when none are present, matching
+// the behaviour of classic Elastic APM agents that do not set agent.name.
+//
+// Callers are responsible for deciding whether to apply the result (e.g.
+// skipping if agent.name is already present on the resource).
+func Derive(sdkName, sdkLanguage, distroName string) string {
+	agentName := "otlp"
+	if sdkName != "" {
+		agentName = sdkName
+	}
+	switch {
+	case distroName != "":
+		lang := "unknown"
+		if sdkLanguage != "" {
+			lang = sdkLanguage
+		}
+		agentName = fmt.Sprintf("%s/%s/%s", agentName, lang, distroName)
+	case sdkLanguage != "":
+		agentName = fmt.Sprintf("%s/%s", agentName, sdkLanguage)
+	}
+	return agentName
+}

--- a/internal/agentname/agentname_test.go
+++ b/internal/agentname/agentname_test.go
@@ -1,0 +1,70 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package agentname
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDerive(t *testing.T) {
+	for name, tc := range map[string]struct {
+		sdkName     string
+		sdkLanguage string
+		distroName  string
+		expected    string
+	}{
+		"sdk name and language": {
+			sdkName:     "opentelemetry",
+			sdkLanguage: "nodejs",
+			expected:    "opentelemetry/nodejs",
+		},
+		"language only": {
+			sdkLanguage: "go",
+			expected:    "otlp/go",
+		},
+		"distro name": {
+			sdkName:     "opentelemetry",
+			sdkLanguage: "java",
+			distroName:  "elastic",
+			expected:    "opentelemetry/java/elastic",
+		},
+		"distro name without language": {
+			sdkName:    "opentelemetry",
+			distroName: "elastic",
+			expected:   "opentelemetry/unknown/elastic",
+		},
+		"distro name without sdk name": {
+			sdkLanguage: "java",
+			distroName:  "elastic",
+			expected:    "otlp/java/elastic",
+		},
+		"sdk name only": {
+			sdkName:  "opentelemetry",
+			expected: "opentelemetry",
+		},
+		"no telemetry attributes defaults to otlp": {
+			expected: "otlp",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, Derive(tc.sdkName, tc.sdkLanguage, tc.distroName))
+		})
+	}
+}

--- a/internal/agentname/go.mod
+++ b/internal/agentname/go.mod
@@ -1,0 +1,11 @@
+module github.com/elastic/opentelemetry-collector-components/internal/agentname
+
+go 1.24.0
+
+require github.com/stretchr/testify v1.11.1
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/internal/agentname/go.sum
+++ b/internal/agentname/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/processor/elasticapmprocessor/go.mod
+++ b/processor/elasticapmprocessor/go.mod
@@ -5,6 +5,7 @@ go 1.26.0
 require (
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/elastic/apm-data v1.22.0
+	github.com/elastic/opentelemetry-collector-components/internal/agentname v0.0.0
 	github.com/elastic/opentelemetry-collector-components/internal/elasticattr v0.40.0
 	github.com/google/go-cmp v0.7.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.156.0
@@ -69,5 +70,7 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/elastic/opentelemetry-collector-components/internal/agentname => ../../internal/agentname
 
 replace github.com/elastic/opentelemetry-collector-components/internal/elasticattr => ../../internal/elasticattr

--- a/processor/elasticapmprocessor/internal/enrichments/resource.go
+++ b/processor/elasticapmprocessor/internal/enrichments/resource.go
@@ -18,10 +18,9 @@
 package enrichments // import "github.com/elastic/opentelemetry-collector-components/processor/elasticapmprocessor/internal/enrichments"
 
 import (
-	"fmt"
-
 	"regexp"
 
+	"github.com/elastic/opentelemetry-collector-components/internal/agentname"
 	"github.com/elastic/opentelemetry-collector-components/internal/elasticattr"
 	"github.com/elastic/opentelemetry-collector-components/processor/elasticapmprocessor/internal/ecs"
 	"github.com/elastic/opentelemetry-collector-components/processor/elasticapmprocessor/internal/enrichments/attribute"
@@ -185,30 +184,8 @@ func (s *resourceEnrichmentContext) setDefaultServiceLanguage(resource pcommon.R
 }
 
 func (s *resourceEnrichmentContext) setAgentName(resource pcommon.Resource) {
-	agentName := "otlp"
-	if s.telemetrySDKName != "" {
-		agentName = s.telemetrySDKName
-	}
-	switch {
-	case s.telemetryDistroName != "":
-		agentLang := "unknown"
-		if s.telemetrySDKLanguage != "" {
-			agentLang = s.telemetrySDKLanguage
-		}
-		agentName = fmt.Sprintf(
-			"%s/%s/%s",
-			agentName,
-			agentLang,
-			s.telemetryDistroName,
-		)
-	case s.telemetrySDKLanguage != "":
-		agentName = fmt.Sprintf(
-			"%s/%s",
-			agentName,
-			s.telemetrySDKLanguage,
-		)
-	}
-	attribute.PutStr(resource.Attributes(), elasticattr.AgentName, agentName)
+	attribute.PutStr(resource.Attributes(), elasticattr.AgentName,
+		agentname.Derive(s.telemetrySDKName, s.telemetrySDKLanguage, s.telemetryDistroName))
 }
 
 func (s *resourceEnrichmentContext) setAgentVersion(resource pcommon.Resource) {

--- a/versions.yaml
+++ b/versions.yaml
@@ -19,6 +19,7 @@ module-sets:
       - github.com/elastic/opentelemetry-collector-components/extension/clientaddrmiddlewareextension
       - github.com/elastic/opentelemetry-collector-components/processor/elastictraceprocessor
       - github.com/elastic/opentelemetry-collector-components/internal/elasticattr
+      - github.com/elastic/opentelemetry-collector-components/internal/agentname
       - github.com/elastic/opentelemetry-collector-components/extension/awscredentialsproviderextension
 
 excluded-modules:


### PR DESCRIPTION
agent.name previously defaulted to the literal string "unknown" for aggregates (service_summary, etc.) built from the metrics/logs signal path, since only the traces path had it set upstream by elasticapmprocessor. This meant a single service instance could end up with two different agent.name values depending on which signal produced the aggregate.

Derive it the same way elasticapmprocessor does for traces, from telemetry.sdk.name/telemetry.sdk.language/telemetry.distro.name, before handing off to the wrapped signaltometricsconnector. The "unknown" default remains as a fallback for resources with no telemetry.* attributes.

Closes https://github.com/elastic/opentelemetry-collector-components/issues/1319