### PR TITLE
[Extension][beats_encoding]  feat: use maps instead of dotted field names

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           cache: false
       - name: Cache Go
         id: go-cache

--- a/extension/beatsencodingextension/csv_test.go
+++ b/extension/beatsencodingextension/csv_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 )
 
@@ -88,9 +89,13 @@ func TestCSVDecoder(t *testing.T) {
 	// Routing attributes must be present so the document lands in the
 	// configured data stream and the integration pipeline runs.
 	body := logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Body().Map()
-	ds, ok := body.Get("data_stream.dataset")
+	dsMap, ok := body.Get("data_stream")
 	require.True(t, ok)
-	assert.Equal(t, "netskope.transaction", ds.Str())
+	require.Equal(t, pcommon.ValueTypeMap, dsMap.Type())
+
+	v, ok := dsMap.Map().Get("dataset")
+	require.True(t, ok)
+	assert.Equal(t, "netskope.transaction", v.Str())
 
 	// Every record must carry a baseline @timestamp (like a Beats doc) so it
 	// indexes into a data stream even when the integration pipeline does not

--- a/extension/beatsencodingextension/extension.go
+++ b/extension/beatsencodingextension/extension.go
@@ -613,7 +613,8 @@ func (e *beatsEncodingExtension) appendLogRecord(sl plog.ScopeLogs, ts pcommon.T
 	dStreamMap.PutStr("namespace", e.config.DataStream.Namespace)
 
 	if e.config.InputType != "" {
-		body.PutStr("input.type", e.config.InputType)
+		inputMap := body.PutEmptyMap("input")
+		inputMap.PutStr("type", e.config.InputType)
 	}
 
 	if len(e.config.Tags) > 0 {

--- a/extension/beatsencodingextension/extension.go
+++ b/extension/beatsencodingextension/extension.go
@@ -590,7 +590,11 @@ func (e *beatsEncodingExtension) appendLogRecord(sl plog.ScopeLogs, ts pcommon.T
 		}
 	}
 
-	body.PutStr("event.created", eventCreated)
+	// Store event and data_stream content as maps
+
+	eventMap := body.PutEmptyMap("event")
+	eventMap.PutStr("created", eventCreated)
+	eventMap.PutStr("dataset", e.config.DataStream.Dataset)
 
 	// Always set @timestamp on the body, like a Beats document. Some
 	// integration ingest pipelines only derive @timestamp on certain code
@@ -603,10 +607,10 @@ func (e *beatsEncodingExtension) appendLogRecord(sl plog.ScopeLogs, ts pcommon.T
 
 	// The data_stream.* should be also set on the body as some
 	// integrations expect them.
-	body.PutStr("data_stream.type", "logs")
-	body.PutStr("data_stream.dataset", e.config.DataStream.Dataset)
-	body.PutStr("data_stream.namespace", e.config.DataStream.Namespace)
-	body.PutStr("event.dataset", e.config.DataStream.Dataset)
+	dStreamMap := body.PutEmptyMap("data_stream")
+	dStreamMap.PutStr("type", "logs")
+	dStreamMap.PutStr("dataset", e.config.DataStream.Dataset)
+	dStreamMap.PutStr("namespace", e.config.DataStream.Namespace)
 
 	if e.config.InputType != "" {
 		body.PutStr("input.type", e.config.InputType)

--- a/extension/beatsencodingextension/extension_test.go
+++ b/extension/beatsencodingextension/extension_test.go
@@ -286,9 +286,13 @@ func TestUnmarshalLogs_StructuralChecks(t *testing.T) {
 		require.True(t, ok, "log record %d: body should have 'event.dataset' key", i)
 		assert.Equal(t, "azure.events", eventDataset.Str(), "log record %d: event.dataset should match data_stream.dataset", i)
 
-		inputType, ok := lr.Body().Map().Get("input.type")
+		inputMap, ok := lr.Body().Map().Get("input")
+		require.True(t, ok, "log record %d: body should have 'input' key", i)
+		require.Equal(t, pcommon.ValueTypeMap, inputMap.Type(), "log record %d: input should be a map", i)
+
+		eType, ok := inputMap.Map().Get("type")
 		require.True(t, ok, "log record %d: body should have 'input.type' key", i)
-		assert.Equal(t, "azure-eventhub", inputType.Str(), "log record %d: input.type mismatch", i)
+		assert.Equal(t, "azure-eventhub", eType.AsString(), "log record %d: input.type mismatch", i)
 
 		tagsVal, ok := lr.Body().Map().Get("tags")
 		require.True(t, ok, "log record %d: body should have 'tags' key", i)

--- a/extension/beatsencodingextension/extension_test.go
+++ b/extension/beatsencodingextension/extension_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest/plogtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.uber.org/zap"
 )
@@ -273,11 +274,15 @@ func TestUnmarshalLogs_StructuralChecks(t *testing.T) {
 		require.True(t, ok, "log record %d: body should have 'message' key", i)
 		assert.NotEmpty(t, msgVal.Str(), "log record %d: message should not be empty", i)
 
-		eventCreated, ok := lr.Body().Map().Get("event.created")
-		require.True(t, ok, "log record %d: body should have 'event.created' key", i)
+		eventMap, ok := lr.Body().Map().Get("event")
+		require.True(t, ok, "log record %d: event should have 'event' key", i)
+		require.Equal(t, pcommon.ValueTypeMap, eventMap.Type(), "log record %d: event should be a map", i)
+
+		eventCreated, ok := eventMap.Map().Get("created")
+		require.True(t, ok, "log record %d: body should have 'created' key", i)
 		assert.NotEmpty(t, eventCreated.Str(), "log record %d: event.created should not be empty", i)
 
-		eventDataset, ok := lr.Body().Map().Get("event.dataset")
+		eventDataset, ok := eventMap.Map().Get("dataset")
 		require.True(t, ok, "log record %d: body should have 'event.dataset' key", i)
 		assert.Equal(t, "azure.events", eventDataset.Str(), "log record %d: event.dataset should match data_stream.dataset", i)
 
@@ -493,8 +498,13 @@ func stripEventCreated(logs plog.Logs) {
 			sl := rl.ScopeLogs().At(j)
 			for k := 0; k < sl.LogRecords().Len(); k++ {
 				lr := sl.LogRecords().At(k)
-				lr.Body().Map().Remove("event.created")
 				lr.Body().Map().Remove("@timestamp")
+
+				v, b := lr.Body().Map().Get("event")
+				if !b || v.Type() != pcommon.ValueTypeMap {
+					continue
+				}
+				v.Map().Remove("created")
 			}
 		}
 	}

--- a/extension/beatsencodingextension/testdata/aws_cloudtrail_expected.yaml
+++ b/extension/beatsencodingextension/testdata/aws_cloudtrail_expected.yaml
@@ -45,8 +45,8 @@ resourceLogs:
                           - key: namespace
                             value:
                               stringValue: default
-            observedTimeUnixNano: "1784054613323058000"
-            timeUnixNano: "1784054613323058000"
+            observedTimeUnixNano: "1784122727853106000"
+            timeUnixNano: "1784122727853106000"
           - attributes:
               - key: data_stream.type
                 value:
@@ -90,8 +90,8 @@ resourceLogs:
                           - key: namespace
                             value:
                               stringValue: default
-            observedTimeUnixNano: "1784054613323058000"
-            timeUnixNano: "1784054613323058000"
+            observedTimeUnixNano: "1784122727853106000"
+            timeUnixNano: "1784122727853106000"
         scope:
           attributes:
             - key: elastic.mapping.mode

--- a/extension/beatsencodingextension/testdata/aws_cloudtrail_expected.yaml
+++ b/extension/beatsencodingextension/testdata/aws_cloudtrail_expected.yaml
@@ -25,20 +25,28 @@ resourceLogs:
                               "awsRegion": "us-east-1",
                               "eventTime": "2026-01-15T10:30:00Z"
                             }
-                  - key: event.dataset
+                  - key: event
                     value:
-                      stringValue: aws.cloudtrail
-                  - key: data_stream.type
+                      kvlistValue:
+                        values:
+                          - key: dataset
+                            value:
+                              stringValue: aws.cloudtrail
+                  - key: data_stream
                     value:
-                      stringValue: logs
-                  - key: data_stream.dataset
-                    value:
-                      stringValue: aws.cloudtrail
-                  - key: data_stream.namespace
-                    value:
-                      stringValue: default
-            observedTimeUnixNano: "1773919567374642000"
-            timeUnixNano: "1773919567374642000"
+                      kvlistValue:
+                        values:
+                          - key: type
+                            value:
+                              stringValue: logs
+                          - key: dataset
+                            value:
+                              stringValue: aws.cloudtrail
+                          - key: namespace
+                            value:
+                              stringValue: default
+            observedTimeUnixNano: "1784054613323058000"
+            timeUnixNano: "1784054613323058000"
           - attributes:
               - key: data_stream.type
                 value:
@@ -62,20 +70,28 @@ resourceLogs:
                               "awsRegion": "us-west-2",
                               "eventTime": "2026-01-15T10:30:01Z"
                             }
-                  - key: event.dataset
+                  - key: event
                     value:
-                      stringValue: aws.cloudtrail
-                  - key: data_stream.type
+                      kvlistValue:
+                        values:
+                          - key: dataset
+                            value:
+                              stringValue: aws.cloudtrail
+                  - key: data_stream
                     value:
-                      stringValue: logs
-                  - key: data_stream.dataset
-                    value:
-                      stringValue: aws.cloudtrail
-                  - key: data_stream.namespace
-                    value:
-                      stringValue: default
-            observedTimeUnixNano: "1773919567374642000"
-            timeUnixNano: "1773919567374642000"
+                      kvlistValue:
+                        values:
+                          - key: type
+                            value:
+                              stringValue: logs
+                          - key: dataset
+                            value:
+                              stringValue: aws.cloudtrail
+                          - key: namespace
+                            value:
+                              stringValue: default
+            observedTimeUnixNano: "1784054613323058000"
+            timeUnixNano: "1784054613323058000"
         scope:
           attributes:
             - key: elastic.mapping.mode

--- a/extension/beatsencodingextension/testdata/aws_elb_expected.yaml
+++ b/extension/beatsencodingextension/testdata/aws_elb_expected.yaml
@@ -38,8 +38,8 @@ resourceLogs:
                           - key: namespace
                             value:
                               stringValue: default
-            observedTimeUnixNano: "1784054613324612000"
-            timeUnixNano: "1784054613324612000"
+            observedTimeUnixNano: "1784122727856742000"
+            timeUnixNano: "1784122727856742000"
           - attributes:
               - key: data_stream.type
                 value:
@@ -76,8 +76,8 @@ resourceLogs:
                           - key: namespace
                             value:
                               stringValue: default
-            observedTimeUnixNano: "1784054613324612000"
-            timeUnixNano: "1784054613324612000"
+            observedTimeUnixNano: "1784122727856742000"
+            timeUnixNano: "1784122727856742000"
         scope:
           attributes:
             - key: elastic.mapping.mode

--- a/extension/beatsencodingextension/testdata/aws_elb_expected.yaml
+++ b/extension/beatsencodingextension/testdata/aws_elb_expected.yaml
@@ -18,20 +18,28 @@ resourceLogs:
                   - key: message
                     value:
                       stringValue: 2026-01-15T10:30:00.000000Z my-elb 172.31.16.139:80 10.0.0.1:80 0.000073 0.001048 0.000057 200 200 0 29 "GET http://my-elb-1234567890.us-east-1.elb.amazonaws.com:80/ HTTP/1.1" "curl/7.46.0" - -
-                  - key: event.dataset
+                  - key: event
                     value:
-                      stringValue: aws.elb_logs
-                  - key: data_stream.type
+                      kvlistValue:
+                        values:
+                          - key: dataset
+                            value:
+                              stringValue: aws.elb_logs
+                  - key: data_stream
                     value:
-                      stringValue: logs
-                  - key: data_stream.dataset
-                    value:
-                      stringValue: aws.elb_logs
-                  - key: data_stream.namespace
-                    value:
-                      stringValue: default
-            observedTimeUnixNano: "1773919567376149000"
-            timeUnixNano: "1773919567376149000"
+                      kvlistValue:
+                        values:
+                          - key: type
+                            value:
+                              stringValue: logs
+                          - key: dataset
+                            value:
+                              stringValue: aws.elb_logs
+                          - key: namespace
+                            value:
+                              stringValue: default
+            observedTimeUnixNano: "1784054613324612000"
+            timeUnixNano: "1784054613324612000"
           - attributes:
               - key: data_stream.type
                 value:
@@ -48,20 +56,28 @@ resourceLogs:
                   - key: message
                     value:
                       stringValue: 2026-01-15T10:30:01.000000Z my-elb 172.31.16.140:80 10.0.0.2:80 0.000086 0.001152 0.000048 200 200 0 29 "GET http://my-elb-1234567890.us-east-1.elb.amazonaws.com:80/health HTTP/1.1" "ELB-HealthChecker/2.0" - -
-                  - key: event.dataset
+                  - key: event
                     value:
-                      stringValue: aws.elb_logs
-                  - key: data_stream.type
+                      kvlistValue:
+                        values:
+                          - key: dataset
+                            value:
+                              stringValue: aws.elb_logs
+                  - key: data_stream
                     value:
-                      stringValue: logs
-                  - key: data_stream.dataset
-                    value:
-                      stringValue: aws.elb_logs
-                  - key: data_stream.namespace
-                    value:
-                      stringValue: default
-            observedTimeUnixNano: "1773919567376149000"
-            timeUnixNano: "1773919567376149000"
+                      kvlistValue:
+                        values:
+                          - key: type
+                            value:
+                              stringValue: logs
+                          - key: dataset
+                            value:
+                              stringValue: aws.elb_logs
+                          - key: namespace
+                            value:
+                              stringValue: default
+            observedTimeUnixNano: "1784054613324612000"
+            timeUnixNano: "1784054613324612000"
         scope:
           attributes:
             - key: elastic.mapping.mode

--- a/extension/beatsencodingextension/testdata/aws_vpcflow_expected.yaml
+++ b/extension/beatsencodingextension/testdata/aws_vpcflow_expected.yaml
@@ -38,8 +38,8 @@ resourceLogs:
                           - key: namespace
                             value:
                               stringValue: default
-            observedTimeUnixNano: "1784054613323755000"
-            timeUnixNano: "1784054613323755000"
+            observedTimeUnixNano: "1784122727855391000"
+            timeUnixNano: "1784122727855391000"
           - attributes:
               - key: data_stream.type
                 value:
@@ -76,8 +76,8 @@ resourceLogs:
                           - key: namespace
                             value:
                               stringValue: default
-            observedTimeUnixNano: "1784054613323755000"
-            timeUnixNano: "1784054613323755000"
+            observedTimeUnixNano: "1784122727855391000"
+            timeUnixNano: "1784122727855391000"
           - attributes:
               - key: data_stream.type
                 value:
@@ -114,8 +114,8 @@ resourceLogs:
                           - key: namespace
                             value:
                               stringValue: default
-            observedTimeUnixNano: "1784054613323755000"
-            timeUnixNano: "1784054613323755000"
+            observedTimeUnixNano: "1784122727855391000"
+            timeUnixNano: "1784122727855391000"
         scope:
           attributes:
             - key: elastic.mapping.mode

--- a/extension/beatsencodingextension/testdata/aws_vpcflow_expected.yaml
+++ b/extension/beatsencodingextension/testdata/aws_vpcflow_expected.yaml
@@ -18,20 +18,28 @@ resourceLogs:
                   - key: message
                     value:
                       stringValue: 2 123456789012 eni-1235b8ca123456789 172.31.16.139 172.31.16.21 20641 22 6 20 4249 1418530010 1418530070 ACCEPT OK
-                  - key: event.dataset
+                  - key: event
                     value:
-                      stringValue: aws.vpcflow
-                  - key: data_stream.type
+                      kvlistValue:
+                        values:
+                          - key: dataset
+                            value:
+                              stringValue: aws.vpcflow
+                  - key: data_stream
                     value:
-                      stringValue: logs
-                  - key: data_stream.dataset
-                    value:
-                      stringValue: aws.vpcflow
-                  - key: data_stream.namespace
-                    value:
-                      stringValue: default
-            observedTimeUnixNano: "1773919567375465000"
-            timeUnixNano: "1773919567375465000"
+                      kvlistValue:
+                        values:
+                          - key: type
+                            value:
+                              stringValue: logs
+                          - key: dataset
+                            value:
+                              stringValue: aws.vpcflow
+                          - key: namespace
+                            value:
+                              stringValue: default
+            observedTimeUnixNano: "1784054613323755000"
+            timeUnixNano: "1784054613323755000"
           - attributes:
               - key: data_stream.type
                 value:
@@ -48,20 +56,28 @@ resourceLogs:
                   - key: message
                     value:
                       stringValue: 2 123456789012 eni-1235b8ca123456789 172.31.9.69 172.31.9.12 49761 3389 6 20 4249 1418530010 1418530070 REJECT OK
-                  - key: event.dataset
+                  - key: event
                     value:
-                      stringValue: aws.vpcflow
-                  - key: data_stream.type
+                      kvlistValue:
+                        values:
+                          - key: dataset
+                            value:
+                              stringValue: aws.vpcflow
+                  - key: data_stream
                     value:
-                      stringValue: logs
-                  - key: data_stream.dataset
-                    value:
-                      stringValue: aws.vpcflow
-                  - key: data_stream.namespace
-                    value:
-                      stringValue: default
-            observedTimeUnixNano: "1773919567375465000"
-            timeUnixNano: "1773919567375465000"
+                      kvlistValue:
+                        values:
+                          - key: type
+                            value:
+                              stringValue: logs
+                          - key: dataset
+                            value:
+                              stringValue: aws.vpcflow
+                          - key: namespace
+                            value:
+                              stringValue: default
+            observedTimeUnixNano: "1784054613323755000"
+            timeUnixNano: "1784054613323755000"
           - attributes:
               - key: data_stream.type
                 value:
@@ -78,20 +94,28 @@ resourceLogs:
                   - key: message
                     value:
                       stringValue: 2 123456789012 eni-1235b8ca123456789 10.0.1.5 10.0.2.15 34567 443 6 15 3500 1418530010 1418530070 ACCEPT OK
-                  - key: event.dataset
+                  - key: event
                     value:
-                      stringValue: aws.vpcflow
-                  - key: data_stream.type
+                      kvlistValue:
+                        values:
+                          - key: dataset
+                            value:
+                              stringValue: aws.vpcflow
+                  - key: data_stream
                     value:
-                      stringValue: logs
-                  - key: data_stream.dataset
-                    value:
-                      stringValue: aws.vpcflow
-                  - key: data_stream.namespace
-                    value:
-                      stringValue: default
-            observedTimeUnixNano: "1773919567375465000"
-            timeUnixNano: "1773919567375465000"
+                      kvlistValue:
+                        values:
+                          - key: type
+                            value:
+                              stringValue: logs
+                          - key: dataset
+                            value:
+                              stringValue: aws.vpcflow
+                          - key: namespace
+                            value:
+                              stringValue: default
+            observedTimeUnixNano: "1784054613323755000"
+            timeUnixNano: "1784054613323755000"
         scope:
           attributes:
             - key: elastic.mapping.mode

--- a/extension/beatsencodingextension/testdata/aws_vpcflow_fields_expected.yaml
+++ b/extension/beatsencodingextension/testdata/aws_vpcflow_fields_expected.yaml
@@ -25,6 +25,9 @@ resourceLogs:
                           - key: dataset
                             value:
                               stringValue: aws.vpcflow
+                  - key: environment
+                    value:
+                      stringValue: production
                   - key: data_stream
                     value:
                       kvlistValue:
@@ -38,14 +41,11 @@ resourceLogs:
                           - key: namespace
                             value:
                               stringValue: default
-                  - key: environment
-                    value:
-                      stringValue: production
                   - key: team
                     value:
                       stringValue: security
-            observedTimeUnixNano: "1784054613326675000"
-            timeUnixNano: "1784054613326675000"
+            observedTimeUnixNano: "1784122727859786000"
+            timeUnixNano: "1784122727859786000"
           - attributes:
               - key: data_stream.type
                 value:
@@ -69,6 +69,9 @@ resourceLogs:
                           - key: dataset
                             value:
                               stringValue: aws.vpcflow
+                  - key: team
+                    value:
+                      stringValue: security
                   - key: data_stream
                     value:
                       kvlistValue:
@@ -85,11 +88,8 @@ resourceLogs:
                   - key: environment
                     value:
                       stringValue: production
-                  - key: team
-                    value:
-                      stringValue: security
-            observedTimeUnixNano: "1784054613326675000"
-            timeUnixNano: "1784054613326675000"
+            observedTimeUnixNano: "1784122727859786000"
+            timeUnixNano: "1784122727859786000"
           - attributes:
               - key: data_stream.type
                 value:
@@ -113,6 +113,9 @@ resourceLogs:
                           - key: dataset
                             value:
                               stringValue: aws.vpcflow
+                  - key: environment
+                    value:
+                      stringValue: production
                   - key: data_stream
                     value:
                       kvlistValue:
@@ -126,14 +129,11 @@ resourceLogs:
                           - key: namespace
                             value:
                               stringValue: default
-                  - key: environment
-                    value:
-                      stringValue: production
                   - key: team
                     value:
                       stringValue: security
-            observedTimeUnixNano: "1784054613326675000"
-            timeUnixNano: "1784054613326675000"
+            observedTimeUnixNano: "1784122727859786000"
+            timeUnixNano: "1784122727859786000"
         scope:
           attributes:
             - key: elastic.mapping.mode

--- a/extension/beatsencodingextension/testdata/aws_vpcflow_fields_expected.yaml
+++ b/extension/beatsencodingextension/testdata/aws_vpcflow_fields_expected.yaml
@@ -18,26 +18,34 @@ resourceLogs:
                   - key: message
                     value:
                       stringValue: 2 123456789012 eni-1235b8ca123456789 172.31.16.139 172.31.16.21 20641 22 6 20 4249 1418530010 1418530070 ACCEPT OK
-                  - key: team
+                  - key: event
                     value:
-                      stringValue: security
-                  - key: data_stream.type
+                      kvlistValue:
+                        values:
+                          - key: dataset
+                            value:
+                              stringValue: aws.vpcflow
+                  - key: data_stream
                     value:
-                      stringValue: logs
-                  - key: data_stream.dataset
-                    value:
-                      stringValue: aws.vpcflow
-                  - key: data_stream.namespace
-                    value:
-                      stringValue: default
-                  - key: event.dataset
-                    value:
-                      stringValue: aws.vpcflow
+                      kvlistValue:
+                        values:
+                          - key: type
+                            value:
+                              stringValue: logs
+                          - key: dataset
+                            value:
+                              stringValue: aws.vpcflow
+                          - key: namespace
+                            value:
+                              stringValue: default
                   - key: environment
                     value:
                       stringValue: production
-            observedTimeUnixNano: "1773959383670346000"
-            timeUnixNano: "1773959383670346000"
+                  - key: team
+                    value:
+                      stringValue: security
+            observedTimeUnixNano: "1784054613326675000"
+            timeUnixNano: "1784054613326675000"
           - attributes:
               - key: data_stream.type
                 value:
@@ -54,26 +62,34 @@ resourceLogs:
                   - key: message
                     value:
                       stringValue: 2 123456789012 eni-1235b8ca123456789 172.31.9.69 172.31.9.12 49761 3389 6 20 4249 1418530010 1418530070 REJECT OK
-                  - key: team
+                  - key: event
                     value:
-                      stringValue: security
-                  - key: data_stream.type
+                      kvlistValue:
+                        values:
+                          - key: dataset
+                            value:
+                              stringValue: aws.vpcflow
+                  - key: data_stream
                     value:
-                      stringValue: logs
-                  - key: data_stream.dataset
-                    value:
-                      stringValue: aws.vpcflow
-                  - key: data_stream.namespace
-                    value:
-                      stringValue: default
-                  - key: event.dataset
-                    value:
-                      stringValue: aws.vpcflow
+                      kvlistValue:
+                        values:
+                          - key: type
+                            value:
+                              stringValue: logs
+                          - key: dataset
+                            value:
+                              stringValue: aws.vpcflow
+                          - key: namespace
+                            value:
+                              stringValue: default
                   - key: environment
                     value:
                       stringValue: production
-            observedTimeUnixNano: "1773959383670346000"
-            timeUnixNano: "1773959383670346000"
+                  - key: team
+                    value:
+                      stringValue: security
+            observedTimeUnixNano: "1784054613326675000"
+            timeUnixNano: "1784054613326675000"
           - attributes:
               - key: data_stream.type
                 value:
@@ -90,26 +106,34 @@ resourceLogs:
                   - key: message
                     value:
                       stringValue: 2 123456789012 eni-1235b8ca123456789 10.0.1.5 10.0.2.15 34567 443 6 15 3500 1418530010 1418530070 ACCEPT OK
+                  - key: event
+                    value:
+                      kvlistValue:
+                        values:
+                          - key: dataset
+                            value:
+                              stringValue: aws.vpcflow
+                  - key: data_stream
+                    value:
+                      kvlistValue:
+                        values:
+                          - key: type
+                            value:
+                              stringValue: logs
+                          - key: dataset
+                            value:
+                              stringValue: aws.vpcflow
+                          - key: namespace
+                            value:
+                              stringValue: default
                   - key: environment
                     value:
                       stringValue: production
-                  - key: data_stream.type
-                    value:
-                      stringValue: logs
-                  - key: data_stream.dataset
-                    value:
-                      stringValue: aws.vpcflow
-                  - key: data_stream.namespace
-                    value:
-                      stringValue: default
-                  - key: event.dataset
-                    value:
-                      stringValue: aws.vpcflow
                   - key: team
                     value:
                       stringValue: security
-            observedTimeUnixNano: "1773959383670346000"
-            timeUnixNano: "1773959383670346000"
+            observedTimeUnixNano: "1784054613326675000"
+            timeUnixNano: "1784054613326675000"
         scope:
           attributes:
             - key: elastic.mapping.mode

--- a/extension/beatsencodingextension/testdata/aws_vpcflow_input_type_tags_expected.yaml
+++ b/extension/beatsencodingextension/testdata/aws_vpcflow_input_type_tags_expected.yaml
@@ -18,29 +18,37 @@ resourceLogs:
                   - key: message
                     value:
                       stringValue: 2 123456789012 eni-1235b8ca123456789 172.31.16.139 172.31.16.21 20641 22 6 20 4249 1418530010 1418530070 ACCEPT OK
+                  - key: event
+                    value:
+                      kvlistValue:
+                        values:
+                          - key: dataset
+                            value:
+                              stringValue: aws.vpcflow
+                  - key: data_stream
+                    value:
+                      kvlistValue:
+                        values:
+                          - key: type
+                            value:
+                              stringValue: logs
+                          - key: dataset
+                            value:
+                              stringValue: aws.vpcflow
+                          - key: namespace
+                            value:
+                              stringValue: default
+                  - key: input.type
+                    value:
+                      stringValue: aws-s3
                   - key: tags
                     value:
                       arrayValue:
                         values:
                           - stringValue: forwarded
                           - stringValue: aws-vpcflow
-                  - key: data_stream.type
-                    value:
-                      stringValue: logs
-                  - key: data_stream.dataset
-                    value:
-                      stringValue: aws.vpcflow
-                  - key: data_stream.namespace
-                    value:
-                      stringValue: default
-                  - key: event.dataset
-                    value:
-                      stringValue: aws.vpcflow
-                  - key: input.type
-                    value:
-                      stringValue: aws-s3
-            observedTimeUnixNano: "1773919567377884000"
-            timeUnixNano: "1773919567377884000"
+            observedTimeUnixNano: "1784054613327395000"
+            timeUnixNano: "1784054613327395000"
           - attributes:
               - key: data_stream.type
                 value:
@@ -57,29 +65,37 @@ resourceLogs:
                   - key: message
                     value:
                       stringValue: 2 123456789012 eni-1235b8ca123456789 172.31.9.69 172.31.9.12 49761 3389 6 20 4249 1418530010 1418530070 REJECT OK
+                  - key: event
+                    value:
+                      kvlistValue:
+                        values:
+                          - key: dataset
+                            value:
+                              stringValue: aws.vpcflow
+                  - key: data_stream
+                    value:
+                      kvlistValue:
+                        values:
+                          - key: type
+                            value:
+                              stringValue: logs
+                          - key: dataset
+                            value:
+                              stringValue: aws.vpcflow
+                          - key: namespace
+                            value:
+                              stringValue: default
+                  - key: input.type
+                    value:
+                      stringValue: aws-s3
                   - key: tags
                     value:
                       arrayValue:
                         values:
                           - stringValue: forwarded
                           - stringValue: aws-vpcflow
-                  - key: data_stream.type
-                    value:
-                      stringValue: logs
-                  - key: data_stream.dataset
-                    value:
-                      stringValue: aws.vpcflow
-                  - key: data_stream.namespace
-                    value:
-                      stringValue: default
-                  - key: event.dataset
-                    value:
-                      stringValue: aws.vpcflow
-                  - key: input.type
-                    value:
-                      stringValue: aws-s3
-            observedTimeUnixNano: "1773919567377884000"
-            timeUnixNano: "1773919567377884000"
+            observedTimeUnixNano: "1784054613327395000"
+            timeUnixNano: "1784054613327395000"
           - attributes:
               - key: data_stream.type
                 value:
@@ -96,29 +112,37 @@ resourceLogs:
                   - key: message
                     value:
                       stringValue: 2 123456789012 eni-1235b8ca123456789 10.0.1.5 10.0.2.15 34567 443 6 15 3500 1418530010 1418530070 ACCEPT OK
+                  - key: event
+                    value:
+                      kvlistValue:
+                        values:
+                          - key: dataset
+                            value:
+                              stringValue: aws.vpcflow
+                  - key: data_stream
+                    value:
+                      kvlistValue:
+                        values:
+                          - key: type
+                            value:
+                              stringValue: logs
+                          - key: dataset
+                            value:
+                              stringValue: aws.vpcflow
+                          - key: namespace
+                            value:
+                              stringValue: default
+                  - key: input.type
+                    value:
+                      stringValue: aws-s3
                   - key: tags
                     value:
                       arrayValue:
                         values:
                           - stringValue: forwarded
                           - stringValue: aws-vpcflow
-                  - key: data_stream.type
-                    value:
-                      stringValue: logs
-                  - key: data_stream.dataset
-                    value:
-                      stringValue: aws.vpcflow
-                  - key: data_stream.namespace
-                    value:
-                      stringValue: default
-                  - key: event.dataset
-                    value:
-                      stringValue: aws.vpcflow
-                  - key: input.type
-                    value:
-                      stringValue: aws-s3
-            observedTimeUnixNano: "1773919567377884000"
-            timeUnixNano: "1773919567377884000"
+            observedTimeUnixNano: "1784054613327395000"
+            timeUnixNano: "1784054613327395000"
         scope:
           attributes:
             - key: elastic.mapping.mode

--- a/extension/beatsencodingextension/testdata/aws_vpcflow_input_type_tags_expected.yaml
+++ b/extension/beatsencodingextension/testdata/aws_vpcflow_input_type_tags_expected.yaml
@@ -25,6 +25,12 @@ resourceLogs:
                           - key: dataset
                             value:
                               stringValue: aws.vpcflow
+                  - key: tags
+                    value:
+                      arrayValue:
+                        values:
+                          - stringValue: forwarded
+                          - stringValue: aws-vpcflow
                   - key: data_stream
                     value:
                       kvlistValue:
@@ -38,17 +44,15 @@ resourceLogs:
                           - key: namespace
                             value:
                               stringValue: default
-                  - key: input.type
+                  - key: input
                     value:
-                      stringValue: aws-s3
-                  - key: tags
-                    value:
-                      arrayValue:
+                      kvlistValue:
                         values:
-                          - stringValue: forwarded
-                          - stringValue: aws-vpcflow
-            observedTimeUnixNano: "1784054613327395000"
-            timeUnixNano: "1784054613327395000"
+                          - key: type
+                            value:
+                              stringValue: aws-s3
+            observedTimeUnixNano: "1784122727860660000"
+            timeUnixNano: "1784122727860660000"
           - attributes:
               - key: data_stream.type
                 value:
@@ -72,6 +76,12 @@ resourceLogs:
                           - key: dataset
                             value:
                               stringValue: aws.vpcflow
+                  - key: tags
+                    value:
+                      arrayValue:
+                        values:
+                          - stringValue: forwarded
+                          - stringValue: aws-vpcflow
                   - key: data_stream
                     value:
                       kvlistValue:
@@ -85,17 +95,15 @@ resourceLogs:
                           - key: namespace
                             value:
                               stringValue: default
-                  - key: input.type
+                  - key: input
                     value:
-                      stringValue: aws-s3
-                  - key: tags
-                    value:
-                      arrayValue:
+                      kvlistValue:
                         values:
-                          - stringValue: forwarded
-                          - stringValue: aws-vpcflow
-            observedTimeUnixNano: "1784054613327395000"
-            timeUnixNano: "1784054613327395000"
+                          - key: type
+                            value:
+                              stringValue: aws-s3
+            observedTimeUnixNano: "1784122727860660000"
+            timeUnixNano: "1784122727860660000"
           - attributes:
               - key: data_stream.type
                 value:
@@ -119,6 +127,12 @@ resourceLogs:
                           - key: dataset
                             value:
                               stringValue: aws.vpcflow
+                  - key: tags
+                    value:
+                      arrayValue:
+                        values:
+                          - stringValue: forwarded
+                          - stringValue: aws-vpcflow
                   - key: data_stream
                     value:
                       kvlistValue:
@@ -132,17 +146,15 @@ resourceLogs:
                           - key: namespace
                             value:
                               stringValue: default
-                  - key: input.type
+                  - key: input
                     value:
-                      stringValue: aws-s3
-                  - key: tags
-                    value:
-                      arrayValue:
+                      kvlistValue:
                         values:
-                          - stringValue: forwarded
-                          - stringValue: aws-vpcflow
-            observedTimeUnixNano: "1784054613327395000"
-            timeUnixNano: "1784054613327395000"
+                          - key: type
+                            value:
+                              stringValue: aws-s3
+            observedTimeUnixNano: "1784122727860660000"
+            timeUnixNano: "1784122727860660000"
         scope:
           attributes:
             - key: elastic.mapping.mode

--- a/extension/beatsencodingextension/testdata/azure_diagnostic_settings_expected.yaml
+++ b/extension/beatsencodingextension/testdata/azure_diagnostic_settings_expected.yaml
@@ -47,8 +47,8 @@ resourceLogs:
                           - key: namespace
                             value:
                               stringValue: default
-            observedTimeUnixNano: "1784054613321516000"
-            timeUnixNano: "1784054613321516000"
+            observedTimeUnixNano: "1784122727848635000"
+            timeUnixNano: "1784122727848635000"
           - attributes:
               - key: data_stream.type
                 value:
@@ -92,8 +92,8 @@ resourceLogs:
                           - key: namespace
                             value:
                               stringValue: default
-            observedTimeUnixNano: "1784054613321516000"
-            timeUnixNano: "1784054613321516000"
+            observedTimeUnixNano: "1784122727848635000"
+            timeUnixNano: "1784122727848635000"
         scope:
           attributes:
             - key: elastic.mapping.mode

--- a/extension/beatsencodingextension/testdata/azure_diagnostic_settings_expected.yaml
+++ b/extension/beatsencodingextension/testdata/azure_diagnostic_settings_expected.yaml
@@ -27,20 +27,28 @@ resourceLogs:
                               "resultType": "0",
                               "durationMs": 0
                             }
-                  - key: event.dataset
+                  - key: event
                     value:
-                      stringValue: azure.events
-                  - key: data_stream.type
+                      kvlistValue:
+                        values:
+                          - key: dataset
+                            value:
+                              stringValue: azure.events
+                  - key: data_stream
                     value:
-                      stringValue: logs
-                  - key: data_stream.dataset
-                    value:
-                      stringValue: azure.events
-                  - key: data_stream.namespace
-                    value:
-                      stringValue: default
-            observedTimeUnixNano: "1773919567373288000"
-            timeUnixNano: "1773919567373288000"
+                      kvlistValue:
+                        values:
+                          - key: type
+                            value:
+                              stringValue: logs
+                          - key: dataset
+                            value:
+                              stringValue: azure.events
+                          - key: namespace
+                            value:
+                              stringValue: default
+            observedTimeUnixNano: "1784054613321516000"
+            timeUnixNano: "1784054613321516000"
           - attributes:
               - key: data_stream.type
                 value:
@@ -64,20 +72,28 @@ resourceLogs:
                               "category": "Administrative",
                               "resultType": "Success"
                             }
