### PR TITLE
lsmintervalprocessor: skip unmarshal on lone MERGE compact

### DIFF
--- a/processor/lsmintervalprocessor/internal/merger/merger.go
+++ b/processor/lsmintervalprocessor/internal/merger/merger.go
@@ -18,32 +18,81 @@
 package merger // import "github.com/elastic/opentelemetry-collector-components/processor/lsmintervalprocessor/internal/merger"
 
 import (
+	"fmt"
 	"io"
-	"sync"
+	"slices"
 
 	"github.com/cockroachdb/pebble"
+
+	"github.com/elastic/opentelemetry-collector-components/processor/lsmintervalprocessor/config"
 )
 
 var _ pebble.ValueMerger = (*Merger)(nil)
 
+const pebbleMergerName = "pmetrics_merger"
+
+// NewPebbleMerger returns the Pebble merger used by the processor during
+// compact and memtable combine.
+//
+// Merge clones the first operand and does not unmarshal it. Unmarshal
+// runs when a sibling operand arrives. Finish returns the clone when no
+// sibling arrived. That skips Unmarshal and AppendBinary on a lone MERGE.
+func NewPebbleMerger(
+	resourceLimit, scopeLimit, metricLimit, datapointLimit config.LimitConfig,
+	maxExponentialHistogramBuckets int,
+) *pebble.Merger {
+	return &pebble.Merger{
+		Name: pebbleMergerName,
+		Merge: func(_ []byte, value []byte) (pebble.ValueMerger, error) {
+			// Pebble keeps ownership of value and may reuse it before Finish.
+			return &Merger{
+				raw:                            slices.Clone(value),
+				resourceLimitCfg:               resourceLimit,
+				scopeLimitCfg:                  scopeLimit,
+				metricLimitCfg:                 metricLimit,
+				datapointLimitCfg:              datapointLimit,
+				maxExponentialHistogramBuckets: maxExponentialHistogramBuckets,
+			}, nil
+		},
+	}
+}
+
+// Merger implements pebble.ValueMerger for pmetric values in the LSM.
 type Merger struct {
-	bufferPool sync.Pool
-	current    *Value
+	current *Value
+	// raw is a copy of the first merge operand. Merge sets it.
+	// ensureUnmarshaled clears it. Finish returns it when current is nil.
+	raw []byte
+
+	resourceLimitCfg               config.LimitConfig
+	scopeLimitCfg                  config.LimitConfig
+	metricLimitCfg                 config.LimitConfig
+	datapointLimitCfg              config.LimitConfig
+	maxExponentialHistogramBuckets int
 }
 
