### PR TITLE
ci: add otel-devs team as a co-codeowner to every component

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,26 +2,26 @@
 * @elastic/otel-devs
 
 # Per-component owners
-.github/workflows/bump_otelbench.yaml      @elastic/obs-ds-intake-services @elastic/obs-ds-hosted-services
-.github/workflows/changelog_otelbench.yaml @elastic/obs-ds-intake-services @elastic/obs-ds-hosted-services
-.github/workflows/release_otelbench.yaml   @elastic/obs-ds-intake-services @elastic/obs-ds-hosted-services
-internal/elasticattr                   @elastic/obs-ds-intake-services @elastic/obs-ds-hosted-services
-loadgen                                @elastic/obs-ds-intake-services @elastic/obs-ds-hosted-services
-receiver/loadgenreceiver               @elastic/obs-ds-intake-services @elastic/obs-ds-hosted-services
-receiver/elasticapmintakereceiver      @elastic/obs-ds-intake-services @elastic/obs-ds-hosted-services @elastic/obs-signals-traces-team
-receiver/akamaisiemreceiver            @elastic/security-service-integrations
-receiver/entityanalyticsreceiver       @elastic/security-service-integrations
-receiver/vercelreceiver                @elastic/obs-ds-intake-services @elastic/obs-ds-hosted-services
-processor/elasticinframetricsprocessor @elastic/obs-infraobs-integrations
-processor/elasticapmprocessor          @elastic/obs-ds-intake-services @elastic/obs-ds-hosted-services @elastic/obs-signals-traces-team
-processor/elastictraceprocessor        @elastic/obs-ds-intake-services @elastic/obs-ds-hosted-services @elastic/obs-signals-traces-team
-processor/lsmintervalprocessor         @elastic/obs-ds-intake-services @elastic/obs-ds-hosted-services
-processor/ratelimitprocessor           @elastic/ingest-managed-jobs
-processor/integrationprocessor         @elastic/ecosystem
-connector/elasticapmconnector          @elastic/obs-ds-intake-services @elastic/obs-ds-hosted-services @elastic/obs-signals-traces-team
-extension/apikeyauthextension          @elastic/obs-ds-intake-services @elastic/obs-ds-hosted-services
-extension/apmconfigextension           @elastic/obs-signals-traces-team
-extension/fileintegrationextension     @elastic/ecosystem
-extension/vercelencodingextension      @elastic/obs-infraobs-integrations
-pkg/integrations                       @elastic/ecosystem
-extension/awscredentialsproviderextension             @elastic/obs-infraobs-integrations
+.github/workflows/bump_otelbench.yaml      @elastic/otel-devs @elastic/obs-ds-intake-services @elastic/obs-ds-hosted-services
+.github/workflows/changelog_otelbench.yaml @elastic/otel-devs @elastic/obs-ds-intake-services @elastic/obs-ds-hosted-services
+.github/workflows/release_otelbench.yaml   @elastic/otel-devs @elastic/obs-ds-intake-services @elastic/obs-ds-hosted-services
+internal/elasticattr                       @elastic/otel-devs @elastic/obs-ds-intake-services @elastic/obs-ds-hosted-services
+loadgen                                    @elastic/otel-devs @elastic/obs-ds-intake-services @elastic/obs-ds-hosted-services
+receiver/loadgenreceiver                   @elastic/otel-devs @elastic/obs-ds-intake-services @elastic/obs-ds-hosted-services
+receiver/elasticapmintakereceiver          @elastic/otel-devs @elastic/obs-ds-intake-services @elastic/obs-ds-hosted-services @elastic/obs-signals-traces-team
+receiver/akamaisiemreceiver                @elastic/otel-devs @elastic/security-service-integrations
+receiver/entityanalyticsreceiver           @elastic/otel-devs @elastic/security-service-integrations
+receiver/vercelreceiver                    @elastic/otel-devs @elastic/obs-ds-intake-services @elastic/obs-ds-hosted-services
+processor/elasticinframetricsprocessor     @elastic/otel-devs @elastic/obs-infraobs-integrations
+processor/elasticapmprocessor              @elastic/otel-devs @elastic/obs-ds-intake-services @elastic/obs-ds-hosted-services @elastic/obs-signals-traces-team
+processor/elastictraceprocessor            @elastic/otel-devs @elastic/obs-ds-intake-services @elastic/obs-ds-hosted-services @elastic/obs-signals-traces-team
+processor/lsmintervalprocessor             @elastic/otel-devs @elastic/obs-ds-intake-services @elastic/obs-ds-hosted-services
+processor/ratelimitprocessor               @elastic/otel-devs @elastic/ingest-managed-jobs
+processor/integrationprocessor             @elastic/otel-devs @elastic/ecosystem
+connector/elasticapmconnector              @elastic/otel-devs @elastic/obs-ds-intake-services @elastic/obs-ds-hosted-services @elastic/obs-signals-traces-team
+extension/apikeyauthextension              @elastic/otel-devs @elastic/obs-ds-intake-services @elastic/obs-ds-hosted-services
+extension/apmconfigextension               @elastic/otel-devs @elastic/obs-signals-traces-team
+extension/fileintegrationextension         @elastic/otel-devs @elastic/ecosystem
+extension/vercelencodingextension          @elastic/otel-devs @elastic/obs-infraobs-integrations
+pkg/integrations                           @elastic/otel-devs @elastic/ecosystem
+extension/awscredentialsproviderextension  @elastic/otel-devs @elastic/obs-infraobs-integrations


### PR DESCRIPTION
This is a proposed solution to the problem of simple PRs like dependency updates being blocked from merging, waiting on reviews from multiple teams.

The approach is similar to that in upstream [CODEOWNERS](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/0458335a480d544e098da4a7a854652b193b3961/.github/CODEOWNERS) file.
It shifts the semantics from "codeowners must approve" to "codeowners are notified, maintainers can approve".
The otel-devs team was chosen as the "maintainers" team as the best candidate at the moment.