### PR TITLE
ci: group Dependabot updates across directories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,10 @@ updates:
           - "go.opentelemetry.io/*"
           - "github.com/open-telemetry/opentelemetry-collector-contrib/*"
           - "github.com/elastic/opentelemetry-lib"
+      non-otel:
+        group-by: dependency-name
+        patterns:
+          - "*"
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION
This should prevent multiple PRs for a single dependency update ([example](https://github.com/elastic/opentelemetry-collector-components/pulls?q=is:pr+author:app/dependabot+in:title+testify+1.11.1+1.12.0)) in the future.