### PR TITLE
[receiver/loadgen]Add config options for better trace manipulation

### DIFF
--- a/receiver/loadgenreceiver/README.md
+++ b/receiver/loadgenreceiver/README.md
@@ -23,7 +23,33 @@ The receiver generates telemetry as quickly as possible. Any rate limiting shoul
 
 ## Telemetry cardinality
 
-The receiver only rewrites timestamps to Now, and does not modify any other fields. Therefore, it will have the same cardinality as the original canned data. To simulate higher cardinality (e.g. trace ID, service name), use `transform` processor with OTTL to rewrite fields. 
+The receiver only rewrites timestamps to Now, and does not modify any other fields by default. Therefore, it will have the same cardinality as the original canned data. To simulate higher cardinality (e.g. service name), use `transform` processor with OTTL to rewrite fields. For trace IDs, prefer `traces::rewrite_ids` below: an OTTL per-span rewrite breaks span grouping, and replaying without any rewrite re-sends the same trace IDs on every pass.
+
+## Tail-based sampling testing
+
+Two traces options exist to exercise tail-based sampling backends:
+
+```yaml
+receivers:
+  loadgen:
+    traces:
+      # rewrite_ids deterministically remaps trace/span IDs per replay pass:
+      # spans sharing a trace ID keep sharing one (even across JSONL lines
+      # within a pass, parent-child and link IDs included), while every pass
+      # and every run produces globally new trace IDs with the same
+      # statistical shape.
+      rewrite_ids: true
+      # late_spans holds back spans from emitted payloads and re-emits them
+      # after a wall-clock delay, exercising late-arrival paths (partial trace
+      # at decision time, decision cache hits, re-decision after eviction).
+      late_spans:
+        fraction: 0.05 # probability a payload gets spans held back
+        spans: 1       # max spans held back per selected payload
+        delay_min: 10s
+        delay_max: 60s
+```
+
+Payloads whose span count does not exceed `spans` are never split, since delaying a whole payload does not make any span late relative to the rest of its trace.
 
 ## Config
 