-                  - key: event.dataset
+                  - key: event
                     value:
-                      stringValue: azure.events
-                  - key: data_stream.type
+                      kvlistValue:
+                        values:
+                          - key: dataset
+                            value:
+                              stringValue: azure.events
+                  - key: data_stream
                     value:
-                      stringValue: logs
-                  - key: data_stream.dataset
-                    value:
-                      stringValue: azure.events
-                  - key: data_stream.namespace
-                    value:
-                      stringValue: default
-            observedTimeUnixNano: "1773919567373288000"
-            timeUnixNano: "1773919567373288000"
+                      kvlistValue:
+                        values:
+                          - key: type
+                            value:
+                              stringValue: logs
+                          - key: dataset
+                            value:
+                              stringValue: azure.events
+                          - key: namespace
+                            value:
+                              stringValue: default
+            observedTimeUnixNano: "1784054613321516000"
+            timeUnixNano: "1784054613321516000"
         scope:
           attributes:
             - key: elastic.mapping.mode

--- a/extension/beatsencodingextension/testdata/json_nested_complex_expected.yaml
+++ b/extension/beatsencodingextension/testdata/json_nested_complex_expected.yaml
@@ -21,23 +21,31 @@ resourceLogs:
                   - key: Nano
                     value:
                       intValue: "1779801400123456000"
