### PR TITLE
apmconfigextension: read non-identifying OpAMP attributes

### DIFF
--- a/extension/apmconfigextension/README.md
+++ b/extension/apmconfigextension/README.md
@@ -262,20 +262,24 @@ message](https://github.com/open-telemetry/opamp-spec/blob/main/specification.md
 
 An OpAMP client **must** set the attributes (`service.name` and optionally `deployment.environment.name`) on the
 [AgentDescription.identifying_attributes](https://github.com/open-telemetry/opamp-spec/blob/main/specification.md#agentdescriptionidentifying_attributes)
+or
+[AgentDescription.non_identifying_attributes](https://github.com/open-telemetry/opamp-spec/blob/main/specification.md#agentdescriptionnon_identifying_attributes)
 field during the first send
 [AgentToServer](https://github.com/open-telemetry/opamp-spec/blob/main/specification.md#agenttoserver-message)
-message. As the `AgentDescription` should not be sent if not changed, the
-extension will maintain an internal mapping between the `Agent.instance_uid` and
-its service identifying attributes.
+message. The extension reads both attribute lists; if the same key is present
+in both, the value from `identifying_attributes` takes precedence. As the
+`AgentDescription` should not be sent if not changed, the extension will
+maintain an internal mapping between the `Agent.instance_uid` and its service
+identifying attributes.
 
 The [ServerToAgent.ReportFullState
 flag](https://github.com/open-telemetry/opamp-spec/blob/main/specification.md#servertoagentflags)
 will be set in the following cases:
 
-- The agent did not include the `service.name` identifying attributes during the
-first message.
+- The agent did not include the `service.name` attribute in either the identifying
+or non-identifying attributes during the first message.
 - The OpAMP server was not able to identify the agent (undefined
 `Agent.instance_uid`).
 
-The agent **must** return a message with the corresponding
-`AgentDescription.identifying_attributes`.
+The agent **must** return a message with the corresponding `AgentDescription`
+attributes in either `identifying_attributes` or `non_identifying_attributes`.

--- a/extension/apmconfigextension/apmconfig/client.go
+++ b/extension/apmconfigextension/apmconfig/client.go
@@ -31,6 +31,8 @@ type (
 	// protobufs.AgentToServer.InstanceUid
 	InstanceUid []byte
 	// Attributes like service.name used to identify the service being monitored.
+	// They may originate from either the identifying or non-identifying
+	// attributes of the OpAMP AgentDescription.
 	IdentifyingAttributes []*protobufs.KeyValue
 	// The hash of the agent's current configuration, used for caching.
 	LastConfigHash []byte

--- a/extension/apmconfigextension/opamp_callbacks.go
+++ b/extension/apmconfigextension/opamp_callbacks.go
@@ -98,6 +98,34 @@ func newRemoteConfigCallbacks(ctx context.Context, configClient apmconfig.Remote
 	return opampCallbacks, nil
 }
 
+// serviceAttributes returns the attributes used to identify the monitored
+// service from an OpAMP AgentDescription. Both identifying_attributes and
+// non_identifying_attributes are considered, since the OpAMP specification
+// does not mandate where attributes such as deployment.environment.name are
+// reported. When the same key is present in both lists, the identifying
+// attribute takes precedence.
+func serviceAttributes(desc *protobufs.AgentDescription) apmconfig.IdentifyingAttributes {
+	identifying := desc.GetIdentifyingAttributes()
+	nonIdentifying := desc.GetNonIdentifyingAttributes()
+	if len(nonIdentifying) == 0 {
+		return identifying
+	}
+
+	attrs := make(apmconfig.IdentifyingAttributes, 0, len(identifying)+len(nonIdentifying))
+	seen := make(map[string]struct{}, len(identifying))
+	for _, attr := range identifying {
+		seen[attr.GetKey()] = struct{}{}
+		attrs = append(attrs, attr)
+	}
+	for _, attr := range nonIdentifying {
+		if _, ok := seen[attr.GetKey()]; ok {
+			continue
+		}
+		attrs = append(attrs, attr)
+	}
+	return attrs
+}
+
 func (rc *remoteConfigCallbacks) serverError(msg string, message *protobufs.ServerToAgent, logFields ...zap.Field) *protobufs.ServerToAgent {
 	message.ErrorResponse = &protobufs.ServerErrorResponse{
 		ErrorMessage: msg,
@@ -127,7 +155,7 @@ func (rc *remoteConfigCallbacks) onMessage(ctx context.Context, conn types.Conne
 		// new description might lead to another remote configuration
 		_ = rc.agentState.Add(agentUid, &agentInfo{
 			agentUid:              message.GetInstanceUid(),
-			identifyingAttributes: message.AgentDescription.IdentifyingAttributes,
+			identifyingAttributes: serviceAttributes(message.GetAgentDescription()),
 		})
 	}
 

--- a/extension/apmconfigextension/opamp_callbacks_test.go
+++ b/extension/apmconfigextension/opamp_callbacks_test.go
@@ -326,6 +326,96 @@ func TestOnMessage(t *testing.T) {
 	}
 }
 
+func TestOnMessage_ServiceAttributes(t *testing.T) {
+	kv := func(key, value string) *protobufs.KeyValue {
+		return &protobufs.KeyValue{Key: key, Value: &protobufs.AnyValue{Value: &protobufs.AnyValue_StringValue{StringValue: value}}}
+	}
+
+	testcases := map[string]struct {
+		description   *protobufs.AgentDescription
+		expectedAttrs apmconfig.IdentifyingAttributes
+	}{
+		"only identifying attributes": {
+			description: &protobufs.AgentDescription{
+				IdentifyingAttributes: []*protobufs.KeyValue{
+					kv("service.name", "my-app"),
+					kv("deployment.environment.name", "production"),
+				},
+			},
+			expectedAttrs: apmconfig.IdentifyingAttributes{
+				kv("service.name", "my-app"),
+				kv("deployment.environment.name", "production"),
+			},
+		},
+		"only non-identifying attributes": {
+			description: &protobufs.AgentDescription{
+				NonIdentifyingAttributes: []*protobufs.KeyValue{
+					kv("service.name", "my-app"),
+					kv("deployment.environment.name", "production"),
+				},
+			},
+			expectedAttrs: apmconfig.IdentifyingAttributes{
+				kv("service.name", "my-app"),
+				kv("deployment.environment.name", "production"),
+			},
+		},
+		"split between identifying and non-identifying attributes": {
+			description: &protobufs.AgentDescription{
+				IdentifyingAttributes: []*protobufs.KeyValue{
+					kv("service.name", "my-app"),
+				},
+				NonIdentifyingAttributes: []*protobufs.KeyValue{
+					kv("deployment.environment.name", "production"),
+					kv("os.type", "linux"),
+				},
+			},
+			expectedAttrs: apmconfig.IdentifyingAttributes{
+				kv("service.name", "my-app"),
+				kv("deployment.environment.name", "production"),
+				kv("os.type", "linux"),
+			},
+		},
+		"identifying attributes take precedence on duplicate keys": {
+			description: &protobufs.AgentDescription{
+				IdentifyingAttributes: []*protobufs.KeyValue{
+					kv("service.name", "my-app"),
+					kv("deployment.environment.name", "production"),
+				},
+				NonIdentifyingAttributes: []*protobufs.KeyValue{
+					kv("deployment.environment.name", "staging"),
+				},
+			},
+			expectedAttrs: apmconfig.IdentifyingAttributes{
+				kv("service.name", "my-app"),
+				kv("deployment.environment.name", "production"),
+			},
+		},
+	}
+
+	for name, tt := range testcases {
+		t.Run(name, func(t *testing.T) {
+			ctx, cancelFn := context.WithCancel(context.Background())
+			defer cancelFn()
+
+			var receivedAttrs apmconfig.IdentifyingAttributes
+			callbacks, err := newRemoteConfigCallbacks(ctx, &remoteConfigMock{
+				remoteConfigFn: func(_ context.Context, attrs apmconfig.IdentifyingAttributes, _ apmconfig.LastConfigHash) (*protobufs.AgentRemoteConfig, error) {
+					receivedAttrs = attrs
+					return nil, nil
+				},
+			}, defaultCacheConfig, zap.NewNop())
+			assert.NoError(t, err)
+
+			connectionCallbacks := callbacks.OnConnecting(nil).ConnectionCallbacks
+			connectionCallbacks.OnMessage(context.TODO(), nil, &protobufs.AgentToServer{
+				InstanceUid:      []byte("test"),
+				AgentDescription: tt.description,
+			})
+			assert.Equal(t, tt.expectedAttrs, receivedAttrs)
+		})
+	}
+}
+
 func TestOnMessageLRU(t *testing.T) {
 	ctx, cancelFn := context.WithCancel(context.Background())
 	defer cancelFn()


### PR DESCRIPTION
## Summary

The apmconfig extension only read `AgentDescription.identifying_attributes` when resolving `service.name` and `deployment.environment.name`. The OpAMP spec does not mandate where `deployment.environment.name` is reported, so SDKs placing it in `non_identifying_attributes` were matched without an environment and could receive the wrong central configuration. The extension now reads both lists.

## Changes

- Merge `identifying_attributes` and `non_identifying_attributes` from the AgentDescription before resolving the remote configuration. When a key is present in both, the identifying attribute takes precedence.
- Add tests covering attributes reported only as identifying, only as non-identifying, split across both lists, and duplicate keys.
- Update the README to state that the service attributes can be set in either field and document the precedence rule.