### PR TITLE
test(receiver/entity_analytics): harden flaky integration test `TestADReceiverLifecycle_ES`

### DIFF
--- a/receiver/entityanalyticsreceiver/Makefile
+++ b/receiver/entityanalyticsreceiver/Makefile
@@ -1,1 +1,5 @@
+# The integration tests start a dedicated Elasticsearch container per
+# ES-backed test, so the package needs more than the default budget.
+GOTEST_TIMEOUT=480s
+
 include ../../Makefile.Common

--- a/receiver/entityanalyticsreceiver/es_store_test.go
+++ b/receiver/entityanalyticsreceiver/es_store_test.go
@@ -140,7 +140,7 @@ func TestESStore_LargeShardDocument(t *testing.T) {
 
 func TestESStore_MissingIndex(t *testing.T) {
 	client := esClient(t)
-	store := newESStore(t, client, "test-missing-index")
+	store := newESStoreWithoutIndex(t, client, "test-missing-index")
 
 	// First Set should succeed — ES auto-creates the index.
 	err := store.Set("first", "value")
@@ -205,16 +205,24 @@ func esClient(t *testing.T) *elasticsearch.Client {
 		t.Fatalf("creating ES client: %v", err)
 	}
 
-	deadline := time.Now().Add(2 * time.Minute)
+	// Wait for the cluster to reach at least yellow health. GET / on
+	// a freshly started node returns 200 before the cluster state is
+	// recovered, and document requests issued in that window block on
+	// the "state not recovered" cluster block, which can eat most of
+	// a test's wait budget.
+	deadline := time.Now().Add(esStartupTimeout)
 	var lastErr error
 	for time.Now().Before(deadline) {
-		resp, err := client.Info()
+		resp, err := client.Cluster.Health(
+			client.Cluster.Health.WithWaitForStatus("yellow"),
+			client.Cluster.Health.WithTimeout(5*time.Second),
+		)
 		if err != nil {
 			lastErr = err
 		} else {
 			_ = resp.Body.Close()
 			if resp.IsError() {
-				lastErr = fmt.Errorf("ES info: %s", resp.Status())
+				lastErr = fmt.Errorf("ES cluster health: %s", resp.Status())
 			} else {
 				lastErr = nil
 				break
@@ -223,13 +231,19 @@ func esClient(t *testing.T) *elasticsearch.Client {
 		time.Sleep(time.Second)
 	}
 	if lastErr != nil {
-		t.Fatalf("ES not ready after 2m: %v", lastErr)
+		t.Fatalf("ES not ready after %s: %v", esStartupTimeout, lastErr)
 	}
 
 	return client
 }
 
-const esPort = "9200"
+const (
+	esPort = "9200"
+
+	// esStartupTimeout bounds how long tests wait for Elasticsearch to
+	// become reachable and healthy.
+	esStartupTimeout = 2 * time.Minute
+)
 
 // startESContainer starts an Elasticsearch container via
 // testcontainers-go and returns its HTTP endpoint. The container is
@@ -245,7 +259,17 @@ func startESContainer(t *testing.T) string {
 			"ES_JAVA_OPTS":           "-Xms512m -Xmx512m",
 			"xpack.security.enabled": "false",
 		},
-		WaitingFor: wait.ForListeningPort(esPort).WithStartupTimeout(2 * time.Minute),
+		// The port opens before the cluster state is recovered, so also
+		// require the health endpoint to report yellow (or better).
+		// ES answers 408 while the requested status has not been reached.
+		WaitingFor: wait.ForAll(
+			wait.ForListeningPort(esPort),
+			wait.ForHTTP("/_cluster/health?wait_for_status=yellow&timeout=1s").
+				WithPort(esPort+"/tcp").
+				WithStatusCodeMatcher(func(status int) bool {
+					return status >= 200 && status < 300
+				}),
+		).WithDeadline(esStartupTimeout),
 	}
 
 	container, err := testcontainers.GenericContainer(context.Background(), testcontainers.GenericContainerRequest{
@@ -286,12 +310,38 @@ type esStore struct {
 
 // newESStore returns an esStore backed by the given index. Any
 // existing index with the same name is deleted first so the test
-// starts with a clean slate.
+// starts with a clean slate, and the index is then created up front
+// so the first write under test does not pay for index auto-creation
+// and dynamic mapping while a timed assertion is running.
 func newESStore(t *testing.T, client *elasticsearch.Client, index string) *esStore {
 	t.Helper()
+	store := newESStoreWithoutIndex(t, client, index)
+
+	resp, err := client.Indices.Create(index,
+		client.Indices.Create.WithWaitForActiveShards("1"),
+	)
+	if err != nil {
+		t.Fatalf("create index %s: %v", index, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.IsError() {
+		t.Fatalf("create index %s: %s", index, resp.Status())
+	}
+	return store
+}
+
+// newESStoreWithoutIndex returns an esStore whose index does not
+// exist yet. Any existing index with the same name is deleted. Use
+// this when a test needs to exercise ES index auto-creation.
+func newESStoreWithoutIndex(t *testing.T, client *elasticsearch.Client, index string) *esStore {
+	t.Helper()
 	resp, err := client.Indices.Delete([]string{index})
-	if err == nil {
-		_ = resp.Body.Close()
+	if err != nil {
+		t.Fatalf("delete index %s: %v", index, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.IsError() && resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("delete index %s: %s", index, resp.Status())
 	}
 	return &esStore{client: client, index: index}
 }

--- a/receiver/entityanalyticsreceiver/integration_es_test.go
+++ b/receiver/entityanalyticsreceiver/integration_es_test.go
@@ -29,6 +29,20 @@ import (
 	ecokta "github.com/elastic/entcollect/provider/okta"
 )
 
+const (
+	// esLogsTimeout is the budget for a sync phase to publish its
+	// expected records when the receiver is backed by a real
+	// Elasticsearch store. It is wider than the in-memory tests'
+	// budget because every idset load and commit is an ES round-trip
+	// against a container that may still be warming up.
+	esLogsTimeout = 60 * time.Second
+
+	// esStoreKeyTimeout is the budget for the receiver's committed
+	// state to become visible in the ES store after the last record
+	// of a sync has been published.
+	esStoreKeyTimeout = 30 * time.Second
+)
+
 // TestADReceiverLifecycle_ES exercises the full AD receiver lifecycle
 // with a real Elasticsearch store instead of newMemoryStore. This
 // validates that the esStore implementation satisfies the
@@ -59,13 +73,14 @@ func TestADReceiverLifecycle_ES(t *testing.T) {
 
 	// Phase 1: first sync discovers all.
 	sink1 := &consumertest.LogsSink{}
-	rcvr1 := newReceiver(nopSettings(), adIntegConfig(provName, ldapURL), sink1)
+	set1, logs1 := observedSettings(t)
+	rcvr1 := newReceiver(set1, adIntegConfig(provName, ldapURL), sink1)
 	err := rcvr1.Start(t.Context(), testHost(provName, store))
 	if err != nil {
 		t.Fatalf("receiver start failed: %v", err)
 	}
-	waitForLogs(t, sink1, 3, 30*time.Second)
-	waitForStoreKey(t, store, "ad.users.idset.meta", 10*time.Second)
+	waitForLogsOrSyncError(t, sink1, logs1, 3, esLogsTimeout)
+	waitForStoreKey(t, store, "ad.users.idset.meta", esStoreKeyTimeout)
 	err = rcvr1.Shutdown(t.Context())
 	if err != nil {
 		t.Fatalf("receiver shutdown failed: %v", err)
@@ -75,12 +90,13 @@ func TestADReceiverLifecycle_ES(t *testing.T) {
 	// Phase 2: remove bob, restart with same store.
 	fix.users = fix.users[:1]
 	sink2 := &consumertest.LogsSink{}
-	rcvr2 := newReceiver(nopSettings(), adIntegConfig(provName, ldapURL), sink2)
+	set2, logs2 := observedSettings(t)
+	rcvr2 := newReceiver(set2, adIntegConfig(provName, ldapURL), sink2)
 	err = rcvr2.Start(t.Context(), testHost(provName, store))
 	if err != nil {
 		t.Fatalf("second receiver start failed: %v", err)
 	}
-	waitForLogs(t, sink2, 3, 30*time.Second)
+	waitForLogsOrSyncError(t, sink2, logs2, 3, esLogsTimeout)
 	err = rcvr2.Shutdown(t.Context())
 	if err != nil {
 		t.Fatalf("second receiver shutdown failed: %v", err)
@@ -113,13 +129,14 @@ func TestOktaReceiverLifecycle_ES(t *testing.T) {
 
 	// Phase 1: discover all.
 	sink1 := &consumertest.LogsSink{}
-	rcvr1 := newReceiver(nopSettings(), oktaIntegConfig(provName, host), sink1)
+	set1, logs1 := observedSettings(t)
+	rcvr1 := newReceiver(set1, oktaIntegConfig(provName, host), sink1)
 	err := rcvr1.Start(t.Context(), testHost(provName, store))
 	if err != nil {
 		t.Fatalf("receiver start failed: %v", err)
 	}
-	waitForLogs(t, sink1, 2, 30*time.Second)
-	waitForStoreKey(t, store, "okta.users.idset.meta", 10*time.Second)
+	waitForLogsOrSyncError(t, sink1, logs1, 2, esLogsTimeout)
+	waitForStoreKey(t, store, "okta.users.idset.meta", esStoreKeyTimeout)
 	err = rcvr1.Shutdown(t.Context())
 	if err != nil {
 		t.Fatalf("receiver shutdown failed: %v", err)
@@ -129,12 +146,13 @@ func TestOktaReceiverLifecycle_ES(t *testing.T) {
 	// Phase 2: remove u2, restart with same store.
 	fix.users = fix.users[:1]
 	sink2 := &consumertest.LogsSink{}
-	rcvr2 := newReceiver(nopSettings(), oktaIntegConfig(provName, host), sink2)
+	set2, logs2 := observedSettings(t)
+	rcvr2 := newReceiver(set2, oktaIntegConfig(provName, host), sink2)
 	err = rcvr2.Start(t.Context(), testHost(provName, store))
 	if err != nil {
 		t.Fatalf("second receiver start failed: %v", err)
 	}
-	waitForLogs(t, sink2, 2, 30*time.Second)
+	waitForLogsOrSyncError(t, sink2, logs2, 2, esLogsTimeout)
 	err = rcvr2.Shutdown(t.Context())
 	if err != nil {
 		t.Fatalf("second receiver shutdown failed: %v", err)
@@ -168,12 +186,13 @@ func TestEntraidReceiverLifecycle_ES(t *testing.T) {
 
 	// Phase 1: discover all — 2 users + 1 device = 3 events.
 	sink1 := &consumertest.LogsSink{}
-	rcvr1 := newReceiver(nopSettings(), entraidIntegConfig(provName, srv.URL), sink1)
+	set1, logs1 := observedSettings(t)
+	rcvr1 := newReceiver(set1, entraidIntegConfig(provName, srv.URL), sink1)
 	err := rcvr1.Start(t.Context(), testHost(provName, store))
 	if err != nil {
 		t.Fatalf("receiver start failed: %v", err)
 	}
-	waitForLogs(t, sink1, 3, 30*time.Second)
+	waitForLogsOrSyncError(t, sink1, logs1, 3, esLogsTimeout)
 	err = rcvr1.Shutdown(t.Context())
 	if err != nil {
 		t.Fatalf("receiver shutdown failed: %v", err)
@@ -187,12 +206,13 @@ func TestEntraidReceiverLifecycle_ES(t *testing.T) {
 	}
 
 	sink2 := &consumertest.LogsSink{}
-	rcvr2 := newReceiver(nopSettings(), entraidIntegConfig(provName, srv.URL), sink2)
+	set2, logs2 := observedSettings(t)
+	rcvr2 := newReceiver(set2, entraidIntegConfig(provName, srv.URL), sink2)
 	err = rcvr2.Start(t.Context(), testHost(provName, store))
 	if err != nil {
 		t.Fatalf("second receiver start failed: %v", err)
 	}
-	waitForLogs(t, sink2, 3, 30*time.Second)
+	waitForLogsOrSyncError(t, sink2, logs2, 3, esLogsTimeout)
 	err = rcvr2.Shutdown(t.Context())
 	if err != nil {
 		t.Fatalf("second receiver shutdown failed: %v", err)

--- a/receiver/entityanalyticsreceiver/integration_test.go
+++ b/receiver/entityanalyticsreceiver/integration_test.go
@@ -26,6 +26,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -35,6 +36,10 @@ import (
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/receiver"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/elastic/entcollect"
 	ecjamf "github.com/elastic/entcollect/provider/jamf"
@@ -397,6 +402,76 @@ func waitForLogs(t *testing.T, sink *consumertest.LogsSink, n int, timeout time.
 		case <-time.After(10 * time.Millisecond):
 		}
 	}
+}
+
+// observedSettings returns receiver.Settings whose logger records every
+// entry in the returned observer. Tests use it to surface the receiver's
+// own "sync failed" errors, which would otherwise be swallowed by the
+// nop logger and only show up as an opaque wait timeout.
+func observedSettings(t *testing.T) (receiver.Settings, *observer.ObservedLogs) {
+	t.Helper()
+	core, observed := observer.New(zapcore.DebugLevel)
+	set := nopSettings()
+	set.Logger = zap.New(core)
+	return set, observed
+}
+
+// receiverSyncErrorMessages are the messages the receiver logs at error
+// level when a sync attempt gives up. Once one of these is logged no
+// further records will arrive until the next sync tick, so a test
+// waiting for records should fail immediately rather than time out.
+var receiverSyncErrorMessages = []string{"sync failed", "committing sync state"}
+
+// waitForLogsOrSyncError polls the sink until it contains at least n log
+// records or the timeout expires. Unlike waitForLogs it also watches the
+// receiver's logs and fails fast, with the underlying error, if the
+// receiver reports a failed sync while the test is waiting.
+func waitForLogsOrSyncError(t *testing.T, sink *consumertest.LogsSink, observed *observer.ObservedLogs, n int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.After(timeout)
+	for {
+		if sink.LogRecordCount() >= n {
+			return
+		}
+		if entry, ok := firstSyncError(observed); ok {
+			t.Fatalf("receiver reported %q after %d of %d log records: %v\nreceiver logs:\n%s",
+				entry.Message, sink.LogRecordCount(), n, entry.ContextMap()["error"], formatObservedLogs(observed))
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("timed out waiting for %d log records (got %d)\nreceiver logs:\n%s",
+				n, sink.LogRecordCount(), formatObservedLogs(observed))
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+}
+
+// firstSyncError returns the first error-level entry matching one of
+// receiverSyncErrorMessages, if any.
+func firstSyncError(observed *observer.ObservedLogs) (observer.LoggedEntry, bool) {
+	for _, entry := range observed.FilterLevelExact(zapcore.ErrorLevel).All() {
+		for _, msg := range receiverSyncErrorMessages {
+			if entry.Message == msg {
+				return entry, true
+			}
+		}
+	}
+	return observer.LoggedEntry{}, false
+}
+
+// formatObservedLogs renders observed receiver log entries, one per line,
+// for inclusion in failure messages.
+func formatObservedLogs(observed *observer.ObservedLogs) string {
+	entries := observed.All()
+	if len(entries) == 0 {
+		return "  (none)"
+	}
+	var sb strings.Builder
+	for _, entry := range entries {
+		fmt.Fprintf(&sb, "  %s %s %s %v\n",
+			entry.Time.Format(time.RFC3339Nano), entry.Level, entry.Message, entry.ContextMap())
+	}
+	return sb.String()
 }
 
 // checkActionCounts extracts event.action values from all log records and


### PR DESCRIPTION
`TestADReceiverLifecycle_ES` fails intermittently in CI with "timed out waiting for N log records", both on PRs and on main. The in-memory variant never fails, so the culprit is timing against the freshly started Elasticsearch container.

- Wait for cluster health yellow before running tests; GET / returns 200 before the cluster state is recovered and document requests issued in that window block.
- Pre-create the test index so the first commit under test does not pay for auto-creation and dynamic mapping.
- Capture receiver logs with a zap observer and fail fast with the underlying error when the receiver reports "sync failed", instead of an opaque 30s timeout.
- Raise the ES-backed wait budgets (60s/30s) and set the module GOTEST_TIMEOUT to 480s, as the package starts one ES container per ES-backed test and was running close to the 240s default.

Assisted-by: Claude Fable 5.1