+                  - key: event
+                    value:
+                      kvlistValue:
+                        values:
+                          - key: dataset
+                            value:
+                              stringValue: custom
+                  - key: data_stream
+                    value:
+                      kvlistValue:
+                        values:
+                          - key: type
+                            value:
+                              stringValue: logs
+                          - key: dataset
+                            value:
+                              stringValue: custom
+                          - key: namespace
+                            value:
+                              stringValue: default
                   - key: input.type
                     value:
                       stringValue: aws-s3
-                  - key: data_stream.type
-                    value:
-                      stringValue: logs
-                  - key: data_stream.dataset
-                    value:
-                      stringValue: custom
-                  - key: data_stream.namespace
-                    value:
-                      stringValue: default
-                  - key: event.dataset
-                    value:
-                      stringValue: custom
-            observedTimeUnixNano: "1779817241863875000"
-            timeUnixNano: "1779817241863875000"
+            observedTimeUnixNano: "1784054613328143000"
+            timeUnixNano: "1784054613328143000"
           - attributes:
               - key: data_stream.type
                 value:
@@ -57,23 +65,31 @@ resourceLogs:
                   - key: Nano
                     value:
                       intValue: "1779801500123456000"
+                  - key: event
+                    value:
+                      kvlistValue:
+                        values:
+                          - key: dataset
+                            value:
+                              stringValue: custom
+                  - key: data_stream
+                    value:
+                      kvlistValue:
+                        values:
+                          - key: type
+                            value:
+                              stringValue: logs
+                          - key: dataset
+                            value:
+                              stringValue: custom
+                          - key: namespace
+                            value:
+                              stringValue: default
                   - key: input.type
                     value:
                       stringValue: aws-s3
