### PR TITLE
[extension/apikeyauth] change error handler to return `codes.ResourceExhausted` for exhausted ES 502 and 503 responses

### DIFF
--- a/extension/apikeyauthextension/authenticator.go
+++ b/extension/apikeyauthextension/authenticator.go
@@ -414,7 +414,9 @@ func (a *authenticator) Authenticate(ctx context.Context, headers map[string][]s
 			switch elasticsearchErr.Status {
 			case http.StatusUnauthorized, http.StatusForbidden:
 				return ctx, status.Error(codes.Unauthenticated, err.Error())
-			case http.StatusTooManyRequests, http.StatusGatewayTimeout:
+			case http.StatusTooManyRequests, http.StatusGatewayTimeout, http.StatusBadGateway, http.StatusServiceUnavailable:
+				// 502/503/504/429 are transient ES overload/unavailability errors (retried by the ES client when enabled);
+				// surface as backpressure so callers throttle+retry
 				return ctx, errorWithDetails(status.New(
 					codes.ResourceExhausted, "failed to check privileges",
 				), id, retryDelay)
@@ -438,10 +440,6 @@ func (a *authenticator) Authenticate(ctx context.Context, headers map[string][]s
 					), id, 0)
 				a.cache.Add(cacheKey, &cacheEntry{key: derivedKey, err: goneErr})
 				return ctx, goneErr
-			case http.StatusBadGateway, http.StatusServiceUnavailable:
-				return ctx, errorWithDetails(status.New(
-					codes.Unavailable, "failed to check privileges",
-				), id, retryDelay)
 			default:
 				return ctx, status.Errorf(codes.Internal, "error checking privileges: %v", err)
 			}

--- a/extension/apikeyauthextension/authenticator_test.go
+++ b/extension/apikeyauthextension/authenticator_test.go
@@ -108,7 +108,7 @@ func TestAuthenticator(t *testing.T) {
 				},
 				Status: 503,
 			}),
-			expectedErr: `rpc error: code = Unavailable desc = failed to check privileges`,
+			expectedErr: `rpc error: code = ResourceExhausted desc = failed to check privileges`,
 		},
 		"server_429_error": {
 			handler: newCannedErrorHandler(types.ElasticsearchError{
@@ -147,7 +147,7 @@ func TestAuthenticator(t *testing.T) {
 				},
 				Status: 502,
 			}),
-			expectedErr: `rpc error: code = Unavailable desc = failed to check privileges`,
+			expectedErr: `rpc error: code = ResourceExhausted desc = failed to check privileges`,
 		},
 		"server_500_error": {
 			handler: newCannedErrorHandler(types.ElasticsearchError{
@@ -579,7 +579,7 @@ func TestAuthenticator_RetryInfoDetails(t *testing.T) {
 
 			st, ok := status.FromError(err)
 			require.True(t, ok)
-			require.Equal(t, codes.Unavailable, st.Code())
+			require.Equal(t, codes.ResourceExhausted, st.Code())
 
 			details := st.Details()
 
@@ -1205,7 +1205,7 @@ func TestAuthenticator_RetryDisabled(t *testing.T) {
 
 			st, ok := status.FromError(err)
 			require.True(t, ok)
-			assert.Equal(t, codes.Unavailable, st.Code())
+			assert.Equal(t, codes.ResourceExhausted, st.Code())
 			require.Equal(t, 1, calls)
 		})
 	}


### PR DESCRIPTION
# Overview

This PR updates the `extension/apikeyauth` logic for handling typed  errors (`ElasticsearchError`) that return a 502 or 503. These errors indicated the ES instance is not healthy and the ES client will internally retry (when retries are enabled).  The extension will now return `codes.ResourceExhausted` so clients can throttle and retry,