--- a/receiver/loadgenreceiver/config.go
+++ b/receiver/loadgenreceiver/config.go
@@ -107,6 +107,38 @@ type TracesConfig struct {
 	JsonlFile `mapstructure:",squash"`
 
 	SignalConfig `mapstructure:",squash"`
+
+	// RewriteIDs rewrites trace and span IDs on every replay pass so that each
+	// pass over the input file produces unique trace IDs with an identical
+	// statistical shape. IDs are remapped deterministically per pass: spans
+	// sharing a trace ID keep sharing one, and parent-child span ID links are
+	// preserved. Without this, replaying a file re-sends the same trace IDs,
+	// which tail-based sampling backends treat as late spans of already-decided
+	// traces instead of new traces.
+	RewriteIDs bool `mapstructure:"rewrite_ids"`
+
+	// LateSpans holds back spans from emitted traces and re-emits them after a
+	// wall-clock delay, to exercise tail-based sampling late-arrival paths
+	// (partial trace at decision time, decision cache hits, re-decisions after
+	// cache eviction).
+	LateSpans *LateSpansConfig `mapstructure:"late_spans"`
+}
+
+// LateSpansConfig configures delayed re-emission of spans held back from
+// generated traces.
+type LateSpansConfig struct {
+	// Fraction is the probability in [0, 1] that spans are held back from an
+	// emitted payload.
+	Fraction float64 `mapstructure:"fraction"`
+
+	// Spans is the maximum number of spans held back per selected payload.
+	// Defaults to 1.
+	Spans int `mapstructure:"spans"`
+
+	// DelayMin and DelayMax bound the uniform random delay after which the
+	// held spans are emitted.
+	DelayMin time.Duration `mapstructure:"delay_min"`
+	DelayMax time.Duration `mapstructure:"delay_max"`
 }
 
 type ProfilesConfig struct {
@@ -189,6 +221,20 @@ func (cfg *Config) Validate() error {
 	err = validateSignal(cfg.Traces.SignalConfig, cfg.Traces.JsonlFile)
 	if err != nil {
 		return fmt.Errorf("traces::%w", err)
+	}
+	if ls := cfg.Traces.LateSpans; ls != nil {
+		if ls.Fraction < 0 || ls.Fraction > 1 {
+			return fmt.Errorf("traces::late_spans::fraction must be in [0, 1]")
+		}
+		if ls.Spans < 0 {
+			return fmt.Errorf("traces::late_spans::spans must be >= 0")
+		}
+		if ls.DelayMin < 0 {
+			return fmt.Errorf("traces::late_spans::delay_min must be >= 0")
+		}
+		if ls.DelayMax < ls.DelayMin {
+			return fmt.Errorf("traces::late_spans::delay_max must be >= delay_min")
+		}
 	}
 
 	err = validateSignal(cfg.Profiles.SignalConfig, cfg.Profiles.JsonlFile)

--- a/receiver/loadgenreceiver/internal/list/looping.go
+++ b/receiver/loadgenreceiver/internal/list/looping.go
@@ -46,20 +46,28 @@ func NewLoopingList[T any](items []T, loopLimit int) *LoopingList[T] {
 // If loop limit is reached, it returns ErrLoopLimitReached.
 // Safe for concurrent use.
 func (s *LoopingList[T]) Next() (T, error) {
+	item, _, err := s.NextLoop()
+	return item, err
+}
+
+// NextLoop is Next but additionally returns the zero-based loop pass the
+// returned item belongs to.
+func (s *LoopingList[T]) NextLoop() (T, int, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	if s.loopLimit != 0 && s.loopCnt >= s.loopLimit {
 		var zero T
-		return zero, ErrLoopLimitReached
+		return zero, 0, ErrLoopLimitReached
 	}
 
 	item := s.items[s.idx]
+	loop := s.loopCnt
 
 	s.idx = (s.idx + 1) % len(s.items)
 	if s.idx == 0 {
 		s.loopCnt++
 	}
 
-	return item, nil
+	return item, loop, nil
 }

--- a/receiver/loadgenreceiver/traces.go
+++ b/receiver/loadgenreceiver/traces.go
@@ -21,9 +21,12 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"crypto/sha256"
 	_ "embed"
+	"encoding/binary"
 	"errors"
 	"io"
+	"math/rand/v2"
 	"sync"
 	"time"
 
@@ -45,6 +48,10 @@ type tracesGenerator struct {
 	logger *zap.Logger
 
 	samples *list.LoopingList[ptrace.Traces]
+
+	// idSeed salts the per-pass trace/span ID rewrite so that separate
+	// generator runs replaying the same file also produce distinct IDs.
+	idSeed uint64
 
 	stats   Stats
 	statsMu sync.Mutex
@@ -105,6 +112,7 @@ func createTracesReceiver(
 		logger:   set.Logger,
 		consumer: consumer,
 		samples:  list.NewLoopingList(items, genConfig.Traces.MaxReplay),
+		idSeed:   rand.Uint64(),
 	}, nil
 }
 
@@ -134,20 +142,20 @@ func (ar *tracesGenerator) Start(ctx context.Context, _ component.Host) error {
 				if errors.Is(err, list.ErrLoopLimitReached) {
 					return
 				}
+				late, hasLate := ar.splitLateSpans(next)
 				// For graceful shutdown, use ctx instead of startCtx to shield Consume* from context canceled
 				// In other words, Consume* will finish at its own pace, which may take indefinitely long.
-				recordCount := next.SpanCount()
-				if err := ar.consumer.ConsumeTraces(ctx, next); err != nil {
-					ar.logger.Error(err.Error())
-					ar.statsMu.Lock()
-					ar.stats.FailedRequests++
-					ar.stats.FailedSpans += recordCount
-					ar.statsMu.Unlock()
-				} else {
-					ar.statsMu.Lock()
-					ar.stats.Requests++
-					ar.stats.Spans += recordCount
-					ar.statsMu.Unlock()
+				ar.consume(ctx, next)
+				if hasLate {
+					ar.inflightConcurrency.Add(1)
+					go func() {
+						defer ar.inflightConcurrency.Done()
+						ls := ar.cfg.Traces.LateSpans
+						// Emit only if the delay elapses before shutdown.
+						if waitJitter(startCtx, &JitterRange{Min: ls.DelayMin, Max: ls.DelayMax}) {
+							ar.consume(ctx, late)
+						}
+					}()
 				}
 				if !waitJitter(startCtx, ar.cfg.Traces.Jitter) {
 					return
@@ -173,11 +181,24 @@ func (ar *tracesGenerator) Shutdown(context.Context) error {
 }
 
 func (ar *tracesGenerator) nextTraces(next ptrace.Traces) error {
-	sample, err := ar.samples.Next()
+	sample, loop, err := ar.samples.NextLoop()
 	if err != nil {
 		return err
 	}
 	sample.CopyTo(next)
+
+	var idSalt [16]byte
+	if ar.cfg.Traces.RewriteIDs {
+		// The salt is deterministic per (seed, loop pass): spans of one trace
+		// remain grouped even across payloads within a pass, while every pass
+		// yields globally new IDs. IDs are remapped by hashing salt+original
+		// ID rather than XOR: hashing yields uniformly distributed IDs even
+		// from low-entropy originals (e.g. counter-based corpus IDs), which
+		// hash-based tail samplers such as the probabilistic tail_sampling
+		// policy depend on.
+		binary.LittleEndian.PutUint64(idSalt[:8], ar.idSeed)
+		binary.LittleEndian.PutUint64(idSalt[8:], uint64(loop))
+	}
 
 	rm := next.ResourceSpans()
 	for i := 0; i < rm.Len(); i++ {
@@ -189,9 +210,116 @@ func (ar *tracesGenerator) nextTraces(next ptrace.Traces) error {
 				duration := time.Duration(sspan.EndTimestamp() - sspan.StartTimestamp())
 				sspan.SetEndTimestamp(pcommon.NewTimestampFromTime(now))
 				sspan.SetStartTimestamp(pcommon.NewTimestampFromTime(now.Add(-duration)))
+
+				if ar.cfg.Traces.RewriteIDs {
+					sspan.SetTraceID(remapTraceID(sspan.TraceID(), idSalt))
+					sspan.SetSpanID(remapSpanID(sspan.SpanID(), idSalt))
+					sspan.SetParentSpanID(remapSpanID(sspan.ParentSpanID(), idSalt))
+					for l := 0; l < sspan.Links().Len(); l++ {
+						link := sspan.Links().At(l)
+						link.SetTraceID(remapTraceID(link.TraceID(), idSalt))
+						link.SetSpanID(remapSpanID(link.SpanID(), idSalt))
+					}
+				}
 			}
 		}
 	}
 
 	return nil
+}
+
+// remapTraceID remaps a trace ID to SHA-256(salt, id). Empty (all-zero) IDs
+// stay empty as they mark the absence of an ID.
+func remapTraceID(id pcommon.TraceID, salt [16]byte) pcommon.TraceID {
+	if id.IsEmpty() {
+		return id
+	}
+	sum := sha256.Sum256(append(salt[:], id[:]...))
+	copy(id[:], sum[:])
+	return id
+}
+
+// remapSpanID remaps a span ID to SHA-256(salt, id). Empty (all-zero) IDs stay
+// empty: an empty parent span ID marks a root span.
+func remapSpanID(id pcommon.SpanID, salt [16]byte) pcommon.SpanID {
+	if id.IsEmpty() {
+		return id
+	}
+	sum := sha256.Sum256(append(salt[:], id[:]...))
+	copy(id[:], sum[:])
+	return id
+}
+
+// splitLateSpans moves up to cfg.Traces.LateSpans.Spans spans from the tail of
+// next into a separately owned payload for delayed emission. It must run after
+// nextTraces (so held spans carry the rewritten IDs) and before next is handed
+// to the consumer.
+func (ar *tracesGenerator) splitLateSpans(next ptrace.Traces) (ptrace.Traces, bool) {
+	ls := ar.cfg.Traces.LateSpans
+	if ls == nil || rand.Float64() >= ls.Fraction {
+		return ptrace.Traces{}, false
+	}
+	maxHeld := ls.Spans
+	if maxHeld <= 0 {
+		maxHeld = 1
+	}
+	if next.SpanCount() <= maxHeld {
+		// Holding back the whole payload would just delay it, not make spans
+		// late relative to their trace.
+		return ptrace.Traces{}, false
+	}
+
+	late := ptrace.NewTraces()
+	held := 0
+	rm := next.ResourceSpans()
+	for i := rm.Len() - 1; i >= 0 && held < maxHeld; i-- {
+		rs := rm.At(i)
+		var lateRS ptrace.ResourceSpans
+		hasLateRS := false
+		for j := rs.ScopeSpans().Len() - 1; j >= 0 && held < maxHeld; j-- {
+			ss := rs.ScopeSpans().At(j)
+			spans := ss.Spans()
+			n := min(maxHeld-held, spans.Len())
+			if n == 0 {
+				continue
+			}
+			if !hasLateRS {
+				lateRS = late.ResourceSpans().AppendEmpty()
+				rs.Resource().CopyTo(lateRS.Resource())
+				lateRS.SetSchemaUrl(rs.SchemaUrl())
+				hasLateRS = true
+			}
+			lateSS := lateRS.ScopeSpans().AppendEmpty()
+			ss.Scope().CopyTo(lateSS.Scope())
+			lateSS.SetSchemaUrl(ss.SchemaUrl())
+			cut := spans.Len() - n
+			idx := 0
+			spans.RemoveIf(func(s ptrace.Span) bool {
+				idx++
+				if idx <= cut {
+					return false
+				}
+				s.MoveTo(lateSS.Spans().AppendEmpty())
+				return true
+			})
+			held += n
+		}
+	}
+	return late, held > 0
+}
+
+func (ar *tracesGenerator) consume(ctx context.Context, td ptrace.Traces) {
+	recordCount := td.SpanCount()
+	if err := ar.consumer.ConsumeTraces(ctx, td); err != nil {
+		ar.logger.Error(err.Error())
+		ar.statsMu.Lock()
+		ar.stats.FailedRequests++
+		ar.stats.FailedSpans += recordCount
+		ar.statsMu.Unlock()
+	} else {
+		ar.statsMu.Lock()
+		ar.stats.Requests++
+		ar.stats.Spans += recordCount
+		ar.statsMu.Unlock()
+	}
 }

--- a/receiver/loadgenreceiver/traces_test.go
+++ b/receiver/loadgenreceiver/traces_test.go
@@ -21,17 +21,21 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/receiver"
 	"go.uber.org/zap"
 )
@@ -64,6 +68,195 @@ func TestTracesGenerator_doneCh(t *testing.T) {
 			assert.Equal(t, sink.SpanCount(), stats.Spans)
 		})
 	}
+}
+
+// Two JSONL lines sharing one trace: line A holds the root span and a child
+// (with a link back to the root), line B holds a second child of the same
+// trace. Exercises cross-line trace grouping within a replay pass.
+const (
+	rewriteTraceID = "0102030405060708090a0b0c0d0e0f10"
+	rewriteRootID  = "0101010101010101"
+	rewriteLineA   = `{"resourceSpans":[{"resource":{},"scopeSpans":[{"spans":[` +
+		`{"traceId":"0102030405060708090a0b0c0d0e0f10","spanId":"0101010101010101","name":"root","startTimeUnixNano":"1","endTimeUnixNano":"2","kind":2},` +
+		`{"traceId":"0102030405060708090a0b0c0d0e0f10","spanId":"0202020202020202","parentSpanId":"0101010101010101","name":"child1","startTimeUnixNano":"1","endTimeUnixNano":"2","kind":3,"links":[{"traceId":"0102030405060708090a0b0c0d0e0f10","spanId":"0101010101010101"}]}` +
+		`]}]}]}`
+	rewriteLineB = `{"resourceSpans":[{"resource":{},"scopeSpans":[{"spans":[` +
+		`{"traceId":"0102030405060708090a0b0c0d0e0f10","spanId":"0303030303030303","parentSpanId":"0101010101010101","name":"child2","startTimeUnixNano":"1","endTimeUnixNano":"2","kind":3}` +
+		`]}]}]}`
+)
+
+func writeTracesJSONL(t *testing.T, lines ...string) string {
+	t.Helper()
+	filePath := filepath.Join(t.TempDir(), strings.ReplaceAll(t.Name(), "/", "_")+".jsonl")
+	require.NoError(t, os.WriteFile(filePath, []byte(strings.Join(lines, "\n")), 0o644))
+	return filePath
+}
+
+func startTracesGenerator(t *testing.T, cfg component.Config) *consumertest.TracesSink {
+	t.Helper()
+	sink := &consumertest.TracesSink{}
+	r, err := createTracesReceiver(context.Background(), receiver.Settings{
+		ID: component.ID{},
+		TelemetrySettings: component.TelemetrySettings{
+			Logger: zap.NewNop(),
+		},
+		BuildInfo: component.BuildInfo{},
+	}, cfg, sink)
+	require.NoError(t, err)
+	require.NoError(t, r.Start(context.Background(), componenttest.NewNopHost()))
+	t.Cleanup(func() {
+		assert.NoError(t, r.Shutdown(context.Background()))
+	})
+	return sink
+}
+
+func spansByName(all []ptrace.Traces) map[string]ptrace.Span {
+	out := map[string]ptrace.Span{}
+	for _, td := range all {
+		rm := td.ResourceSpans()
+		for i := 0; i < rm.Len(); i++ {
+			for j := 0; j < rm.At(i).ScopeSpans().Len(); j++ {
+				spans := rm.At(i).ScopeSpans().At(j).Spans()
+				for k := 0; k < spans.Len(); k++ {
+					out[spans.At(k).Name()] = spans.At(k)
+				}
+			}
+		}
+	}
+	return out
+}
+
+func TestTracesGenerator_RewriteIDs(t *testing.T) {
+	doneCh := make(chan Stats)
+	cfg := createDefaultReceiverConfig(nil, nil, doneCh, nil)
+	cfg.(*Config).Traces.JsonlFile = JsonlFile{Path: writeTracesJSONL(t, rewriteLineA, rewriteLineB)}
+	cfg.(*Config).Traces.MaxReplay = 2
+	cfg.(*Config).Traces.RewriteIDs = true
+	cfg.(*Config).Concurrency = 1
+	// The sink retains payloads, so the pdata-reuse optimization would let
+	// later emissions overwrite them.
+	cfg.(*Config).DisablePdataReuse = true
+
+	sink := startTracesGenerator(t, cfg)
+	<-doneCh
+
+	all := sink.AllTraces()
+	require.Len(t, all, 4) // 2 lines x 2 passes
+
+	origTraceID := mustTraceID(t, rewriteTraceID)
+	origRootID := mustSpanID(t, rewriteRootID)
+
+	// Payloads arrive in order: pass 0 (line A, line B), pass 1 (line A, line B).
+	for pass := 0; pass < 2; pass++ {
+		byName := spansByName(all[pass*2 : pass*2+2])
+		root, child1, child2 := byName["root"], byName["child1"], byName["child2"]
+
+		assert.NotEqual(t, origTraceID, root.TraceID(), "trace ID must be rewritten")
+		assert.Equal(t, root.TraceID(), child1.TraceID(), "same-line spans keep sharing a trace ID")
+		assert.Equal(t, root.TraceID(), child2.TraceID(), "cross-line spans of one trace keep sharing a trace ID within a pass")
+
+		assert.NotEqual(t, origRootID, root.SpanID(), "span ID must be rewritten")
+		assert.True(t, root.ParentSpanID().IsEmpty(), "root span must stay a root span")
+		assert.Equal(t, root.SpanID(), child1.ParentSpanID(), "parent-child links must be preserved")
+		assert.Equal(t, root.SpanID(), child2.ParentSpanID(), "parent-child links must be preserved across lines")
+
+		require.Equal(t, 1, child1.Links().Len())
+		assert.Equal(t, root.TraceID(), child1.Links().At(0).TraceID(), "link trace ID must follow the rewrite")
+		assert.Equal(t, root.SpanID(), child1.Links().At(0).SpanID(), "link span ID must follow the rewrite")
+	}
+
+	pass0 := spansByName(all[0:2])
+	pass1 := spansByName(all[2:4])
+	assert.NotEqual(t, pass0["root"].TraceID(), pass1["root"].TraceID(), "each pass must produce new trace IDs")
+}
+
+func TestTracesGenerator_LateSpans(t *testing.T) {
+	doneCh := make(chan Stats)
+	cfg := createDefaultReceiverConfig(nil, nil, doneCh, nil)
+	cfg.(*Config).Traces.JsonlFile = JsonlFile{Path: writeTracesJSONL(t, rewriteLineA, rewriteLineB)}
+	cfg.(*Config).Traces.MaxReplay = 1
+	cfg.(*Config).Traces.RewriteIDs = true
+	cfg.(*Config).Traces.LateSpans = &LateSpansConfig{
+		Fraction: 1,
+		Spans:    1,
+		DelayMin: 10 * time.Millisecond,
+		DelayMax: 20 * time.Millisecond,
+	}
+	cfg.(*Config).Concurrency = 1
+	cfg.(*Config).DisablePdataReuse = true
+
+	start := time.Now()
+	sink := startTracesGenerator(t, cfg)
+	stats := <-doneCh
+	elapsed := time.Since(start)
+
+	// Line A (2 spans) is split into main (1 span) + late (1 span). Line B has
+	// a single span, so holding it back would delay the whole payload rather
+	// than produce a late span; it must be emitted unsplit.
+	all := sink.AllTraces()
+	require.Len(t, all, 3)
+	assert.Equal(t, 3, stats.Spans)
+	assert.GreaterOrEqual(t, elapsed, 10*time.Millisecond, "done only after late spans are emitted")
+
+	byName := spansByName(all)
+	require.Len(t, byName, 3, "no span may be lost or duplicated by the split")
+	assert.Equal(t, byName["root"].TraceID(), byName["child1"].TraceID(),
+		"late span must keep the rewritten trace ID of its payload")
+
+	var spanCounts []int
+	for _, td := range all {
+		spanCounts = append(spanCounts, td.SpanCount())
+	}
+	assert.ElementsMatch(t, []int{1, 1, 1}, spanCounts)
+}
+
+func TestTracesGenerator_LateSpansValidate(t *testing.T) {
+	for name, tc := range map[string]struct {
+		late    LateSpansConfig
+		wantErr string
+	}{
+		"fraction_negative": {LateSpansConfig{Fraction: -0.1}, "fraction must be in [0, 1]"},
+		"fraction_above_1":  {LateSpansConfig{Fraction: 1.1}, "fraction must be in [0, 1]"},
+		"spans_negative":    {LateSpansConfig{Spans: -1}, "spans must be >= 0"},
+		"delay_min_negative": {LateSpansConfig{
+			DelayMin: -time.Second,
+		}, "delay_min must be >= 0"},
+		"delay_max_below_min": {LateSpansConfig{
+			DelayMin: time.Second, DelayMax: time.Millisecond,
+		}, "delay_max must be >= delay_min"},
+		"valid": {LateSpansConfig{
+			Fraction: 0.5, Spans: 2, DelayMin: time.Second, DelayMax: time.Minute,
+		}, ""},
+	} {
+		t.Run(name, func(t *testing.T) {
+			cfg := createDefaultReceiverConfig(nil, nil, nil, nil)
+			cfg.(*Config).Traces.LateSpans = &tc.late
+			err := cfg.(*Config).Validate()
+			if tc.wantErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func mustTraceID(t *testing.T, hexStr string) pcommon.TraceID {
+	t.Helper()
+	var id pcommon.TraceID
+	b, err := hex.DecodeString(hexStr)
+	require.NoError(t, err)
+	copy(id[:], b)
+	return id
+}
+
+func mustSpanID(t *testing.T, hexStr string) pcommon.SpanID {
+	t.Helper()
+	var id pcommon.SpanID
+	b, err := hex.DecodeString(hexStr)
+	require.NoError(t, err)
+	copy(id[:], b)
+	return id
 }
 
 func TestTracesGenerator_MaxBufferSizeAttr(t *testing.T) {


### PR DESCRIPTION
## Description

Adds two traces options to loadgenreceiver to make it usable for stress
testing tail-based sampling backends:

- `traces::rewrite_ids`: deterministically remaps trace/span IDs on every
  replay pass (salt = hash of a per-run seed and the pass number, XORed onto
  the IDs). Spans of one trace keep sharing a trace ID — including across
  JSONL lines within a pass, parent-child links, and span links — while every
  pass and every run produces globally unique trace IDs with the same
  statistical shape. Without this, replaying a file re-sends already-decided
  trace IDs, which tail-based sampling treats as late spans instead of new
  traces. Unlike the OTTL `MD5(UUID())` per-span rewrite suggested in the
  README, this preserves span grouping.
- `traces::late_spans`: holds back up to `spans` spans from a configurable
  `fraction` of emitted payloads and re-emits them after a uniform random
  delay in `[delay_min, delay_max]`. This exercises late-arrival paths in
  tail-based sampling: partial trace at decision time, decision-cache hits,
  and re-decision after cache eviction. Payloads with fewer spans than the
  hold-back count are never split, since delaying a whole payload does not
  make any span late relative to its trace. Held spans are counted in stats
  and awaited before done/shutdown.

Example:

    receivers:
      loadgen:
        traces:
          rewrite_ids: true
          late_spans:
            fraction: 0.05
            spans: 1
            delay_min: 10s
            delay_max: 60s

## Testing

Unit tests cover ID-rewrite grouping/uniqueness/link consistency across
passes, late-span splitting (span conservation, delayed emission, stats),
and config validation.