-                  - key: data_stream.type
-                    value:
-                      stringValue: logs
-                  - key: data_stream.dataset
-                    value:
-                      stringValue: custom
-                  - key: data_stream.namespace
-                    value:
-                      stringValue: default
-                  - key: event.dataset
-                    value:
-                      stringValue: custom
-            observedTimeUnixNano: "1779817241863875000"
-            timeUnixNano: "1779817241863875000"
+            observedTimeUnixNano: "1784054613328143000"
+            timeUnixNano: "1784054613328143000"
           - attributes:
               - key: data_stream.type
                 value:
@@ -93,23 +109,31 @@ resourceLogs:
                   - key: Nano
                     value:
                       intValue: "1779801600123456000"
+                  - key: event
+                    value:
+                      kvlistValue:
+                        values:
+                          - key: dataset
+                            value:
+                              stringValue: custom
+                  - key: data_stream
+                    value:
+                      kvlistValue:
+                        values:
+                          - key: type
+                            value:
+                              stringValue: logs
+                          - key: dataset
+                            value:
+                              stringValue: custom
+                          - key: namespace
+                            value:
+                              stringValue: default
                   - key: input.type
                     value:
                       stringValue: aws-s3
-                  - key: data_stream.type
-                    value:
-                      stringValue: logs
-                  - key: data_stream.dataset
-                    value:
-                      stringValue: custom
-                  - key: data_stream.namespace
-                    value:
-                      stringValue: default
-                  - key: event.dataset
-                    value:
-                      stringValue: custom
-            observedTimeUnixNano: "1779817241863875000"
-            timeUnixNano: "1779817241863875000"
+            observedTimeUnixNano: "1784054613328143000"
+            timeUnixNano: "1784054613328143000"
         scope:
           attributes:
             - key: elastic.mapping.mode

