### PR TITLE
bump multimod version

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -1,6 +1,6 @@
 module-sets:
   edot-base:
-    version: v0.62.0
+    version: v0.67.0
     modules:
       - github.com/elastic/opentelemetry-collector-components/receiver/elasticapmintakereceiver
       - github.com/elastic/opentelemetry-collector-components/receiver/loadgenreceiver

--- a/versions.yaml
+++ b/versions.yaml
@@ -36,3 +36,4 @@ excluded-modules:
   - github.com/elastic/opentelemetry-collector-components/receiver/prometheusremotewritev1receiver/correctnesstests
   - github.com/elastic/opentelemetry-collector-components/receiver/akamaisiemreceiver
   - github.com/elastic/opentelemetry-collector-components/receiver/entityanalyticsreceiver
+  - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter


### PR DESCRIPTION
Bump version of mutlimod to latest used for the `make push-tags` command.

I had to add: - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter due to make push-tags failing due to this not being present in the exclude section of versions.yaml.