-func New(v *Value) *Merger {
-	return &Merger{
-		current: v,
-	}
-}
-
+// MergeNewer implements pebble.ValueMerger.
 func (m *Merger) MergeNewer(value []byte) error {
+	return m.mergeOperand(value)
+}
+
+// MergeOlder implements pebble.ValueMerger.
+func (m *Merger) MergeOlder(value []byte) error {
+	return m.mergeOperand(value)
+}
+
+// mergeOperand unmarshals the first operand if needed, unmarshals value,
+// and merges the two Values.
+func (m *Merger) mergeOperand(value []byte) error {
+	if err := m.ensureUnmarshaled(); err != nil {
+		return err
+	}
 	op := NewValue(
-		m.current.resourceLimitCfg,
-		m.current.scopeLimitCfg,
-		m.current.metricLimitCfg,
-		m.current.datapointLimitCfg,
-		m.current.maxExponentialHistogramBuckets,
+		m.resourceLimitCfg,
+		m.scopeLimitCfg,
+		m.metricLimitCfg,
+		m.datapointLimitCfg,
+		m.maxExponentialHistogramBuckets,
 	)
 	if err := op.Unmarshal(value); err != nil {
 		return err
@@ -51,41 +100,33 @@ func (m *Merger) MergeNewer(value []byte) error {
 	return m.current.Merge(op)
 }
 
-func (m *Merger) MergeOlder(value []byte) error {
-	op := NewValue(
-		m.current.resourceLimitCfg,
-		m.current.scopeLimitCfg,
-		m.current.metricLimitCfg,
-		m.current.datapointLimitCfg,
-		m.current.maxExponentialHistogramBuckets,
-	)
-	if err := op.Unmarshal(value); err != nil {
-		return err
+// ensureUnmarshaled unmarshals raw into current. A second call is a no-op.
+func (m *Merger) ensureUnmarshaled() error {
+	if m.current != nil {
+		return nil
 	}
-	return m.current.Merge(op)
+	v := NewValue(
+		m.resourceLimitCfg,
+		m.scopeLimitCfg,
+		m.metricLimitCfg,
+		m.datapointLimitCfg,
+		m.maxExponentialHistogramBuckets,
+	)
+	if err := v.Unmarshal(m.raw); err != nil {
+		return fmt.Errorf("failed to unmarshal value from db: %w", err)
+	}
+	m.current = v
+	m.raw = nil
+	return nil
 }
 
 func (m *Merger) Finish(includesBase bool) ([]byte, io.Closer, error) {
-	pb, ok := m.bufferPool.Get().(*pooledBuffer)
-	if !ok {
-		pb = &pooledBuffer{pool: &m.bufferPool}
+	if m.current == nil {
+		return m.raw, nil, nil
 	}
-	newBuf, err := m.current.AppendBinary(pb.buf[:0])
+	buf, err := m.current.AppendBinary(nil)
 	if err != nil {
-		m.bufferPool.Put(pb)
 		return nil, nil, err
 	}
-	pb.buf = newBuf
-	return newBuf, pb, nil
-}
-
-type pooledBuffer struct {
-	pool *sync.Pool
-	buf  []byte
-}
-
-func (b *pooledBuffer) Close() error {
-	b.buf = b.buf[:0]
-	b.pool.Put(b)
-	return nil
+	return buf, nil, nil
 }

--- a/processor/lsmintervalprocessor/internal/merger/merger_bench_test.go
+++ b/processor/lsmintervalprocessor/internal/merger/merger_bench_test.go
@@ -1,0 +1,240 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package merger
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/cockroachdb/pebble"
+	"github.com/cockroachdb/pebble/vfs"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+
+	"github.com/elastic/opentelemetry-collector-components/processor/lsmintervalprocessor/config"
+)
+
+type fatLSMShape struct {
+	resources int
+	dps       int
+}
+
+// BenchmarkCompactPeak measures lone MERGE and sibling combine on a fat
+// operand. It does not measure ingest, export, or other merger testdata.
+//
+// base is one operand (expo histograms, explicit histograms, attributes).
+// sibling overlaps the first 16 resources of base so a combine merges
+// histogram streams instead of only appending new identities.
+//
+// Finish calls Merge/MergeOlder/Finish only. PebbleCompact writes the same
+// bytes, flushes each operand to its own sstable, then Compacts that key.
+func BenchmarkCompactPeak(b *testing.B) {
+	base := mustFatLSMOperand(b, fatLSMShape{resources: 64, dps: 16})
+	// Sibling overlaps the first 16 resources so MergeOlder combines
+	// histogram streams instead of only appending new identities.
+	sibling := mustFatLSMOperand(b, fatLSMShape{resources: 16, dps: 16})
+
+	// One MERGE operand, no sibling. Lazy Finish returns the clone.
+	b.Run(fmt.Sprintf("lone/Finish/%dKiB", len(base)/1024), func(b *testing.B) {
+		benchFinish(b, base)
+	})
+	b.Run(fmt.Sprintf("lone/PebbleCompact/%dKiB", len(base)/1024), func(b *testing.B) {
+		benchPebbleCompact(b, base)
+	})
+	// Sibling on the same key. Unmarshal still runs on both operands.
+	b.Run(fmt.Sprintf("combine/Finish/%dKiB+%dKiB", len(base)/1024, len(sibling)/1024), func(b *testing.B) {
+		benchFinish(b, base, sibling)
+	})
+	b.Run(fmt.Sprintf("combine/PebbleCompact/%dKiB+%dKiB", len(base)/1024, len(sibling)/1024), func(b *testing.B) {
+		benchPebbleCompact(b, base, sibling)
+	})
+}
+
+func benchFinish(b *testing.B, operand []byte, siblings ...[]byte) {
+	b.Helper()
+	total := len(operand)
+	for _, s := range siblings {
+		total += len(s)
+	}
+	b.ReportAllocs()
+	b.SetBytes(int64(total))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		out, closer := compactFinish(b, operand, siblings...)
+		if closer != nil {
+			if err := closer.Close(); err != nil {
+				b.Fatal(err)
+			}
+		}
+		if len(out) == 0 {
+			b.Fatal("finish wrote empty operand")
+		}
+	}
+}
+
+func benchPebbleCompact(b *testing.B, operand []byte, siblings ...[]byte) {
+	b.Helper()
+	db := openPeakDB(b)
+	b.Cleanup(func() {
+		require.NoError(b, db.Close())
+	})
+	total := len(operand)
+	for _, s := range siblings {
+		total += len(s)
+	}
+	b.ReportAllocs()
+	b.SetBytes(int64(total))
+	b.ResetTimer()
+	for i := range b.N {
+		key := binary.BigEndian.AppendUint64(nil, uint64(i))
+		end := binary.BigEndian.AppendUint64(nil, uint64(i)+1)
+		if err := db.Merge(key, operand, pebble.NoSync); err != nil {
+			b.Fatal(err)
+		}
+		if err := db.Flush(); err != nil {
+			b.Fatal(err)
+		}
+		for _, s := range siblings {
+			if err := db.Merge(key, s, pebble.NoSync); err != nil {
+				b.Fatal(err)
+			}
+			if err := db.Flush(); err != nil {
+				b.Fatal(err)
+			}
+		}
+		if err := db.Compact(key, end, false); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// noLimit is the processor default. MaxCardinality 0 disables overflow
+// tracking, so the fat fixture keeps every identity. A limit of 1 would
+// collapse the operand into overflow buckets and miss the compact-peak shape.
+var noLimit config.LimitConfig
+
+func peakValue() *Value {
+	return NewValue(noLimit, noLimit, noLimit, noLimit, defaultMaxBuckets)
+}
+
+func peakPebbleMerger() *pebble.Merger {
+	return NewPebbleMerger(noLimit, noLimit, noLimit, noLimit, defaultMaxBuckets)
+}
+
+func mustFatLSMOperand(tb testing.TB, shape fatLSMShape) []byte {
+	tb.Helper()
+	v := peakValue()
+	require.NoError(tb, updateValueWithPMetrics(peakCompactMetrics(shape), v))
+	operand, err := v.AppendBinary(nil)
+	require.NoError(tb, err)
+	require.NotEmpty(tb, operand)
+	return operand
+}
+
+func compactFinish(tb testing.TB, operand []byte, siblings ...[]byte) ([]byte, io.Closer) {
+	tb.Helper()
+	vm, err := peakPebbleMerger().Merge(nil, operand)
+	require.NoError(tb, err)
+	for _, s := range siblings {
+		require.NoError(tb, vm.MergeOlder(s))
+	}
+	out, closer, err := vm.Finish(true)
+	require.NoError(tb, err)
+	return out, closer
+}
+
+func openPeakDB(tb testing.TB) *pebble.DB {
+	tb.Helper()
+	opts := &pebble.Options{
+		FS:                          vfs.NewMem(),
+		DisableWAL:                  true,
+		DisableAutomaticCompactions: true,
+		MemTableSize:                32 << 20,
+		Merger:                      peakPebbleMerger(),
+	}
+	db, err := pebble.Open("", opts)
+	require.NoError(tb, err)
+	return db
+}
+
+// peakCompactMetrics builds expo-histogram buckets, explicit histograms,
+// and attributes.
+func peakCompactMetrics(shape fatLSMShape) pmetric.Metrics {
+	expoBuckets := make([]uint64, defaultMaxBuckets)
+	for i := range expoBuckets {
+		expoBuckets[i] = uint64(i + 1)
+	}
+	explicitBounds := []float64{1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1000, 2000, 4000, 8000, 16000, 32000}
+	explicitCounts := make([]uint64, len(explicitBounds)+1)
+	for i := range explicitCounts {
+		explicitCounts[i] = uint64(i + 1)
+	}
+
+	md := pmetric.NewMetrics()
+	for r := 0; r < shape.resources; r++ {
+		rm := md.ResourceMetrics().AppendEmpty()
+		attrs := rm.Resource().Attributes()
+		attrs.PutStr("service.name", fmt.Sprintf("svc-%d", r))
+		attrs.PutStr("service.environment", "prod")
+		attrs.PutStr("deployment.environment", "production")
+		attrs.PutStr("telemetry.sdk.language", "go")
+
+		sm := rm.ScopeMetrics().AppendEmpty()
+		sm.Scope().SetName("github.com/elastic/apm-data")
+		sm.Scope().SetVersion("1.0.0")
+
+		expo := sm.Metrics().AppendEmpty()
+		expo.SetName("transaction.duration")
+		expo.SetUnit("us")
+		eh := expo.SetEmptyExponentialHistogram()
+		eh.SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
+
+		hist := sm.Metrics().AppendEmpty()
+		hist.SetName("transaction.duration.histogram")
+		hist.SetUnit("us")
+		h := hist.SetEmptyHistogram()
+		h.SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
+
+		for d := 0; d < shape.dps; d++ {
+			edp := eh.DataPoints().AppendEmpty()
+			edp.Attributes().PutStr("transaction.name", fmt.Sprintf("GET /api/%d", d))
+			edp.Attributes().PutStr("transaction.type", "request")
+			edp.Attributes().PutStr("event.outcome", "success")
+			edp.SetCount(1000)
+			edp.SetSum(float64(1000 * (d + 1)))
+			edp.SetScale(0)
+			edp.SetZeroCount(1)
+			edp.Positive().SetOffset(0)
+			edp.Positive().BucketCounts().FromRaw(expoBuckets)
+			edp.Negative().SetOffset(0)
+			edp.Negative().BucketCounts().FromRaw(expoBuckets)
+
+			hdp := h.DataPoints().AppendEmpty()
+			hdp.Attributes().PutStr("transaction.name", fmt.Sprintf("GET /api/%d", d))
+			hdp.Attributes().PutStr("transaction.type", "request")
+			hdp.Attributes().PutStr("event.outcome", "success")
+			hdp.SetCount(1000)
+			hdp.SetSum(float64(1000 * (d + 1)))
+			hdp.ExplicitBounds().FromRaw(explicitBounds)
+			hdp.BucketCounts().FromRaw(explicitCounts)
+		}
+	}
+	return md
+}

--- a/processor/lsmintervalprocessor/internal/merger/merger_test.go
+++ b/processor/lsmintervalprocessor/internal/merger/merger_test.go
@@ -1,0 +1,105 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package merger
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+)
+
+// Finish must not Unmarshal and re-encode a single MERGE operand.
+func TestLoneMergeFinishRoundTrip(t *testing.T) {
+	operand := mustFatLSMOperand(t, fatLSMShape{
+		resources: 4,
+		dps:       2,
+	})
+
+	out, closer := compactFinish(t, operand)
+	t.Cleanup(func() {
+		if closer != nil {
+			require.NoError(t, closer.Close())
+		}
+	})
+
+	require.Equal(t, operand, out)
+}
+
+// TestLoneMergeFinishCopiesOperand checks that Finish does not alias
+// Pebble's input buffer. Pebble may reuse that buffer after Merge.
+func TestLoneMergeFinishCopiesOperand(t *testing.T) {
+	operand := mustFatLSMOperand(t, fatLSMShape{resources: 2, dps: 1})
+	orig := append([]byte(nil), operand...)
+
+	vm, err := peakPebbleMerger().Merge(nil, operand)
+	require.NoError(t, err)
+	operand[0] ^= 0xff
+
+	out, closer, err := vm.Finish(true)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if closer != nil {
+			require.NoError(t, closer.Close())
+		}
+	})
+	require.Equal(t, orig, out)
+}
+
+// A sibling operand forces Unmarshal and a real merge.
+func TestCombineMergeFinishMergesSibling(t *testing.T) {
+	base := mustFatLSMOperand(t, fatLSMShape{resources: 4, dps: 2})
+	sibling := mustFatLSMOperand(t, fatLSMShape{resources: 2, dps: 2})
+
+	out, closer := compactFinish(t, base, sibling)
+	t.Cleanup(func() {
+		if closer != nil {
+			require.NoError(t, closer.Close())
+		}
+	})
+
+	require.NotEqual(t, base, out)
+
+	merged := peakValue()
+	require.NoError(t, merged.Unmarshal(out))
+	md, _, err := merged.Finalize()
+	require.NoError(t, err)
+
+	// Base is 4 resources × 2 expo datapoints × count 1000 = 8000.
+	// Sibling overlaps the first 2 resources (4 expo datapoints × 1000).
+	// Merge must add those counts, not append rows.
+	var expoCount uint64
+	rms := md.ResourceMetrics()
+	for i := 0; i < rms.Len(); i++ {
+		sms := rms.At(i).ScopeMetrics()
+		for j := 0; j < sms.Len(); j++ {
+			ms := sms.At(j).Metrics()
+			for k := 0; k < ms.Len(); k++ {
+				metric := ms.At(k)
+				if metric.Type() != pmetric.MetricTypeExponentialHistogram {
+					continue
+				}
+				dps := metric.ExponentialHistogram().DataPoints()
+				for l := 0; l < dps.Len(); l++ {
+					expoCount += dps.At(l).Count()
+				}
+			}
+		}
+	}
+	require.Equal(t, uint64(12000), expoCount)
+}

--- a/processor/lsmintervalprocessor/internal/merger/merger_test.go
+++ b/processor/lsmintervalprocessor/internal/merger/merger_test.go
@@ -18,88 +18,66 @@
 package merger
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 )
 
-// Finish must not Unmarshal and re-encode a single MERGE operand.
-func TestLoneMergeFinishRoundTrip(t *testing.T) {
-	operand := mustFatLSMOperand(t, fatLSMShape{
-		resources: 4,
-		dps:       2,
-	})
-
-	out, closer := compactFinish(t, operand)
-	t.Cleanup(func() {
-		if closer != nil {
-			require.NoError(t, closer.Close())
-		}
-	})
-
-	require.Equal(t, operand, out)
+func TestMergeFinishLone(t *testing.T) {
+	op := mustFatLSMOperand(t, fatLSMShape{resources: 4, dps: 2})
+	out, _ := compactFinish(t, op)
+	require.Equal(t, op, out)
 }
 
-// TestLoneMergeFinishCopiesOperand checks that Finish does not alias
-// Pebble's input buffer. Pebble may reuse that buffer after Merge.
-func TestLoneMergeFinishCopiesOperand(t *testing.T) {
-	operand := mustFatLSMOperand(t, fatLSMShape{resources: 2, dps: 1})
-	orig := append([]byte(nil), operand...)
+func TestMergeFinishCombine(t *testing.T) {
+	baseShape := fatLSMShape{resources: 4, dps: 2}
+	sibShape := fatLSMShape{resources: 2, dps: 2}
+	base := mustFatLSMOperand(t, baseShape)
+	sib := mustFatLSMOperand(t, sibShape)
+	out, _ := compactFinish(t, base, sib)
+	require.NotEqual(t, base, out)
 
-	vm, err := peakPebbleMerger().Merge(nil, operand)
+	v := peakValue()
+	require.NoError(t, v.Unmarshal(out))
+	md, _, err := v.Finalize()
 	require.NoError(t, err)
-	operand[0] ^= 0xff
 
-	out, closer, err := vm.Finish(true)
+	// peakCompactMetrics sets each expo datapoint count to 1000.
+	// Overlapping identities add those counts.
+	want := uint64((baseShape.resources*baseShape.dps + sibShape.resources*sibShape.dps) * 1000)
+	require.Equal(t, want, expoHistogramCount(md))
+}
+
+func TestMergeFinishCopiesOperand(t *testing.T) {
+	op := mustFatLSMOperand(t, fatLSMShape{resources: 2, dps: 1})
+	orig := slices.Clone(op)
+
+	vm, err := peakPebbleMerger().Merge(nil, op)
 	require.NoError(t, err)
-	t.Cleanup(func() {
-		if closer != nil {
-			require.NoError(t, closer.Close())
-		}
-	})
+	op[0] ^= 0xff
+
+	out, _, err := vm.Finish(true)
+	require.NoError(t, err)
 	require.Equal(t, orig, out)
 }
 
-// A sibling operand forces Unmarshal and a real merge.
-func TestCombineMergeFinishMergesSibling(t *testing.T) {
-	base := mustFatLSMOperand(t, fatLSMShape{resources: 4, dps: 2})
-	sibling := mustFatLSMOperand(t, fatLSMShape{resources: 2, dps: 2})
-
-	out, closer := compactFinish(t, base, sibling)
-	t.Cleanup(func() {
-		if closer != nil {
-			require.NoError(t, closer.Close())
-		}
-	})
-
-	require.NotEqual(t, base, out)
-
-	merged := peakValue()
-	require.NoError(t, merged.Unmarshal(out))
-	md, _, err := merged.Finalize()
-	require.NoError(t, err)
-
-	// Base is 4 resources × 2 expo datapoints × count 1000 = 8000.
-	// Sibling overlaps the first 2 resources (4 expo datapoints × 1000).
-	// Merge must add those counts, not append rows.
-	var expoCount uint64
+func expoHistogramCount(md pmetric.Metrics) uint64 {
+	var n uint64
 	rms := md.ResourceMetrics()
 	for i := 0; i < rms.Len(); i++ {
 		sms := rms.At(i).ScopeMetrics()
 		for j := 0; j < sms.Len(); j++ {
-			ms := sms.At(j).Metrics()
-			for k := 0; k < ms.Len(); k++ {
-				metric := ms.At(k)
-				if metric.Type() != pmetric.MetricTypeExponentialHistogram {
+			for _, m := range sms.At(j).Metrics().All() {
+				if m.Type() != pmetric.MetricTypeExponentialHistogram {
 					continue
 				}
-				dps := metric.ExponentialHistogram().DataPoints()
-				for l := 0; l < dps.Len(); l++ {
-					expoCount += dps.At(l).Count()
+				for _, dp := range m.ExponentialHistogram().DataPoints().All() {
+					n += dp.Count()
 				}
 			}
 		}
 	}
-	require.Equal(t, uint64(12000), expoCount)
+	return n
 }

--- a/processor/lsmintervalprocessor/processor.go
+++ b/processor/lsmintervalprocessor/processor.go
@@ -114,22 +114,13 @@ func newProcessor(
 	}
 
 	dbOpts := &pebble.Options{
-		Merger: &pebble.Merger{
-			Name: "pmetrics_merger",
-			Merge: func(key, value []byte) (pebble.ValueMerger, error) {
-				v := merger.NewValue(
-					cfg.ResourceLimit,
-					cfg.ScopeLimit,
-					cfg.MetricLimit,
-					cfg.DatapointLimit,
-					cfg.ExponentialHistogramMaxBuckets,
-				)
-				if err := v.Unmarshal(value); err != nil {
-					return nil, fmt.Errorf("failed to unmarshal value from db: %w", err)
-				}
-				return merger.New(v), nil
-			},
-		},
+		Merger: merger.NewPebbleMerger(
+			cfg.ResourceLimit,
+			cfg.ScopeLimit,
+			cfg.MetricLimit,
+			cfg.DatapointLimit,
+			cfg.ExponentialHistogramMaxBuckets,
+		),
 		MemTableSize:                pebbleMemTableSize,
 		MemTableStopWritesThreshold: pebbleMemTableStopWritesThreshold,
 	}


### PR DESCRIPTION
Pebble compact unmarshals every lone `MERGE` operand, then encodes it again as a `SET`.

`Merge` clones the first operand and does not unmarshal it. Unmarshal runs when a sibling arrives. If no sibling arrives, `Finish` returns the clone. That skips Unmarshal and `AppendBinary` on a lone `MERGE`. A sibling combine still unmarshals both operands.

`benchstat` of `BenchmarkCompactPeak` (`-count=10`) against the eager `Merge` baseline:

```
                                                  │    old.txt    │        lazy-finish-no-pool.txt        │
                                                  │    sec/op     │    sec/op      vs base                │
CompactPeak/lone/Finish/922KiB-8                    7647.3µ ± 14%   354.7µ ±  21%  -95.36% (p=0.000 n=10)
CompactPeak/lone/PebbleCompact/922KiB-8              8.201m ± 29%   1.242m ±  42%  -84.86% (p=0.000 n=10)
CompactPeak/combine/Finish/922KiB+230KiB-8           14.36m ± 32%   19.74m ± 112%        ~ (p=0.912 n=10)
CompactPeak/combine/PebbleCompact/922KiB+230KiB-8    28.20m ± 21%   17.94m ±  30%  -36.39% (p=0.000 n=10)
geomean                                              12.62m         3.534m         -72.01%

                                                  │    old.txt     │       lazy-finish-no-pool.txt        │
                                                  │      B/op      │     B/op      vs base                │
CompactPeak/lone/Finish/922KiB-8                    11606.9Ki ± 0%   928.2Ki ± 0%  -92.00% (p=0.000 n=10)
CompactPeak/lone/PebbleCompact/922KiB-8              12.473Mi ± 1%   1.056Mi ± 2%  -91.54% (p=0.000 n=10)
CompactPeak/combine/Finish/922KiB+230KiB-8            15.08Mi ± 0%   15.99Mi ± 0%   +6.00% (p=0.000 n=10)
CompactPeak/combine/PebbleCompact/922KiB+230KiB-8     36.95Mi ± 1%   22.51Mi ± 1%  -39.10% (p=0.000 n=10)
geomean                                               16.75Mi        4.308Mi       -74.29%

                                                  │    old.txt     │       lazy-finish-no-pool.txt        │
                                                  │   allocs/op    │  allocs/op   vs base                 │
CompactPeak/lone/Finish/922KiB-8                    50397.000 ± 0%    2.000 ± 0%  -100.00% (p=0.000 n=10)
CompactPeak/lone/PebbleCompact/922KiB-8               50646.0 ± 0%    247.0 ± 0%   -99.51% (p=0.000 n=10)
CompactPeak/combine/Finish/922KiB+230KiB-8             63.09k ± 0%   63.09k ± 0%    -0.00% (p=0.001 n=10)
CompactPeak/combine/PebbleCompact/922KiB+230KiB-8     139.25k ± 0%   76.22k ± 0%   -45.27% (p=0.000 n=10)
geomean                                                68.81k        1.241k        -98.20%
```