--- a/extension/beatsencodingextension/testdata/json_nested_complex_expected.yaml
+++ b/extension/beatsencodingextension/testdata/json_nested_complex_expected.yaml
@@ -28,6 +28,13 @@ resourceLogs:
                           - key: dataset
                             value:
                               stringValue: custom
+                  - key: input
+                    value:
+                      kvlistValue:
+                        values:
+                          - key: type
+                            value:
+                              stringValue: aws-s3
                   - key: data_stream
                     value:
                       kvlistValue:
@@ -41,11 +48,8 @@ resourceLogs:
                           - key: namespace
                             value:
                               stringValue: default
-                  - key: input.type
-                    value:
-                      stringValue: aws-s3
-            observedTimeUnixNano: "1784054613328143000"
-            timeUnixNano: "1784054613328143000"
+            observedTimeUnixNano: "1784122727861952000"
+            timeUnixNano: "1784122727861952000"
           - attributes:
               - key: data_stream.type
                 value:
@@ -72,6 +76,13 @@ resourceLogs:
                           - key: dataset
                             value:
                               stringValue: custom
+                  - key: input
+                    value:
+                      kvlistValue:
+                        values:
+                          - key: type
+                            value:
+                              stringValue: aws-s3
                   - key: data_stream
                     value:
                       kvlistValue:
