### PR TITLE
fix(apikeyauth): normalize API key authorization scheme

### DIFF
--- a/extension/apikeyauthextension/authenticator.go
+++ b/extension/apikeyauthextension/authenticator.go
@@ -220,7 +220,7 @@ func (a *authenticator) Shutdown(ctx context.Context) error {
 }
 
 // parseAuthorizationHeader checks that the Authorization header follows the expected format,
-// and returns the full header value, and the API Key ID.
+// and returns the canonical header value and the API Key ID.
 func (a *authenticator) parseAuthorizationHeader(headers map[string][]string) (string, string, error) {
 	orig, ok := getHeader(headers, authorizationHeader, lowerAuthorizationHeader)
 	if !ok {
@@ -246,7 +246,10 @@ func (a *authenticator) parseAuthorizationHeader(headers map[string][]string) (s
 		return "", "", errAuthorizationHeaderInvalid
 	}
 
-	return orig, id, nil
+	// Normalize equivalent representations before forwarding the header and deriving
+	// the cache fingerprint. Otherwise, scheme casing is mistaken for a colliding
+	// API key secret when another representation has already populated the cache.
+	return "ApiKey " + base64.StdEncoding.EncodeToString(decoded), id, nil
 }
 
 func getHeader(headers map[string][]string, titlecase, lowercase string) (string, bool) {

--- a/extension/apikeyauthextension/authenticator_test.go
+++ b/extension/apikeyauthextension/authenticator_test.go
@@ -248,6 +248,60 @@ func TestAuthenticator_ApplicationPrivileges(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestAuthenticator_CanonicalizesAuthorizationScheme(t *testing.T) {
+	encoded := base64.StdEncoding.EncodeToString([]byte("id:secret"))
+	srv := newMockElasticsearch(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "ApiKey "+encoded, r.Header.Get("Authorization"))
+		newCannedHasPrivilegesHandler(successfulResponse).ServeHTTP(w, r)
+	})
+	authenticator := newTestAuthenticator(t, srv, createDefaultConfig().(*Config))
+
+	_, err := authenticator.Authenticate(context.Background(), map[string][]string{
+		"Authorization": {"APIKey " + encoded},
+	})
+	require.NoError(t, err)
+}
+
+func TestAuthenticator_CachingIgnoresAuthorizationSchemeCase(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		firstScheme  string
+		secondScheme string
+	}{
+		{
+			name:         "APIKey_then_ApiKey",
+			firstScheme:  "APIKey",
+			secondScheme: "ApiKey",
+		},
+		{
+			name:         "ApiKey_then_APIKey",
+			firstScheme:  "ApiKey",
+			secondScheme: "APIKey",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var calls int
+			srv := newMockElasticsearch(t, func(w http.ResponseWriter, r *http.Request) {
+				calls++
+				newCannedHasPrivilegesHandler(successfulResponse).ServeHTTP(w, r)
+			})
+			authenticator := newTestAuthenticator(t, srv, createDefaultConfig().(*Config))
+			encoded := base64.StdEncoding.EncodeToString([]byte("id:secret"))
+
+			_, err := authenticator.Authenticate(context.Background(), map[string][]string{
+				"Authorization": {tc.firstScheme + " " + encoded},
+			})
+			require.NoError(t, err)
+
+			_, err = authenticator.Authenticate(context.Background(), map[string][]string{
+				"Authorization": {tc.secondScheme + " " + encoded},
+			})
+			require.NoError(t, err)
+			assert.Equal(t, 1, calls, "equivalent authorization schemes should share a cache entry")
+		})
+	}
+}
+
 func TestAuthenticator_Caching(t *testing.T) {
 	var calls int
 	srv := newMockElasticsearch(t, func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

Normalize accepted API key authorization headers before forwarding them to Elasticsearch and deriving the cache fingerprint.

HTTP authentication schemes are case-insensitive, so `APIKey <credential>` and `ApiKey <credential>` identify the same API key. Previously, parsing accepted both representations but PBKDF2 hashed the original header. Once one representation populated the ID-based cache entry, the other was mistaken for the same ID with a different secret and rejected with HTTP 401 until the cache expired.

## Reproduction

Against a deployed Managed OTLP endpoint with a 35-second auth cache TTL:

- prime with `APIKey`: 40/40 returned 200
- immediately use `ApiKey`: 40/40 returned 401
- expire the cache and prime with `ApiKey`: 40/40 returned 200
- immediately use `APIKey`: 40/40 returned 401

## Changes

- canonicalize valid API key headers to `ApiKey <canonical-base64>`
- use that canonical value for both `_has_privileges` and the cache fingerprint
- verify both scheme orders share one cache entry and make only one Elasticsearch request
- preserve the existing same-ID/different-secret collision behavior

## Testing

- `make test` (race detector enabled, 94.3% statement coverage)
- `make lint` (0 issues)
- `make fmt`
- `git diff --check`