@@ -85,11 +96,8 @@ resourceLogs:
                           - key: namespace
                             value:
                               stringValue: default
-                  - key: input.type
-                    value:
-                      stringValue: aws-s3
-            observedTimeUnixNano: "1784054613328143000"
-            timeUnixNano: "1784054613328143000"
+            observedTimeUnixNano: "1784122727861952000"
+            timeUnixNano: "1784122727861952000"
           - attributes:
               - key: data_stream.type
                 value:
@@ -116,6 +124,13 @@ resourceLogs:
                           - key: dataset
                             value:
                               stringValue: custom
+                  - key: input
+                    value:
+                      kvlistValue:
+                        values:
+                          - key: type
+                            value:
+                              stringValue: aws-s3
                   - key: data_stream
                     value:
                       kvlistValue:
@@ -129,11 +144,8 @@ resourceLogs:
                           - key: namespace
                             value:
                               stringValue: default
-                  - key: input.type
-                    value:
-                      stringValue: aws-s3
-            observedTimeUnixNano: "1784054613328143000"
-            timeUnixNano: "1784054613328143000"
+            observedTimeUnixNano: "1784122727861952000"
+            timeUnixNano: "1784122727861952000"
         scope:
           attributes:
             - key: elastic.mapping.mode

--- a/extension/beatsencodingextension/testdata/json_nested_expected.yaml
+++ b/extension/beatsencodingextension/testdata/json_nested_expected.yaml
@@ -38,8 +38,8 @@ resourceLogs:
                           - key: namespace
                             value:
                               stringValue: default
-            observedTimeUnixNano: "1784054613325690000"
-            timeUnixNano: "1784054613325690000"
+            observedTimeUnixNano: "1784122727858883000"
+            timeUnixNano: "1784122727858883000"
           - attributes:
               - key: data_stream.type
                 value:
@@ -76,8 +76,8 @@ resourceLogs:
                           - key: namespace
                             value:
                               stringValue: default
-            observedTimeUnixNano: "1784054613325690000"
-            timeUnixNano: "1784054613325690000"
+            observedTimeUnixNano: "1784122727858883000"
+            timeUnixNano: "1784122727858883000"
           - attributes:
               - key: data_stream.type
                 value:
@@ -114,8 +114,8 @@ resourceLogs:
                           - key: namespace
                             value:
                               stringValue: default
-            observedTimeUnixNano: "1784054613325690000"
-            timeUnixNano: "1784054613325690000"
+            observedTimeUnixNano: "1784122727858883000"
+            timeUnixNano: "1784122727858883000"
         scope:
           attributes:
             - key: elastic.mapping.mode

--- a/extension/beatsencodingextension/testdata/json_nested_expected.yaml
+++ b/extension/beatsencodingextension/testdata/json_nested_expected.yaml
@@ -18,20 +18,28 @@ resourceLogs:
                   - key: message
                     value:
                       stringValue: '{"id": 1, "name": "first"}'
-                  - key: event.dataset
+                  - key: event
                     value:
-                      stringValue: custom.nested
-                  - key: data_stream.type
+                      kvlistValue:
+                        values:
+                          - key: dataset
+                            value:
+                              stringValue: custom.nested
+                  - key: data_stream
                     value:
-                      stringValue: logs
-                  - key: data_stream.dataset
-                    value:
-                      stringValue: custom.nested
-                  - key: data_stream.namespace
-                    value:
-                      stringValue: default
-            observedTimeUnixNano: "1773919567377340000"
-            timeUnixNano: "1773919567377340000"
+                      kvlistValue:
+                        values:
+                          - key: type
+                            value:
+                              stringValue: logs
+                          - key: dataset
+                            value:
+                              stringValue: custom.nested
+                          - key: namespace
+                            value:
+                              stringValue: default
+            observedTimeUnixNano: "1784054613325690000"
+            timeUnixNano: "1784054613325690000"
           - attributes:
               - key: data_stream.type
                 value:
@@ -48,20 +56,28 @@ resourceLogs:
                   - key: message
                     value:
                       stringValue: '{"id": 2, "name": "second"}'
-                  - key: event.dataset
+                  - key: event
                     value:
-                      stringValue: custom.nested
-                  - key: data_stream.type
+                      kvlistValue:
+                        values:
+                          - key: dataset
+                            value:
+                              stringValue: custom.nested
+                  - key: data_stream
                     value:
-                      stringValue: logs
-                  - key: data_stream.dataset
-                    value:
-                      stringValue: custom.nested
-                  - key: data_stream.namespace
-                    value:
-                      stringValue: default
-            observedTimeUnixNano: "1773919567377340000"
-            timeUnixNano: "1773919567377340000"
+                      kvlistValue:
+                        values:
+                          - key: type
+                            value:
+                              stringValue: logs
+                          - key: dataset
+                            value:
+                              stringValue: custom.nested
+                          - key: namespace
+                            value:
+                              stringValue: default
+            observedTimeUnixNano: "1784054613325690000"
+            timeUnixNano: "1784054613325690000"
           - attributes:
               - key: data_stream.type
                 value:
@@ -78,20 +94,28 @@ resourceLogs:
                   - key: message
                     value:
                       stringValue: '{"id": 3, "name": "third"}'
-                  - key: event.dataset
+                  - key: event
                     value:
-                      stringValue: custom.nested
-                  - key: data_stream.type
+                      kvlistValue:
+                        values:
+                          - key: dataset
+                            value:
+                              stringValue: custom.nested
+                  - key: data_stream
                     value:
-                      stringValue: logs
-                  - key: data_stream.dataset
-                    value:
-                      stringValue: custom.nested
-                  - key: data_stream.namespace
-                    value:
-                      stringValue: default
-            observedTimeUnixNano: "1773919567377340000"
-            timeUnixNano: "1773919567377340000"
+                      kvlistValue:
+                        values:
+                          - key: type
+                            value:
+                              stringValue: logs
+                          - key: dataset
+                            value:
+                              stringValue: custom.nested
+                          - key: namespace
+                            value:
+                              stringValue: default
+            observedTimeUnixNano: "1784054613325690000"
+            timeUnixNano: "1784054613325690000"
         scope:
           attributes:
             - key: elastic.mapping.mode

--- a/extension/beatsencodingextension/testdata/json_single_expected.yaml
+++ b/extension/beatsencodingextension/testdata/json_single_expected.yaml
@@ -18,20 +18,28 @@ resourceLogs:
                   - key: message
                     value:
                       stringValue: '{"key": "value", "number": 42}'
-                  - key: event.dataset
+                  - key: event
                     value:
-                      stringValue: generic
-                  - key: data_stream.type
+                      kvlistValue:
+                        values:
+                          - key: dataset
+                            value:
+                              stringValue: generic
+                  - key: data_stream
                     value:
-                      stringValue: logs
-                  - key: data_stream.dataset
-                    value:
-                      stringValue: generic
-                  - key: data_stream.namespace
-                    value:
-                      stringValue: default
-            observedTimeUnixNano: "1773919567376876000"
-            timeUnixNano: "1773919567376876000"
+                      kvlistValue:
+                        values:
+                          - key: type
+                            value:
+                              stringValue: logs
+                          - key: dataset
+                            value:
+                              stringValue: generic
+                          - key: namespace
+                            value:
+                              stringValue: default
+            observedTimeUnixNano: "1784054613325241000"
+            timeUnixNano: "1784054613325241000"
         scope:
           attributes:
             - key: elastic.mapping.mode

--- a/extension/beatsencodingextension/testdata/json_single_expected.yaml
+++ b/extension/beatsencodingextension/testdata/json_single_expected.yaml
@@ -38,8 +38,8 @@ resourceLogs:
                           - key: namespace
                             value:
                               stringValue: default
-            observedTimeUnixNano: "1784054613325241000"
-            timeUnixNano: "1784054613325241000"
+            observedTimeUnixNano: "1784122727857712000"
+            timeUnixNano: "1784122727857712000"
         scope:
           attributes:
             - key: elastic.mapping.mode


### PR DESCRIPTION
### Overview

This PR improves `beats_encoding` extension by using maps for `event.*` & `dataset.*` fields. 

Prior to this change, extension used dotted field keys such as `event.created`.

Note - Updated go version for vulnerability check as it's failing

### Why

Dotted field keys has known incompatibility with ingest pipelines. The fix proposed here helps to utilize this extension with existing pipelines without modifications. 